### PR TITLE
Add more version links

### DIFF
--- a/src/Costellobot/CustomHttpHeadersMiddleware.cs
+++ b/src/Costellobot/CustomHttpHeadersMiddleware.cs
@@ -18,7 +18,7 @@ public sealed class CustomHttpHeadersMiddleware
             "style-src 'self' cdn.jsdelivr.net cdnjs.cloudflare.com use.fontawesome.com",
             "style-src-elem 'self' cdn.jsdelivr.net cdnjs.cloudflare.com use.fontawesome.com",
             "img-src 'self' avatars.githubusercontent.com",
-            "font-src 'self' cdnjs.cloudflare.com  use.fontawesome.com",
+            "font-src 'self' cdnjs.cloudflare.com use.fontawesome.com",
             "connect-src 'self'",
             "media-src 'none'",
             "object-src 'none'",

--- a/src/Costellobot/Program.cs
+++ b/src/Costellobot/Program.cs
@@ -70,6 +70,9 @@ app.MapGet("/version", () => new
     {
         self = new { href = "https://costellobot.martincostello.com" },
         repo = new { href = "https://github.com/martincostello/costellobot" },
+        branch = new { href = $"https://github.com/martincostello/costellobot/tree/{GitMetadata.Branch}" },
+        commit = new { href = $"https://github.com/martincostello/costellobot/commit/{GitMetadata.Commit}" },
+        deploy = new { href = $"https://github.com/martincostello/costellobot/actions/runs/{GitMetadata.BuildId}" },
     },
 }).AllowAnonymous();
 


### PR DESCRIPTION
- Add some more links to the `/version` resource.
- Fix rogue space in the `Content-Security-Policy` header.
