### PR TITLE
Improve header rendering

### DIFF
--- a/src/Costellobot/IWebhookClient.cs
+++ b/src/Costellobot/IWebhookClient.cs
@@ -3,7 +3,6 @@
 
 using System.Text.Json;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Primitives;
 
 namespace MartinCostello.Costellobot;
 
@@ -13,5 +12,5 @@ public interface IWebhookClient
     Task LogAsync(object logEntry);
 
     [HubMethodName("webhook-logs")]
-    Task WebhookAsync(IDictionary<string, StringValues> headers, JsonElement webhookEvent);
+    Task WebhookAsync(IDictionary<string, string> headers, JsonElement webhookEvent);
 }

--- a/src/Costellobot/scripts/ts/App.ts
+++ b/src/Costellobot/scripts/ts/App.ts
@@ -61,7 +61,7 @@ export class App {
 
         const timestamp = moment();
 
-        indexItem.textContent = `${webhookHeaders.event} (${webhookHeaders.delivery})`;
+        indexItem.textContent = `${webhookHeaders['X-GitHub-Event']} (${webhookHeaders['X-GitHub-Delivery']})`;
 
         indexItem.classList.add('list-group-item');
         indexItem.classList.add('list-group-item-action');


### PR DESCRIPTION
- Improve the rendering of webhook headers by using a string-string dictionary.
- Fix the webhook event and delivery not being rendered.
