### PR TITLE
Change Lighthouse access token

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_MULTILEVEL_LOOKUP: 0
@@ -57,7 +60,7 @@ jobs:
       uses: foo-software/lighthouse-check-action@v8.0.2
       with:
         device: 'all'
-        gitHubAccessToken: ${{ secrets.GITHUB_TOKEN }}
+        gitHubAccessToken: ${{ secrets.LIGHTHOUSE_ACCESS_TOKEN }}
         outputDirectory: ${{ github.workspace }}/artifacts
         prCommentEnabled: true
         urls: 'https://localhost:5001'


### PR DESCRIPTION
- Use an access token that has access to leave reviews from pull requests.
- Set explicit GitHub token permissions.
- Fail workflow if Lighthouse scores regress.
