### PR TITLE
Add Debug UI

### DIFF
--- a/src/Costellobot/GitHubExtensions.cs
+++ b/src/Costellobot/GitHubExtensions.cs
@@ -72,13 +72,13 @@ public static class GitHubExtensions
         services.AddSingleton<WebhookEventProcessor, GitHubEventProcessor>();
         services.AddSingleton<GitHubWebhookQueue>();
         services.AddSingleton<GitHubWebhookService>();
-        services.AddScoped<GitCommitAnalyzer>();
-        services.AddScoped<GitHubWebhookDispatcher>();
+        services.AddTransient<GitCommitAnalyzer>();
+        services.AddTransient<GitHubWebhookDispatcher>();
 
         services.AddSingleton<IHandlerFactory, HandlerFactory>();
-        services.AddScoped<CheckSuiteHandler>();
-        services.AddScoped<DeploymentStatusHandler>();
-        services.AddScoped<PullRequestHandler>();
+        services.AddTransient<CheckSuiteHandler>();
+        services.AddTransient<DeploymentStatusHandler>();
+        services.AddTransient<PullRequestHandler>();
 
         services.AddHostedService<GitHubWebhookService>();
 

--- a/src/Costellobot/Pages/Home/Index.cshtml.cs
+++ b/src/Costellobot/Pages/Home/Index.cshtml.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable SA1649
-
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace MartinCostello.Costellobot.Pages;
 
 [CostellobotAdmin]
-public sealed class IndexModel : PageModel
+public sealed partial class IndexModel : PageModel
 {
     public void OnGet()
     {

--- a/src/Costellobot/Pages/Shared/Error.cshtml.cs
+++ b/src/Costellobot/Pages/Shared/Error.cshtml.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable SA1649
-
 using System.Diagnostics;
 using System.Net;
 using Microsoft.AspNetCore.Authorization;
@@ -14,7 +12,7 @@ namespace MartinCostello.Costellobot.Pages;
 [AllowAnonymous]
 [IgnoreAntiforgeryToken]
 [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
-public sealed class ErrorModel : PageModel
+public sealed partial class ErrorModel : PageModel
 {
     public int ErrorStatusCode { get; private set; } = StatusCodes.Status500InternalServerError;
 

--- a/src/Costellobot/Pages/Shared/SignIn.cshtml.cs
+++ b/src/Costellobot/Pages/Shared/SignIn.cshtml.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable SA1649
-
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace MartinCostello.Costellobot.Pages;
 
-public sealed class SignInModel : PageModel
+public sealed partial class SignInModel : PageModel
 {
     public IActionResult OnGet()
     {

--- a/src/Costellobot/Pages/Shared/_Layout.cshtml
+++ b/src/Costellobot/Pages/Shared/_Layout.cshtml
@@ -89,7 +89,14 @@
                             <span class="fa-brands fa-github" aria-hidden="true"></span>
                         </a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="~/github-webhook" title="Debug">
+                            Debug
+                            <span class="fa-solid fa-bug"></span>
+                        </a>
+                    </li>
                 </ul>
+
                 @if (User.Identity!.IsAuthenticated)
                 {
                     <div class="dropdown-divider"></div>

--- a/src/Costellobot/Pages/Webhook/Debug.cshtml
+++ b/src/Costellobot/Pages/Webhook/Debug.cshtml
@@ -1,0 +1,47 @@
+@page "/github-webhook"
+@model DebugModel
+@{
+    ViewData["Title"] = "Debug Webhook";
+}
+<div id="debug-content" app-id="@(Model.AppId)">
+  <form action="#">
+    <div class="form-group">
+      <label for="webhook-event"><a href="https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads" target="_blank" rel="noopener">Event</a></label>
+      <select id="webhook-event" class="form-control text-webhook" autofocus="autofocus" aria-label="Event" aria-describedby="webhook-event-help">
+        <option value="check_suite">check_suite</option>
+        <option value="deployment_status">deployment_status</option>
+        <option value="installation">installation</option>
+        <option value="pull_request" selected>pull_request</option>
+        <option value="status">status</option>
+      </select>
+    </div>
+    @if (Model.RequireSignature)
+    {
+      <div class="form-group">
+        <label for="webhook-signature">Signature</label>
+        <input id="webhook-signature" class="form-control" type="text" autocomplete="off" spellcheck="false">
+      </div>
+    }
+    <div class="form-group">
+      <label for="webhook-payload">Payload</label>
+      @{
+        string example = @"{
+  ""action"": ""opened"",
+  ""number"": 1,
+  ""pull_request"": {
+    ""url"": ""https://api.github.com/repos/octocat/Hello-World/pulls/1"",
+    ""id"": 1,
+    ""node_id"": ""MDY6Q29tbWl0MTgwMzkzMzA1"",
+    ""html_url"": """"
+  }
+}";
+      }
+      <textarea id="webhook-payload" class="form-control form-payload text-webhook" placeholder="@(example)" rows="20" spellcheck="false" aria-describedby="webhook-payload-help"></textarea>
+    </div>
+    <button id="post-webhook" type="submit" class="btn btn-primary" disabled>
+      POST
+      <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
+    </button>
+    <span class="badge webhook-status d-none"></span>
+  </form>
+</div>

--- a/src/Costellobot/Pages/Webhook/Debug.cshtml.cs
+++ b/src/Costellobot/Pages/Webhook/Debug.cshtml.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Options;
+
+namespace MartinCostello.Costellobot.Pages;
+
+[CostellobotAdmin]
+public sealed partial class DebugModel : PageModel
+{
+    public DebugModel(IOptions<GitHubOptions> options)
+    {
+        AppId = options.Value.AppId;
+        RequireSignature = !string.IsNullOrWhiteSpace(options.Value.WebhookSecret);
+    }
+
+    public string AppId { get; }
+
+    public bool RequireSignature { get; }
+
+    public void OnGet()
+    {
+        // No-op
+    }
+}

--- a/src/Costellobot/wwwroot/css/site.css
+++ b/src/Costellobot/wwwroot/css/site.css
@@ -20,6 +20,10 @@ img.user-profile {
     max-width: 30px;
 }
 
+textarea.form-payload {
+    resize: none;
+}
+
 .body-content {
     padding-top: 10px;
 }
@@ -37,6 +41,10 @@ img.user-profile {
     max-height: 20rem;
     min-height: 20rem;
     resize: none;
+}
+
+.text-webhook {
+    font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
 }
 
 .webhook-item > pre {

--- a/tests/Costellobot.Tests/ResourceTests.cs
+++ b/tests/Costellobot.Tests/ResourceTests.cs
@@ -52,6 +52,7 @@ public sealed class ResourceTests : IntegrationTests<AppFixture>
     [InlineData("/error.html", MediaTypeNames.Text.Html)]
     [InlineData("/favicon.png", "image/png")]
     [InlineData("/forbidden.html", MediaTypeNames.Text.Html)]
+    [InlineData("/github-webhook", MediaTypeNames.Text.Html)]
     [InlineData("/humans.txt", MediaTypeNames.Text.Plain)]
     [InlineData("/manifest.webmanifest", "application/manifest+json")]
     [InlineData("/not-found.html", MediaTypeNames.Text.Html)]
@@ -76,6 +77,7 @@ public sealed class ResourceTests : IntegrationTests<AppFixture>
 
     [Theory]
     [InlineData("/")]
+    [InlineData("/github-webhook")]
     public async Task Cannot_Get_Resource_Unauthenticated(string requestUri)
     {
         // Arrange


### PR DESCRIPTION
- Add a page for manually submitting webhook payloads to aid with debugging.
- Fix some issues with scoping of services when debugging locally.
- Remove the need for pragmas by making Razor page classes partial.
