### PR TITLE
Fix log stream

### DIFF
--- a/src/Costellobot/IWebhookClient.cs
+++ b/src/Costellobot/IWebhookClient.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Text.Json;
 using Microsoft.AspNetCore.SignalR;
-using Octokit.Webhooks;
+using Microsoft.Extensions.Primitives;
 
 namespace MartinCostello.Costellobot;
 
@@ -12,5 +13,5 @@ public interface IWebhookClient
     Task LogAsync(object logEntry);
 
     [HubMethodName("webhook-logs")]
-    Task WebhookAsync(WebhookHeaders headers, WebhookEvent webhookEvent);
+    Task WebhookAsync(IDictionary<string, StringValues> headers, JsonElement webhookEvent);
 }


### PR DESCRIPTION
Fix the log stream erroring due to an inability for Octokit.Webhooks to serialize `DateTimeOffset` values.
