### PR TITLE
Use one property for ASP.NET Core version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,4 +1,7 @@
 <Project>
+  <PropertyGroup>
+    <MicrosoftAspNetCoreVersion>6.0.5</MicrosoftAspNetCoreVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="6.0.6" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
@@ -10,9 +13,9 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="3.1.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="6.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="6.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.17.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.21.0" />


### PR DESCRIPTION
Use a single MSBuild property for the version of all packages built from the dotnet/aspnetcore repo.

This should reduce merge conflicts and make #52 easier to keep up-to-date.
