### PR TITLE
Show recent logs and webhooks

### DIFF
--- a/src/Costellobot/ChannelQueue`1.cs
+++ b/src/Costellobot/ChannelQueue`1.cs
@@ -1,14 +1,17 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using System.Threading.Channels;
 
 namespace MartinCostello.Costellobot;
 
 public abstract class ChannelQueue<T>
 {
+    private const int HistoryCapacity = 5;
     private const int QueueCapacity = 1000;
 
+    private readonly ConcurrentQueue<T> _history;
     private readonly Channel<T> _queue;
 
     protected ChannelQueue()
@@ -21,6 +24,7 @@ public abstract class ChannelQueue<T>
         };
 
         _queue = Channel.CreateBounded<T>(channelOptions);
+        _history = new ConcurrentQueue<T>();
     }
 
     protected Channel<T> Queue => _queue;
@@ -39,6 +43,20 @@ public abstract class ChannelQueue<T>
 
     public virtual bool Enqueue(T item)
     {
-        return _queue.Writer.TryWrite(item);
+        bool written = _queue.Writer.TryWrite(item);
+
+        if (written)
+        {
+            _history.Enqueue(item);
+
+            while (_history.Count > HistoryCapacity)
+            {
+                _ = _history.TryDequeue(out _);
+            }
+        }
+
+        return written;
     }
+
+    public IList<T> History() => new List<T>(_history);
 }

--- a/src/Costellobot/GitHubEvent.cs
+++ b/src/Costellobot/GitHubEvent.cs
@@ -1,8 +1,13 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Text.Json;
 using Octokit.Webhooks;
 
 namespace MartinCostello.Costellobot;
 
-public record GitHubEvent(WebhookHeaders Headers, WebhookEvent Event);
+public record GitHubEvent(
+    WebhookHeaders Headers,
+    WebhookEvent Event,
+    IDictionary<string, string> RawHeaders,
+    JsonElement RawPayload);

--- a/src/Costellobot/GitHubWebhookHub.cs
+++ b/src/Costellobot/GitHubWebhookHub.cs
@@ -8,4 +8,25 @@ namespace MartinCostello.Costellobot;
 [CostellobotAdmin]
 public class GitHubWebhookHub : Hub<IWebhookClient>
 {
+    private readonly ClientLogQueue _logs;
+    private readonly GitHubWebhookQueue _webhooks;
+
+    public GitHubWebhookHub(ClientLogQueue logs, GitHubWebhookQueue webhooks)
+    {
+        _logs = logs;
+        _webhooks = webhooks;
+    }
+
+    public override async Task OnConnectedAsync()
+    {
+        foreach (var logEntry in _logs.History())
+        {
+            await Clients.Caller.LogAsync(logEntry);
+        }
+
+        foreach (var @event in _webhooks.History())
+        {
+            await Clients.Caller.WebhookAsync(@event.RawHeaders, @event.RawPayload);
+        }
+    }
 }

--- a/tests/Costellobot.Tests/Builders/GitHubFixtures.cs
+++ b/tests/Costellobot.Tests/Builders/GitHubFixtures.cs
@@ -111,8 +111,14 @@ public static class GitHubFixtures
 
         var webhookHeaders = WebhookHeaders.Parse(headers);
         var webhookEvent = JsonSerializer.Deserialize<PullRequestOpenedEvent>(body);
+        var rawHeaders = headers.ToDictionary((k) => k.Key, (v) => v.ToString());
+        using var rawBody = JsonDocument.Parse(body);
 
-        return new(webhookHeaders, webhookEvent!);
+        return new(
+            webhookHeaders,
+            webhookEvent!,
+            rawHeaders,
+            rawBody.RootElement.Clone());
     }
 
     public static AccessTokenBuilder CreateAccessToken(string? token = null)

--- a/tests/Costellobot.Tests/GitHubWebhookServiceTests.cs
+++ b/tests/Costellobot.Tests/GitHubWebhookServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Text.Json;
 using MartinCostello.Costellobot.Handlers;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
@@ -39,7 +40,9 @@ public class GitHubWebhookServiceTests
                 {
                     Id = installationId,
                 },
-            });
+            },
+            new Dictionary<string, string>(),
+            JsonDocument.Parse("{}").RootElement.Clone());
 
         // Act
         await target.ProcessAsync(message);


### PR DESCRIPTION
Buffer log messages and webhooks. to show the last 5 log messages and payloads when a client connects over SignalR.

Resolves #31.
