### PR TITLE
Trust @octokit/types

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -46,6 +46,7 @@
       "Dependencies": [
         "^@actions\/.*$",
         "^@microsoft\/signalr$",
+        "^@octokit\/types$",
         "^@types\/.*$",
         "^actions\/.*$",
         "^Amazon.Lambda\\..*$",


### PR DESCRIPTION
Add the `@octokit/types` package to the trusted dependencies (e.g. for martincostello/update-dotnet-sdk#170).
