### PR TITLE
SignalR tweaks

### DIFF
--- a/src/Costellobot/ChannelQueue`1.cs
+++ b/src/Costellobot/ChannelQueue`1.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Threading.Channels;
+
+namespace MartinCostello.Costellobot;
+
+public abstract class ChannelQueue<T>
+{
+    private const int QueueCapacity = 1000;
+
+    private readonly Channel<T> _queue;
+
+    protected ChannelQueue()
+    {
+        var channelOptions = new BoundedChannelOptions(QueueCapacity)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+            SingleWriter = false,
+        };
+
+        _queue = Channel.CreateBounded<T>(channelOptions);
+    }
+
+    protected Channel<T> Queue => _queue;
+
+    public async virtual Task<T?> DequeueAsync(CancellationToken cancellationToken)
+    {
+        T? item = default;
+
+        if (await _queue.Reader.WaitToReadAsync(cancellationToken))
+        {
+            item = await _queue.Reader.ReadAsync(cancellationToken);
+        }
+
+        return item;
+    }
+
+    public virtual bool Enqueue(T item)
+    {
+        return _queue.Writer.TryWrite(item);
+    }
+}

--- a/src/Costellobot/ChannelQueue`1.cs
+++ b/src/Costellobot/ChannelQueue`1.cs
@@ -25,7 +25,7 @@ public abstract class ChannelQueue<T>
 
     protected Channel<T> Queue => _queue;
 
-    public async virtual Task<T?> DequeueAsync(CancellationToken cancellationToken)
+    public virtual async Task<T?> DequeueAsync(CancellationToken cancellationToken)
     {
         T? item = default;
 

--- a/src/Costellobot/ClientLogQueue.cs
+++ b/src/Costellobot/ClientLogQueue.cs
@@ -1,42 +1,8 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using System.Threading.Channels;
-
 namespace MartinCostello.Costellobot;
 
-public sealed partial class ClientLogQueue
+public sealed partial class ClientLogQueue : ChannelQueue<ClientLogMessage>
 {
-    private const int QueueCapacity = 1000;
-
-    private readonly Channel<ClientLogMessage> _queue;
-
-    public ClientLogQueue()
-    {
-        var channelOptions = new BoundedChannelOptions(QueueCapacity)
-        {
-            FullMode = BoundedChannelFullMode.DropOldest,
-            SingleReader = true,
-            SingleWriter = false,
-        };
-
-        _queue = Channel.CreateBounded<ClientLogMessage>(channelOptions);
-    }
-
-    public async Task<ClientLogMessage?> DequeueAsync(CancellationToken cancellationToken)
-    {
-        ClientLogMessage? logEntry = null;
-
-        if (await _queue.Reader.WaitToReadAsync(cancellationToken))
-        {
-            logEntry = await _queue.Reader.ReadAsync(cancellationToken);
-        }
-
-        return logEntry;
-    }
-
-    public void Enqueue(ClientLogMessage logEntry)
-    {
-        _ = _queue.Writer.TryWrite(logEntry);
-    }
 }

--- a/src/Costellobot/GitHubWebhookQueue.cs
+++ b/src/Costellobot/GitHubWebhookQueue.cs
@@ -13,7 +13,7 @@ public sealed partial class GitHubWebhookQueue : ChannelQueue<GitHubEvent>
         _logger = logger;
     }
 
-    public async override Task<GitHubEvent?> DequeueAsync(CancellationToken cancellationToken)
+    public override async Task<GitHubEvent?> DequeueAsync(CancellationToken cancellationToken)
     {
         Log.WaitingForWebhook(_logger);
 

--- a/src/Costellobot/IWebhookClient.cs
+++ b/src/Costellobot/IWebhookClient.cs
@@ -9,7 +9,7 @@ namespace MartinCostello.Costellobot;
 public interface IWebhookClient
 {
     [HubMethodName("application-logs")]
-    Task LogAsync(object logEntry);
+    Task LogAsync(ClientLogMessage logEntry);
 
     [HubMethodName("webhook-logs")]
     Task WebhookAsync(IDictionary<string, string> headers, JsonElement webhookEvent);

--- a/src/Costellobot/Pages/Home/Index.cshtml
+++ b/src/Costellobot/Pages/Home/Index.cshtml
@@ -11,7 +11,7 @@
     </h3>
     <div class="row">
       <div class="col-12">
-        <textarea class="form-control log-console" id="logs" readonly>Awaiting logs...</textarea>
+        <textarea class="form-control log-console" id="logs" placeholder="Awaiting logs..." readonly></textarea>
       </div>
     </div>
   </div>

--- a/src/Costellobot/scripts/ts/App.ts
+++ b/src/Costellobot/scripts/ts/App.ts
@@ -12,7 +12,6 @@ export class App {
     private readonly webhooksIndexContainer: HTMLElement;
     private readonly webhooksContentContainer: HTMLElement;
 
-    private logIndex: number = 1;
     private webhookIndex: number = 1;
 
     constructor() {

--- a/src/Costellobot/scripts/ts/App.ts
+++ b/src/Costellobot/scripts/ts/App.ts
@@ -8,16 +8,13 @@ import 'moment/locale/en-gb';
 export class App {
 
     private readonly connection: signalR.HubConnection;
-    private readonly logsContainer: HTMLInputElement;
-    private readonly webhooksIndexContainer: HTMLElement;
-    private readonly webhooksContentContainer: HTMLElement;
 
+    private logsContainer: HTMLInputElement;
+    private webhooksIndexContainer: HTMLElement;
+    private webhooksContentContainer: HTMLElement;
     private webhookIndex: number = 1;
 
     constructor() {
-        this.logsContainer = <HTMLInputElement>document.getElementById('logs');
-        this.webhooksIndexContainer = document.getElementById('webhooks-index');
-        this.webhooksContentContainer = document.getElementById('webhooks-content');
         this.connection = new signalR.HubConnectionBuilder()
             .withUrl('/admin/git-hub')
             .withAutomaticReconnect()
@@ -25,6 +22,14 @@ export class App {
     }
 
     async initialize(): Promise<void> {
+
+        this.logsContainer = <HTMLInputElement>document.getElementById('logs');
+        this.webhooksIndexContainer = document.getElementById('webhooks-index');
+        this.webhooksContentContainer = document.getElementById('webhooks-content');
+
+        if (!this.logsContainer) {
+            return;
+        }
 
         moment.locale('en-gb');
 

--- a/src/Costellobot/scripts/ts/App.ts
+++ b/src/Costellobot/scripts/ts/App.ts
@@ -20,6 +20,7 @@ export class App {
         this.webhooksContentContainer = document.getElementById('webhooks-content');
         this.connection = new signalR.HubConnectionBuilder()
             .withUrl('/admin/git-hub')
+            .withAutomaticReconnect()
             .build();
     }
 

--- a/src/Costellobot/scripts/ts/App.ts
+++ b/src/Costellobot/scripts/ts/App.ts
@@ -61,7 +61,10 @@ export class App {
 
         const timestamp = moment();
 
-        indexItem.textContent = `${webhookHeaders['X-GitHub-Event']} (${webhookHeaders['X-GitHub-Delivery']})`;
+        const delivery = webhookHeaders['X-GitHub-Delivery'];
+        const event = webhookHeaders['X-GitHub-Event'];
+
+        indexItem.textContent = `${event} (${delivery})`;
 
         indexItem.classList.add('list-group-item');
         indexItem.classList.add('list-group-item-action');
@@ -105,13 +108,14 @@ export class App {
 
     private addLog(logEntry: LogEntry) {
 
+        const event = logEntry.eventName ?? logEntry.eventId;
         const timestamp = moment(logEntry.timestamp);
 
         if (this.logsContainer.textContent) {
             this.logsContainer.textContent += '\n';
         }
 
-        this.logsContainer.textContent += `${timestamp.toISOString()} [${logEntry.level}] ${logEntry.category}[${logEntry.eventName ?? logEntry.eventId}]: ${logEntry.message}`;
+        this.logsContainer.textContent += `${timestamp.toISOString()} [${logEntry.level}] ${logEntry.category}[${event}]: ${logEntry.message}`;
         this.logsContainer.scrollTop = this.logsContainer.scrollHeight;
     }
 }

--- a/tests/Costellobot.Tests/Infrastructure/AppFixture.cs
+++ b/tests/Costellobot.Tests/Infrastructure/AppFixture.cs
@@ -60,6 +60,8 @@ public class AppFixture : WebApplicationFactory<Program>, ITestOutputHelperAcces
         }
     }
 
+    public virtual HttpClient CreateHttpClientForApp() => CreateDefaultClient();
+
     public void OverrideConfiguration(string key, string value, bool reload = true)
     {
         _configOverrides[key] = value;

--- a/tests/Costellobot.Tests/Infrastructure/HttpServerFixture.cs
+++ b/tests/Costellobot.Tests/Infrastructure/HttpServerFixture.cs
@@ -33,6 +33,20 @@ public sealed class HttpServerFixture : AppFixture
         }
     }
 
+    public override HttpClient CreateHttpClientForApp()
+    {
+        var handler = new HttpClientHandler()
+        {
+            CheckCertificateRevocationList = true,
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+        };
+
+        return new HttpClient(handler, disposeHandler: true)
+        {
+            BaseAddress = new(ServerAddress, UriKind.Absolute),
+        };
+    }
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         base.ConfigureWebHost(builder);

--- a/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
+++ b/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
@@ -340,7 +340,7 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
     {
         (string payload, string signature) = CreateWebhook(value, webhookSecret);
 
-        using var client = Fixture.CreateDefaultClient();
+        using var client = Fixture.CreateHttpClientForApp();
 
         client.DefaultRequestHeaders.Add("Accept", "*/*");
         client.DefaultRequestHeaders.Add("User-Agent", "GitHub-Hookshot/f05835d");

--- a/tests/Costellobot.Tests/Pages/AdminPage.cs
+++ b/tests/Costellobot.Tests/Pages/AdminPage.cs
@@ -12,11 +12,12 @@ public class AdminPage : AppPage
     {
     }
 
-    public async Task<string> GetLogsAsync()
-        => await Page.InputValueAsync(Selectors.Logs);
-
     public async Task WaitForContentAsync()
         => await Page.WaitForSelectorAsync(Selectors.AdminContent);
+
+    public async Task WaitForLogsTextAsync(string value)
+        => await Assertions.Expect(Page.Locator(Selectors.Logs))
+                           .ToContainTextAsync(value);
 
     private sealed class Selectors
     {

--- a/tests/Costellobot.Tests/Pages/AdminPage.cs
+++ b/tests/Costellobot.Tests/Pages/AdminPage.cs
@@ -12,11 +12,15 @@ public class AdminPage : AppPage
     {
     }
 
+    public async Task<string> GetLogsAsync()
+        => await Page.InputValueAsync(Selectors.Logs);
+
     public async Task WaitForContentAsync()
         => await Page.WaitForSelectorAsync(Selectors.AdminContent);
 
     private sealed class Selectors
     {
         internal const string AdminContent = "id=admin-content";
+        internal const string Logs = "id=logs";
     }
 }

--- a/tests/Costellobot.Tests/UITests.cs
+++ b/tests/Costellobot.Tests/UITests.cs
@@ -150,7 +150,7 @@ public class UITests : IntegrationTests<HttpServerFixture>
             using var response = await PostWebhookAsync("ping", value);
             response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
-            await Task.Delay(TimeSpan.FromSeconds(0.5));
+            await Task.Delay(TimeSpan.FromSeconds(2));
 
             // Assert - Verify log entries were written
             string actual = await app.GetLogsAsync();

--- a/tests/Costellobot.Tests/UITests.cs
+++ b/tests/Costellobot.Tests/UITests.cs
@@ -150,13 +150,8 @@ public class UITests : IntegrationTests<HttpServerFixture>
             using var response = await PostWebhookAsync("ping", value);
             response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
-            await Task.Delay(TimeSpan.FromSeconds(2));
-
             // Assert - Verify log entries were written
-            string actual = await app.GetLogsAsync();
-
-            actual.ShouldNotBeNullOrWhiteSpace();
-            actual.ShouldContain("Received webhook with ID 109948940.");
+            await app.WaitForLogsTextAsync("Received webhook with ID 109948940.");
         });
     }
 

--- a/tests/Costellobot.Tests/UITests.cs
+++ b/tests/Costellobot.Tests/UITests.cs
@@ -127,7 +127,7 @@ public class UITests : IntegrationTests<HttpServerFixture>
             await app.WaitForContentAsync();
 
             // Wait for the web socket to have connected
-            await connected.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await connected.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
             // Act - Deliver a ping webhook
             var value = new

--- a/tests/Costellobot.Tests/UITests.cs
+++ b/tests/Costellobot.Tests/UITests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Net;
 using MartinCostello.Costellobot.Infrastructure;
 using MartinCostello.Costellobot.Pages;
 using Microsoft.Extensions.Caching.Memory;
@@ -88,6 +89,74 @@ public class UITests : IntegrationTests<HttpServerFixture>
 
             // Assert
             await app.WaitForSignedOutAsync();
+        });
+    }
+
+    [Theory(Skip = "The browser is not connecting to the web socket.")]
+    [MemberData(nameof(Browsers))]
+    public async Task Can_View_Logs(string browserType, string? browserChannel)
+    {
+        // Arrange
+        var options = new BrowserFixtureOptions()
+        {
+            BrowserType = browserType,
+            BrowserChannel = browserChannel,
+        };
+
+        var browser = new BrowserFixture(options, OutputHelper);
+        await browser.WithPageAsync(async page =>
+        {
+            // Load the application
+            await page.GotoAsync(Fixture.ServerAddress);
+            await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
+
+            var app = new AdminPage(page);
+
+            // Act - Sign in
+            await app.SignInAsync();
+
+            // Assert
+            await app.WaitForSignedInAsync();
+            await app.UserNameAsync().ShouldBe("John Smith");
+
+            // Arrange - Wait for the page to be ready
+            await app.WaitForContentAsync();
+
+            // Act - Deliver a ping webhook
+            var value = new
+            {
+                zen = "You tried your best and you failed miserably. The lesson is, never try.",
+                hook_id = 109948940,
+                hook = new
+                {
+                    type = "App",
+                    id = 109948940,
+                    name = "web",
+                    active = true,
+                    events = new[] { "*" },
+                },
+                config = new
+                {
+                    content_type = "json",
+                    insecure_ssl = "0",
+                    url = "https://costellobot.martincostello.local/github-webhook",
+                },
+                updated_at = "2022-03-23T23:13:43Z",
+                created_at = "2022-03-23T23:13:43Z",
+                app_id = 349596565,
+                deliveries_url = "https://api.github.com/app/hook/deliveries",
+            };
+
+            using var response = await PostWebhookAsync("ping", value);
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+            await Task.Delay(TimeSpan.FromSeconds(0.5));
+
+            // Assert - Verify log entries were written
+            string actual = await app.GetLogsAsync();
+
+            actual.ShouldNotBeNullOrWhiteSpace();
+            actual.ShouldContain("Received webhook with ID 109948940.");
         });
     }
 

--- a/tests/Costellobot.Tests/UITests.cs
+++ b/tests/Costellobot.Tests/UITests.cs
@@ -127,7 +127,7 @@ public class UITests : IntegrationTests<HttpServerFixture>
             await app.WaitForContentAsync();
 
             // Wait for the web socket to have connected
-            await connected.Task.WaitAsync(TimeSpan.FromSeconds(2));
+            await connected.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
             // Act - Deliver a ping webhook
             var value = new

--- a/tests/Costellobot.Tests/UITests.cs
+++ b/tests/Costellobot.Tests/UITests.cs
@@ -92,11 +92,15 @@ public class UITests : IntegrationTests<HttpServerFixture>
         });
     }
 
-    [Theory]
+    [SkippableTheory]
     [MemberData(nameof(Browsers))]
     public async Task Can_View_Logs(string browserType, string? browserChannel)
     {
         // Arrange
+        Skip.If(
+            string.Equals(browserType, BrowserType.Webkit, StringComparison.OrdinalIgnoreCase),
+            "Webkit does not trust for self-signed certificate with the web socket.");
+
         var options = new BrowserFixtureOptions()
         {
             BrowserType = browserType,

--- a/tests/Costellobot.Tests/UITests.cs
+++ b/tests/Costellobot.Tests/UITests.cs
@@ -92,7 +92,7 @@ public class UITests : IntegrationTests<HttpServerFixture>
         });
     }
 
-    [Theory(Skip = "The browser is not connecting to the web socket.")]
+    [Theory]
     [MemberData(nameof(Browsers))]
     public async Task Can_View_Logs(string browserType, string? browserChannel)
     {

--- a/tests/Costellobot.Tests/UITests.cs
+++ b/tests/Costellobot.Tests/UITests.cs
@@ -106,6 +106,9 @@ public class UITests : IntegrationTests<HttpServerFixture>
         var browser = new BrowserFixture(options, OutputHelper);
         await browser.WithPageAsync(async page =>
         {
+            var connected = new TaskCompletionSource();
+            page.WebSocket += (_, _) => connected.SetResult();
+
             // Load the application
             await page.GotoAsync(Fixture.ServerAddress);
             await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded);
@@ -121,6 +124,9 @@ public class UITests : IntegrationTests<HttpServerFixture>
 
             // Arrange - Wait for the page to be ready
             await app.WaitForContentAsync();
+
+            // Wait for the web socket to have connected
+            await connected.Task.WaitAsync(TimeSpan.FromSeconds(2));
 
             // Act - Deliver a ping webhook
             var value = new

--- a/tests/Costellobot.Tests/UITests.cs
+++ b/tests/Costellobot.Tests/UITests.cs
@@ -107,7 +107,8 @@ public class UITests : IntegrationTests<HttpServerFixture>
         await browser.WithPageAsync(async page =>
         {
             var connected = new TaskCompletionSource();
-            page.WebSocket += (_, _) => connected.SetResult();
+            page.WebSocket += (_, p) =>
+                p.FrameReceived += (_, _) => connected.TrySetResult();
 
             // Load the application
             await page.GotoAsync(Fixture.ServerAddress);


### PR DESCRIPTION
- Enable automatic reconnection for SignalR.
- Fix incorrectly typed method parameter.
- Make an abstract class for the repeated `Channel`-based queue.
- Add a UI test for log streaming.
- Remove unused `logIndex` field.
