### PR TITLE
Tidy up logs

### DIFF
--- a/src/Costellobot/ClientLogger.cs
+++ b/src/Costellobot/ClientLogger.cs
@@ -12,7 +12,7 @@ public sealed class ClientLogger : ILogger
 
     public ClientLogger(string categoryName, ClientLogQueue queue, IClock clock)
     {
-        CategoryName = categoryName;
+        CategoryName = categoryName[ClientLoggingProvider.CategoryPrefix.Length..].TrimStart('.');
         _queue = queue;
         _clock = clock;
     }
@@ -45,10 +45,17 @@ public sealed class ClientLogger : ILogger
             return;
         }
 
+        string levelString = logLevel switch
+        {
+            LogLevel.Information => "Info",
+            LogLevel.Warning => "Warn",
+            _ => logLevel.ToString(),
+        };
+
         var payload = new ClientLogMessage()
         {
             Category = CategoryName,
-            Level = logLevel.ToString(),
+            Level = levelString,
             EventId = eventId.Id,
             EventName = eventId.Name,
             Message = formatter(state, exception),

--- a/src/Costellobot/ClientLoggingProvider.cs
+++ b/src/Costellobot/ClientLoggingProvider.cs
@@ -8,6 +8,8 @@ namespace MartinCostello.Costellobot;
 
 public sealed class ClientLoggingProvider : ILoggerProvider
 {
+    internal const string CategoryPrefix = "MartinCostello.Costellobot";
+
     private readonly IClock _clock;
     private readonly ClientLogQueue _queue;
 
@@ -20,7 +22,7 @@ public sealed class ClientLoggingProvider : ILoggerProvider
     public ILogger CreateLogger(string categoryName)
     {
         return
-            categoryName.StartsWith("MartinCostello.Costellobot", StringComparison.Ordinal) ?
+            categoryName.StartsWith(CategoryPrefix, StringComparison.Ordinal) ?
             new ClientLogger(categoryName, _queue, _clock) :
             NullLoggerFactory.Instance.CreateLogger(categoryName);
     }

--- a/src/Costellobot/GitHubEventProcessor.cs
+++ b/src/Costellobot/GitHubEventProcessor.cs
@@ -89,7 +89,7 @@ public sealed partial class GitHubEventProcessor : WebhookEventProcessor
     {
         [LoggerMessage(
            EventId = 1,
-           Level = LogLevel.Information,
+           Level = LogLevel.Debug,
            Message = "Received webhook with ID {HookId}.")]
         public static partial void ReceivedWebhook(ILogger logger, string? hookId);
     }

--- a/src/Costellobot/GitHubWebhookQueue.cs
+++ b/src/Costellobot/GitHubWebhookQueue.cs
@@ -65,13 +65,13 @@ public sealed partial class GitHubWebhookQueue : ChannelQueue<GitHubEvent>
     {
         [LoggerMessage(
            EventId = 1,
-           Level = LogLevel.Information,
+           Level = LogLevel.Debug,
            Message = "Waiting for webhook to process from queue.")]
         public static partial void WaitingForWebhook(ILogger logger);
 
         [LoggerMessage(
            EventId = 2,
-           Level = LogLevel.Information,
+           Level = LogLevel.Debug,
            Message = "Queued webhook with ID {HookId} for processing.")]
         public static partial void QueuedWebhook(ILogger logger, string? hookId);
 
@@ -83,7 +83,7 @@ public sealed partial class GitHubWebhookQueue : ChannelQueue<GitHubEvent>
 
         [LoggerMessage(
            EventId = 4,
-           Level = LogLevel.Information,
+           Level = LogLevel.Debug,
            Message = "Dequeued webhook with ID {HookId} for processing.")]
         public static partial void DequeuedWebhook(ILogger logger, string? hookId);
 

--- a/tests/Costellobot.Tests/UITests.cs
+++ b/tests/Costellobot.Tests/UITests.cs
@@ -157,6 +157,10 @@ public class UITests : IntegrationTests<HttpServerFixture>
                 created_at = "2022-03-23T23:13:43Z",
                 app_id = 349596565,
                 deliveries_url = "https://api.github.com/app/hook/deliveries",
+                installation = new
+                {
+                    id = 42,
+                },
             };
 
             string delivery = RandomNumberGenerator.GetInt32(int.MaxValue).ToString(CultureInfo.InvariantCulture);
@@ -165,7 +169,7 @@ public class UITests : IntegrationTests<HttpServerFixture>
             response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
             // Assert - Verify log entries were written
-            await app.WaitForLogsTextAsync("Received webhook with ID 109948940.");
+            await app.WaitForLogsTextAsync("Processed webhook with ID 109948940.");
 
             // Act - Get the log entry for the webhook
             var item = await app.WaitForWebhookAsync(delivery);


### PR DESCRIPTION
- Remove the common prefix from all the log messages broadcast to the UI.
- Shorten some of the `LogLevel` strings.
- Change some log levels from `Information` to `Debug` to reduce noise.
- Add log message for failed webhook dispatch.
