### PR TITLE
Log display fixes

### DIFF
--- a/src/Costellobot/Pages/Home/Index.cshtml
+++ b/src/Costellobot/Pages/Home/Index.cshtml
@@ -14,6 +14,12 @@
         <textarea class="form-control log-console" id="logs" placeholder="Awaiting logs..." readonly></textarea>
       </div>
     </div>
+    <div class="row">
+      <div class="form-check form-check-inline ml-3 mt-3">
+        <input class="form-check-input" type="checkbox" id="logs-auto-scroll" checked value="true">
+        <label class="form-check-label" for="logs-auto-scrol">Auto-scroll</label>
+      </div>
+    </div>
   </div>
   <hr/>
   <div class="container-fluid">
@@ -22,10 +28,10 @@
       <span class="fa-solid fa-box-open" />
     </h3>
     <div class="row">
-      <div class="col-12 col-md-4">
+      <div class="col-md-4">
         <div class="list-group" id="webhooks-index" role="tablist"></div>
       </div>
-      <div class="col-12 col-md-8">
+      <div class="col-md-8">
         <div class="tab-content" id="webhooks-content"></div>
       </div>
     </div>

--- a/src/Costellobot/Pages/Home/Index.cshtml
+++ b/src/Costellobot/Pages/Home/Index.cshtml
@@ -22,10 +22,10 @@
       <span class="fa-solid fa-box-open" />
     </h3>
     <div class="row">
-      <div class="col-3">
+      <div class="col-12 col-md-4">
         <div class="list-group" id="webhooks-index" role="tablist"></div>
       </div>
-      <div class="col-9">
+      <div class="col-12 col-md-8">
         <div class="tab-content" id="webhooks-content"></div>
       </div>
     </div>

--- a/src/Costellobot/scripts/ts/App.ts
+++ b/src/Costellobot/scripts/ts/App.ts
@@ -9,6 +9,7 @@ export class App {
 
     private readonly connection: signalR.HubConnection;
 
+    private logsAutoscroll: HTMLInputElement;
     private logsContainer: HTMLInputElement;
     private webhooksIndexContainer: HTMLElement;
     private webhooksContentContainer: HTMLElement;
@@ -22,6 +23,7 @@ export class App {
 
     async initialize(): Promise<void> {
 
+        this.logsAutoscroll = <HTMLInputElement>document.getElementById('logs-auto-scroll');
         this.logsContainer = <HTMLInputElement>document.getElementById('logs');
         this.webhooksIndexContainer = document.getElementById('webhooks-index');
         this.webhooksContentContainer = document.getElementById('webhooks-content');
@@ -143,7 +145,10 @@ export class App {
         }
 
         this.logsContainer.textContent += `${timestamp.toISOString()} [${logEntry.level}] ${logEntry.category}[${event}]: ${logEntry.message}`;
-        this.logsContainer.scrollTop = this.logsContainer.scrollHeight;
+
+        if (this.logsAutoscroll.checked) {
+            this.logsContainer.scrollTop = this.logsContainer.scrollHeight;
+        }
     }
 }
 

--- a/src/Costellobot/wwwroot/css/site.css
+++ b/src/Costellobot/wwwroot/css/site.css
@@ -39,6 +39,10 @@ img.user-profile {
     resize: none;
 }
 
+.webhook-item > pre {
+    overflow: hidden;
+}
+
 .webhook-item.active > pre {
     color: #fff;
 }


### PR DESCRIPTION
- Disable horizontal scroll caused by GUIDs.
- Fix items being truncated on desktop and mobile.
- Support turning off auto-scrolling of the logs.
