### PR TITLE
Remove duplicate package reference

### DIFF
--- a/tests/Costellobot.Tests/Costellobot.Tests.csproj
+++ b/tests/Costellobot.Tests/Costellobot.Tests.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="JustEat.HttpClientInterception" />
     <PackageReference Include="MartinCostello.Logging.XUnit" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />


### PR DESCRIPTION
`GitHubActionsTestLogger` is already imported by `Directory.Build.props`.
