### PR TITLE
Upgrade to Bootstrap 5

### DIFF
--- a/src/Costellobot/CustomHttpHeadersMiddleware.cs
+++ b/src/Costellobot/CustomHttpHeadersMiddleware.cs
@@ -17,7 +17,7 @@ public sealed class CustomHttpHeadersMiddleware
             "script-src-elem 'self' cdn.jsdelivr.net cdnjs.cloudflare.com",
             "style-src 'self' cdn.jsdelivr.net cdnjs.cloudflare.com use.fontawesome.com",
             "style-src-elem 'self' cdn.jsdelivr.net cdnjs.cloudflare.com use.fontawesome.com",
-            "img-src 'self' avatars.githubusercontent.com",
+            "img-src 'self' data: avatars.githubusercontent.com",
             "font-src 'self' cdnjs.cloudflare.com use.fontawesome.com",
             "connect-src 'self'",
             "media-src 'none'",

--- a/src/Costellobot/CustomHttpHeadersMiddleware.cs
+++ b/src/Costellobot/CustomHttpHeadersMiddleware.cs
@@ -58,7 +58,6 @@ public sealed class CustomHttpHeadersMiddleware
                 context.Response.Headers["Expect-CT"] = "max-age=1800";
             }
 
-            context.Response.Headers["Feature-Policy"] = "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'";
             context.Response.Headers["Permissions-Policy"] = "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
             context.Response.Headers["Referrer-Policy"] = "no-referrer-when-downgrade";
             context.Response.Headers["X-Content-Type-Options"] = "nosniff";

--- a/src/Costellobot/Pages/Shared/_Layout.cshtml
+++ b/src/Costellobot/Pages/Shared/_Layout.cshtml
@@ -107,6 +107,7 @@
                                     string profileUrl = User.GetProfileUrl();
                                     string? avatarUrl = User.GetAvatarUrl();
                                 }
+                                <a class="nav-link" href="@profileUrl" title="View your GitHub profile" target="_blank" rel="noopener">
                                     <span id="user-name">@displayName</span>
                                     @if (!string.IsNullOrWhiteSpace(avatarUrl))
                                     {
@@ -133,18 +134,18 @@
             <p>
                 &copy; @(DateTimeOffset.UtcNow.Year) - Martin Costello |
                 Built from
-                <a href="@commit" title="View commit @GitMetadata.Commit on GitHub" target="_blank">
+                <a href="@commit" title="View commit @GitMetadata.Commit on GitHub" target="_blank" rel="noopener">
                     <code>@string.Join(string.Empty, GitMetadata.Commit.Take(7))</code>
                 </a>
                 on
-                <a href="@branch" title="View branch @GitMetadata.Branch on GitHub" target="_blank">
+                <a href="@branch" title="View branch @GitMetadata.Branch on GitHub" target="_blank" rel="noopener">
                     <code>@GitMetadata.Branch</code>
                 </a>
                 @if (!string.IsNullOrWhiteSpace(GitMetadata.BuildId))
                 {
                     <text>
                     by
-                    <a href="@build" title="View deployment on GitHub" target="_blank">
+                    <a href="@build" title="View deployment on GitHub" target="_blank" rel="noopener">
                         GitHub
                     </a>
                     </text>

--- a/src/Costellobot/Pages/Shared/_Layout.cshtml
+++ b/src/Costellobot/Pages/Shared/_Layout.cshtml
@@ -62,7 +62,7 @@
     <meta name="twitter:data1" content="@author" />
     <link rel="manifest" href="@Url.Content("~/manifest.webmanifest")" asp-append-version="true" />
     <link rel="shortcut icon" type="image/x-icon" href="~/favicon.png" asp-append-version="true" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css" integrity="sha384-zCbKRCUGaJDkqS1kPbPd7TveP5iyJE0EjAuZQTgFLD2ylzuqKfdKlfG/eSrtxUkn" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     @{
@@ -78,11 +78,11 @@
                 <img src="~/favicon.png" width="30" height="30" class="d-inline-block align-top" alt="costellobot" aria-hidden="true">
                 costellobot
             </a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#site-navbar" aria-controls="site-navbar" aria-expanded="false" aria-label="Toggle navigation">
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#site-navbar" aria-controls="site-navbar" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="site-navbar">
-                <ul class="navbar-nav mr-auto">
+                <ul class="navbar-nav me-auto">
                     <li class="nav-item">
                         <a class="nav-link" href="@(repository)" target="_blank" rel="noopener" title="GitHub">
                             GitHub
@@ -99,16 +99,14 @@
 
                 @if (User.Identity!.IsAuthenticated)
                 {
-                    <div class="dropdown-divider"></div>
-                    <form action="~/sign-out" method="post" class="navbar-right">
-                        <ul class="nav navbar-nav navbar-right">
+                    <form action="~/sign-out" method="post">
+                        <ul class="nav navbar-nav">
                             <li>
                                 @{
                                     string displayName = User.GetUserName();
                                     string profileUrl = User.GetProfileUrl();
                                     string? avatarUrl = User.GetAvatarUrl();
                                 }
-                                <a class="nav-link" href="@profileUrl" title="View your GitHub profile" target="_blank">
                                     <span id="user-name">@displayName</span>
                                     @if (!string.IsNullOrWhiteSpace(avatarUrl))
                                     {
@@ -155,8 +153,7 @@
             </p>
         </footer>
     </main>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.slim.min.js" integrity="sha512-6ORWJX/LrnSjBzwefdNUyLCMTIsGoNP6NftMy2UAm1JBm6PRZCO1d7OHBStWpVFZLO+RerTvqX/Z9mBFfCJZ4A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-fQybjgWLrvvRgtW6bFlB7jaZrFsaBXjsOMm/tB9LTS58ONXgqbR9W8oWht/amnpF" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="~/static/js/main.js" asp-append-version="true"></script>
 </body>
 <!--

--- a/src/Costellobot/Pages/Webhook/Debug.cshtml
+++ b/src/Costellobot/Pages/Webhook/Debug.cshtml
@@ -5,25 +5,33 @@
 }
 <div id="debug-content" app-id="@(Model.AppId)">
   <form action="#">
-    <div class="form-group">
-      <label for="webhook-event"><a href="https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads" target="_blank" rel="noopener">Event</a></label>
-      <select id="webhook-event" class="form-control text-webhook" autofocus="autofocus" aria-label="Event" aria-describedby="webhook-event-help">
+    <div class="mb-3">
+      <label for="webhook-event" class="form-label">Event</label>
+      <select id="webhook-event" class="form-select text-webhook" autofocus="autofocus" aria-label="Event" aria-describedby="webhook-event-help">
         <option value="check_suite">check_suite</option>
         <option value="deployment_status">deployment_status</option>
         <option value="installation">installation</option>
         <option value="pull_request" selected>pull_request</option>
         <option value="status">status</option>
       </select>
+      <div id="webhook-event-help" class="form-text">
+        The name of the
+        <a href="https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads" target="_blank" rel="noopener">GitHub event</a>
+        associated with the webhook payload.
+      </div>
     </div>
     @if (Model.RequireSignature)
     {
-      <div class="form-group">
+      <div class="mb-3">
         <label for="webhook-signature">Signature</label>
-        <input id="webhook-signature" class="form-control" type="text" autocomplete="off" spellcheck="false">
+        <input id="webhook-signature" class="form-control" placeholder="sha256=5a797ecce27d941c46c6ea5c39d5b17b31881eabccb6f83f0dc8a7cb2666d836" type="text" autocomplete="off" spellcheck="false">
+        <div id="webhook-signature-help" class="form-text">
+          The SHA-256 signature for the payload.
+        </div>
       </div>
     }
-    <div class="form-group">
-      <label for="webhook-payload">Payload</label>
+    <div class="mb-3">
+      <label for="webhook-payload" class="form-label">Payload</label>
       @{
         string example = @"{
   ""action"": ""opened"",
@@ -37,6 +45,9 @@
 }";
       }
       <textarea id="webhook-payload" class="form-control form-payload text-webhook" placeholder="@(example)" rows="20" spellcheck="false" aria-describedby="webhook-payload-help"></textarea>
+      <div id="webhook-payload-help" class="form-text">
+        The JSON payload of the GitHub event.
+      </div>
     </div>
     <button id="post-webhook" type="submit" class="btn btn-primary" disabled>
       POST

--- a/src/Costellobot/scripts/ts/App.ts
+++ b/src/Costellobot/scripts/ts/App.ts
@@ -17,6 +17,7 @@ export class App {
     private webhooksContentContainer: HTMLElement;
 
     private appId: string;
+    private webhookDelivery: number;
     private webhookEvent: HTMLInputElement;
     private webhookPayload: HTMLInputElement;
     private webhookSignature: HTMLInputElement;
@@ -66,6 +67,7 @@ export class App {
     private initiailizeDebug(webhookSubmit: HTMLElement) {
 
         this.appId = document.querySelector('[app-id]').getAttribute('app-id');
+        this.webhookDelivery = 1;
         this.webhookEvent = <HTMLInputElement>document.getElementById('webhook-event');
         this.webhookPayload = <HTMLInputElement>document.getElementById('webhook-payload');
         this.webhookSignature = <HTMLInputElement>document.getElementById('webhook-signature');
@@ -241,8 +243,12 @@ export class App {
 
         headers.set('Accept', 'application/json');
         headers.set('Content-Type', 'application/json');
+
+        headers.set('X-GitHub-Delivery', `debug-${this.webhookDelivery++}`);
         headers.set('X-GitHub-Event', event);
+        headers.set('X-GitHub-Hook-ID', 'debug');
         headers.set('X-GitHub-Hook-Installation-Target-ID', this.appId);
+        headers.set('X-GitHub-Hook-Installation-Target-Type', 'integration');
 
         if (signature) {
             headers.set('X-Hub-Signature-256', signature);

--- a/src/Costellobot/scripts/ts/App.ts
+++ b/src/Costellobot/scripts/ts/App.ts
@@ -104,8 +104,8 @@ export class App {
             const result = await this.postJson(event, payload, signature);
 
             badge.textContent = result.status.toString(10);
-            badge.classList.add(result.isOK ? 'badge-success' : 'badge-danger');
-            badge.classList.remove(result.isOK ? 'badge-danger' : 'badge-success');
+            badge.classList.add(result.isOK ? 'bg-success' : 'bg-danger');
+            badge.classList.remove(result.isOK ? 'bg-danger' : 'bg-success');
 
             this.show(badge);
             this.enable(this.webhookSubmit);
@@ -158,7 +158,7 @@ export class App {
         indexItem.classList.add('webhook-item');
 
         indexItem.setAttribute('id', indexId);
-        indexItem.setAttribute('data-toggle', 'list');
+        indexItem.setAttribute('data-bs-toggle', 'list');
         indexItem.setAttribute('href', `#${contentId}`);
         indexItem.setAttribute('role', 'tab');
         indexItem.setAttribute('aria-controls', contentId);

--- a/src/Costellobot/wwwroot/bad-request.html
+++ b/src/Costellobot/wwwroot/bad-request.html
@@ -16,7 +16,7 @@
     <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css" integrity="sha384-zCbKRCUGaJDkqS1kPbPd7TveP5iyJE0EjAuZQTgFLD2ylzuqKfdKlfG/eSrtxUkn" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="/css/site.css" />
 </head>
@@ -39,7 +39,6 @@
             </p>
         </footer>
     </main>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.slim.min.js" integrity="sha512-6ORWJX/LrnSjBzwefdNUyLCMTIsGoNP6NftMy2UAm1JBm6PRZCO1d7OHBStWpVFZLO+RerTvqX/Z9mBFfCJZ4A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-fQybjgWLrvvRgtW6bFlB7jaZrFsaBXjsOMm/tB9LTS58ONXgqbR9W8oWht/amnpF" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </body>
 </html>

--- a/src/Costellobot/wwwroot/css/site.css
+++ b/src/Costellobot/wwwroot/css/site.css
@@ -9,6 +9,19 @@ html {
 
 a {
     color: #0060C7;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+a.btn:hover,
+a.dropdown-item:hover,
+a.navbar-brand:hover,
+a.nav-link:hover,
+a:not([href]):not([class]):hover {
+    text-decoration: none;
 }
 
 code.webhook-content {
@@ -22,6 +35,10 @@ img.user-profile {
 
 textarea.form-payload {
     resize: none;
+}
+
+.bg-dark {
+    background-color: #343a40 !important;
 }
 
 .body-content {

--- a/src/Costellobot/wwwroot/error.html
+++ b/src/Costellobot/wwwroot/error.html
@@ -16,7 +16,7 @@
     <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css" integrity="sha384-zCbKRCUGaJDkqS1kPbPd7TveP5iyJE0EjAuZQTgFLD2ylzuqKfdKlfG/eSrtxUkn" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="/css/site.css" />
 </head>
@@ -39,7 +39,6 @@
             </p>
         </footer>
     </main>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.slim.min.js" integrity="sha512-6ORWJX/LrnSjBzwefdNUyLCMTIsGoNP6NftMy2UAm1JBm6PRZCO1d7OHBStWpVFZLO+RerTvqX/Z9mBFfCJZ4A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-fQybjgWLrvvRgtW6bFlB7jaZrFsaBXjsOMm/tB9LTS58ONXgqbR9W8oWht/amnpF" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </body>
 </html>

--- a/src/Costellobot/wwwroot/forbidden.html
+++ b/src/Costellobot/wwwroot/forbidden.html
@@ -16,7 +16,7 @@
     <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css" integrity="sha384-zCbKRCUGaJDkqS1kPbPd7TveP5iyJE0EjAuZQTgFLD2ylzuqKfdKlfG/eSrtxUkn" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="/css/site.css" />
 </head>
@@ -39,7 +39,6 @@
             </p>
         </footer>
     </main>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.slim.min.js" integrity="sha512-6ORWJX/LrnSjBzwefdNUyLCMTIsGoNP6NftMy2UAm1JBm6PRZCO1d7OHBStWpVFZLO+RerTvqX/Z9mBFfCJZ4A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-fQybjgWLrvvRgtW6bFlB7jaZrFsaBXjsOMm/tB9LTS58ONXgqbR9W8oWht/amnpF" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </body>
 </html>

--- a/src/Costellobot/wwwroot/not-found.html
+++ b/src/Costellobot/wwwroot/not-found.html
@@ -16,7 +16,7 @@
     <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css" integrity="sha384-zCbKRCUGaJDkqS1kPbPd7TveP5iyJE0EjAuZQTgFLD2ylzuqKfdKlfG/eSrtxUkn" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="/css/site.css" />
 </head>
@@ -39,7 +39,6 @@
             </p>
         </footer>
     </main>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.slim.min.js" integrity="sha512-6ORWJX/LrnSjBzwefdNUyLCMTIsGoNP6NftMy2UAm1JBm6PRZCO1d7OHBStWpVFZLO+RerTvqX/Z9mBFfCJZ4A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-fQybjgWLrvvRgtW6bFlB7jaZrFsaBXjsOMm/tB9LTS58ONXgqbR9W8oWht/amnpF" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </body>
 </html>

--- a/src/Costellobot/wwwroot/unauthorized.html
+++ b/src/Costellobot/wwwroot/unauthorized.html
@@ -16,7 +16,7 @@
     <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css" integrity="sha384-zCbKRCUGaJDkqS1kPbPd7TveP5iyJE0EjAuZQTgFLD2ylzuqKfdKlfG/eSrtxUkn" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="/css/site.css" />
 </head>
@@ -39,7 +39,6 @@
             </p>
         </footer>
     </main>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.slim.min.js" integrity="sha512-6ORWJX/LrnSjBzwefdNUyLCMTIsGoNP6NftMy2UAm1JBm6PRZCO1d7OHBStWpVFZLO+RerTvqX/Z9mBFfCJZ4A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-fQybjgWLrvvRgtW6bFlB7jaZrFsaBXjsOMm/tB9LTS58ONXgqbR9W8oWht/amnpF" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </body>
 </html>

--- a/tests/Costellobot.EndToEndTests/ResourceTests.cs
+++ b/tests/Costellobot.EndToEndTests/ResourceTests.cs
@@ -52,7 +52,6 @@ public class ResourceTests : EndToEndTest
         {
             "Content-Security-Policy",
             "Expect-CT",
-            "Feature-Policy",
             "Permissions-Policy",
             "Referrer-Policy",
             "X-Content-Type-Options",

--- a/tests/Costellobot.Tests/ResourceTests.cs
+++ b/tests/Costellobot.Tests/ResourceTests.cs
@@ -176,7 +176,6 @@ public sealed class ResourceTests : IntegrationTests<AppFixture>
         {
             "Content-Security-Policy",
             "Expect-CT",
-            "Feature-Policy",
             "Permissions-Policy",
             "Referrer-Policy",
             "X-Content-Type-Options",


### PR DESCRIPTION
- Upgrade to Bootstrap 5
- Remove the `Feature-Policy` HTTP response header to fix Chrome warning.
- Add `rel="noopener"` to all the external links.
- Set some more of the expected headers for the GitHub webhook payloads from the debug page.

Resolves #125.
