### PR TITLE
Fix circular dependency

### DIFF
--- a/src/Costellobot/gulpfile.js
+++ b/src/Costellobot/gulpfile.js
@@ -1,4 +1,4 @@
-/// <binding ProjectOpened='default' />
+/// <binding ProjectOpened='watch' />
 const browserify = require('browserify');
 const buffer = require('vinyl-buffer');
 const eslint = require('gulp-eslint');
@@ -58,5 +58,5 @@ gulp.task('test', function () {
 gulp.task('default', gulp.series('prettier', 'lint', 'build', 'test'));
 
 gulp.task('watch', function () {
-    gulp.watch(sourceFiles, gulp.series('default'));
+    gulp.watch(sourceFiles, gulp.series('lint', 'build', 'test'));
 });


### PR DESCRIPTION
Fix running `default` causing a circular dependency with `watch` when formatting was run which would make it build (and format) again.

<!--

Summarise the changes this Pull Request makes.

Please include a reference to a GitHub issue if appropriate.

-->
