### PR TITLE
Add end-to-end test concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,7 @@ jobs:
     name: test-production
     needs: deploy
     runs-on: ubuntu-latest
+    concurrency: production_environment
 
     steps:
 


### PR DESCRIPTION
Use the same concurrency for deployment as the tests to try and prevent subsequent deployments running while the tests from the previous deployment are still running.

<!--

Summarise the changes this Pull Request makes.

Please include a reference to a GitHub issue if appropriate.

-->
