### PR TITLE
Handle quoted dependency names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "05:30"
+    time: "08:30"
     timezone: Europe/London
   reviewers:
     - "martincostello"
@@ -12,7 +12,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "05:30"
+    time: "08:30"
     timezone: Europe/London
   reviewers:
     - "martincostello"

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -44,6 +44,7 @@
     "RerunFailedChecksAttempts": 0,
     "TrustedEntities": {
       "Dependencies": [
+        "^@actions\/.*$",
         "^@types\/.*$",
         "^actions\/.*$",
         "^Amazon.Lambda\\..*$",

--- a/tests/Costellobot.Tests/Builders/GitHubFixtures.cs
+++ b/tests/Costellobot.Tests/Builders/GitHubFixtures.cs
@@ -185,6 +185,22 @@ updated-dependencies:
 
 Signed-off-by: dependabot[bot] <support@github.com>";
 
+    public static string TrustedCommitMessage(string dependency) => $@"
+Bump {dependency} from 5.0.0 to 5.0.1
+Bumps [{dependency}](https://github.com/actions/toolkit/tree/HEAD/packages/github) from 5.0.0 to 5.0.1.
+- [Release notes](https://github.com/actions/toolkit/releases)
+- [Changelog](https://github.com/actions/toolkit/blob/main/packages/github/RELEASES.md)
+- [Commits](https://github.com/actions/toolkit/commits/HEAD/packages/github)
+
+---
+updated-dependencies:
+- dependency-name: ""{dependency}""
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+...
+
+Signed-off-by: dependabot[bot] <support @github.com>";
+
     public static string UntrustedCommitMessage() => @"
 Bump puppeteer from 13.5.0 to 13.5.1 in /src/LondonTravel.Site
 Bumps [puppeteer](https://github.com/puppeteer/puppeteer) from 13.5.0 to 13.5.1.

--- a/tests/Costellobot.Tests/GitCommitAnalyzerTests.cs
+++ b/tests/Costellobot.Tests/GitCommitAnalyzerTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using MartinCostello.Costellobot.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using static MartinCostello.Costellobot.Builders.GitHubFixtures;
+
+namespace MartinCostello.Costellobot;
+
+[Collection(AppCollection.Name)]
+public class GitCommitAnalyzerTests : IntegrationTests<AppFixture>
+{
+    public GitCommitAnalyzerTests(AppFixture fixture, ITestOutputHelper outputHelper)
+        : base(fixture, outputHelper)
+    {
+    }
+
+    [Theory]
+    [InlineData("@actions/github", true)]
+    [InlineData("actions/checkout", true)]
+    [InlineData("martincostello/update-dotnet-sdk", true)]
+    [InlineData("Microsoft.NET.Sdk", true)]
+    [InlineData("NodaTime", true)]
+    [InlineData("NodaTimee", false)]
+    [InlineData("NodaTime.Testing", true)]
+    [InlineData("NodaTime.Testingg", false)]
+    [InlineData("typescript-hax", false)]
+    public void Commit_Is_Analyzed_Correct(string dependency, bool expected)
+    {
+        // Arrange
+        using var scope = Fixture.Services.CreateScope();
+        var target = scope.ServiceProvider.GetRequiredService<GitCommitAnalyzer>();
+
+        var owner = CreateUser();
+        var repo = owner.CreateRepository();
+
+        string sha = "0304f7fb4e17d674ea52392d70e775761ccf5aed";
+        string commitMessage = TrustedCommitMessage(dependency);
+
+        // Act
+        bool actual = target.IsTrustedDependencyUpdate(
+            owner.Login,
+            repo.Name,
+            sha,
+            commitMessage);
+
+        // Assert
+        actual.ShouldBe(expected);
+    }
+}


### PR DESCRIPTION
- Handle dependencies not matching if they are quoted in commit messages.
- Trust @actions npm updates.
- Add unit tests for some of the allowed dependencies.
