### PR TITLE
Support trusted publishers

### DIFF
--- a/src/Costellobot/DependencyEcosystem.cs
+++ b/src/Costellobot/DependencyEcosystem.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Costellobot;
+
+public enum DependencyEcosystem
+{
+    Unknown = 0,
+    Unsupported,
+    GitHubActions,
+    Npm,
+    NuGet,
+    Submodules,
+}

--- a/src/Costellobot/GitCommitAnalyzer.cs
+++ b/src/Costellobot/GitCommitAnalyzer.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
+using MartinCostello.Costellobot.Registries;
 using Microsoft.Extensions.Options;
 using Octokit;
 
@@ -9,36 +11,104 @@ namespace MartinCostello.Costellobot;
 
 public sealed partial class GitCommitAnalyzer
 {
+    private readonly IReadOnlyCollection<IPackageRegistry> _registries;
     private readonly IOptionsMonitor<WebhookOptions> _options;
     private readonly ILogger _logger;
 
     public GitCommitAnalyzer(
+        IEnumerable<IPackageRegistry> registries,
         IOptionsMonitor<WebhookOptions> options,
         ILogger<GitCommitAnalyzer> logger)
     {
+        _registries = registries.ToArray();
         _options = options;
         _logger = logger;
     }
 
-    public bool IsTrustedDependencyUpdate(
-        string owner,
-        string name,
-        GitHubCommit commit)
+    public static bool TryParseVersionNumber(string commitMessage, [MaybeNullWhen(false)] out string? version)
     {
-        return IsTrustedDependencyUpdate(owner, name, commit.Sha, commit.Commit.Message);
+        // Extract the version numbers from the commit message.
+        // See https://github.com/dependabot/fetch-metadata/blob/d9606730415777cc0dc46d64c4ce0e16624bd714/src/dependabot/update_metadata.ts#L30
+        string[] patterns = new[]
+        {
+            @"Bumps .* from (?<from>\d[^ ]*) to (?<to>\d[^ ]*)\.", // Normal version updates
+            @"Bumps .* from \`(?<from>[\da-f][^ ]*)\` to \`(?<to>[\da-f][^ ]*)\`\.", // Git submodule updates
+        };
+
+        foreach (var pattern in patterns)
+        {
+            var match = Regex.Match(commitMessage, pattern, RegexOptions.Multiline);
+            var group = match.Groups["to"];
+
+            if (group.Success)
+            {
+                version = group.Value;
+                return true;
+            }
+        }
+
+        version = null;
+        return false;
     }
 
-    public bool IsTrustedDependencyUpdate(
+    public async Task<bool> IsTrustedDependencyUpdateAsync(
         string owner,
         string name,
+        string? reference,
+        GitHubCommit commit)
+    {
+        return await IsTrustedDependencyUpdateAsync(
+            owner,
+            name,
+            reference,
+            commit.Sha,
+            commit.Commit.Message);
+    }
+
+    public async Task<bool> IsTrustedDependencyUpdateAsync(
+        string owner,
+        string name,
+        string? reference,
         string sha,
         string commitMessage)
+    {
+        bool isTrusted = IsTrustedDependencyName(
+            owner,
+            name,
+            sha,
+            commitMessage,
+            out var dependencies);
+
+        if (!isTrusted)
+        {
+            isTrusted = await IsTrustedDependencyOwnerAsync(
+                owner,
+                name,
+                reference,
+                commitMessage,
+                dependencies);
+        }
+
+        if (isTrusted)
+        {
+            Log.TrustedDependenciesUpdated(
+                _logger,
+                sha,
+                owner,
+                name,
+                dependencies.Count);
+        }
+
+        return isTrusted;
+    }
+
+    private static IReadOnlyList<string> ParseDependencies(string commitMessage)
     {
         string[] commitLines = commitMessage
             .ReplaceLineEndings("\n")
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
-        var dependencies = new HashSet<string>();
+        var dependencies = new List<string>(commitLines.Length);
 
         foreach (string line in commitLines)
         {
@@ -50,10 +120,57 @@ public sealed partial class GitCommitAnalyzer
 
                 if (!string.IsNullOrEmpty(dependencyName))
                 {
-                    dependencies.Add(dependencyName.Trim());
+                    // Sometimes the dependencies are wrapped with quotes,
+                    // for example "- dependency-name: "@actions/github"".
+                    string trimmed = dependencyName
+                        .Trim()
+                        .Trim('"');
+
+                    dependencies.Add(trimmed);
                 }
             }
         }
+
+        dependencies.TrimExcess();
+
+        return dependencies;
+    }
+
+    private static DependencyEcosystem ParseEcosystem(string? reference)
+    {
+        // Approach based on what Dependabot itself does to parse commits to generate release notes.
+        // See https://github.com/dependabot/fetch-metadata/blob/d9606730415777cc0dc46d64c4ce0e16624bd714/src/dependabot/update_metadata.ts#L55.
+        // Example ref (branch) names:
+        // * dependabot/github_actions/actions/dependency-review-action-2
+        // * dependabot/npm_and_yarn/src/Costellobot/typescript-eslint/eslint-plugin-5.31.0
+        // * dependabot/nuget/Microsoft.IdentityModel.JsonWebTokens-6.22.0
+        string[]? parts = reference?.Split('/');
+
+        if (parts is null ||
+            parts.Length < 3 ||
+            !string.Equals(parts[0], "dependabot", StringComparison.Ordinal))
+        {
+            return DependencyEcosystem.Unknown;
+        }
+
+        return parts[1] switch
+        {
+            "github_actions" => DependencyEcosystem.GitHubActions,
+            "npm_and_yarn" => DependencyEcosystem.Npm,
+            "nuget" => DependencyEcosystem.NuGet,
+            "submodules" => DependencyEcosystem.Submodules,
+            _ => DependencyEcosystem.Unsupported,
+        };
+    }
+
+    private bool IsTrustedDependencyName(
+        string owner,
+        string name,
+        string sha,
+        string commitMessage,
+        out IReadOnlyList<string> dependencies)
+    {
+        dependencies = ParseDependencies(commitMessage);
 
         var trustedDependencies = _options.CurrentValue.TrustedEntities.Dependencies;
 
@@ -71,34 +188,98 @@ public sealed partial class GitCommitAnalyzer
 
         foreach (string dependency in dependencies)
         {
-            // Sometimes the dependencies are wrapped with quotes,
-            // for example "- dependency-name: "@actions/github"".
-            string trimmed = dependency.Trim('"');
-
-            if (!trustedDependencies.Any((p) => Regex.IsMatch(trimmed, p)))
+            if (!trustedDependencies.Any((p) => Regex.IsMatch(dependency, p)))
             {
-                Log.UntrustedDependencyUpdated(
+                Log.UntrustedDependencyNameUpdated(
                     _logger,
                     sha,
                     owner,
                     name,
-                    trimmed);
+                    dependency);
 
                 return false;
             }
         }
 
-        Log.TrustedDependenciesUpdated(
-            _logger,
-            sha,
-            owner,
-            name,
-            dependencies.Count);
-
         return true;
     }
 
-    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    private async Task<bool> IsTrustedDependencyOwnerAsync(
+        string owner,
+        string name,
+        string? reference,
+        string commitMessage,
+        IReadOnlyList<string> dependencies)
+    {
+        if (dependencies.Count != 1 || _registries.Count < 1)
+        {
+            // Either no dependencies were parsed, or more than one was found,
+            // in which case we're not able to look up the version for every one.
+            return false;
+        }
+
+        // If only one dependency was found, we can attempt to extract the version
+        // from the commit message to see if the package was from a trusted publisher.
+        string dependency = dependencies[0];
+
+        if (!TryParseVersionNumber(commitMessage, out var version) ||
+            string.IsNullOrWhiteSpace(version))
+        {
+            return false;
+        }
+
+        var ecosystem = ParseEcosystem(reference);
+
+        if (ecosystem == DependencyEcosystem.Unknown ||
+            ecosystem == DependencyEcosystem.Unsupported)
+        {
+            return false;
+        }
+
+        if (!_options.CurrentValue.TrustedEntities.Publishers.TryGetValue(ecosystem, out var publishers) ||
+            publishers.Count < 1)
+        {
+            return false;
+        }
+
+        var registry = _registries
+            .Where((p) => p.Ecosystem == ecosystem)
+            .FirstOrDefault();
+
+        if (registry is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            var owners = await registry.GetPackageOwnersAsync(
+                owner,
+                name,
+                dependency,
+                version);
+
+            if (owners.Any((p) => publishers.Contains(p)))
+            {
+                return true;
+            }
+
+            Log.UntrustedDependencyOwnerUpdated(
+                _logger,
+                reference,
+                owner,
+                name,
+                dependency);
+        }
+        catch (Exception ex)
+        {
+            Log.FailedToQueryPackageRegistry(_logger, dependency, version, ecosystem, ex);
+        }
+
+        return false;
+    }
+
+    [ExcludeFromCodeCoverage]
     private static partial class Log
     {
         [LoggerMessage(
@@ -115,8 +296,8 @@ public sealed partial class GitCommitAnalyzer
         [LoggerMessage(
            EventId = 2,
            Level = LogLevel.Information,
-           Message = "Commit {Sha} for {Owner}/{Repository} updates dependency {Dependency} which is not trusted.")]
-        public static partial void UntrustedDependencyUpdated(
+           Message = "Commit {Sha} for {Owner}/{Repository} updates dependency {Dependency} which is not trusted by its name.")]
+        public static partial void UntrustedDependencyNameUpdated(
             ILogger logger,
             string sha,
             string owner,
@@ -133,5 +314,27 @@ public sealed partial class GitCommitAnalyzer
             string owner,
             string repository,
             int count);
+
+        [LoggerMessage(
+           EventId = 4,
+           Level = LogLevel.Error,
+           Message = "Failed to query owners for package {PackageId} version {PackageVersion} from the {Ecosystem} ecosystem.")]
+        public static partial void FailedToQueryPackageRegistry(
+            ILogger logger,
+            string packageId,
+            string packageVersion,
+            DependencyEcosystem ecosystem,
+            Exception exception);
+
+        [LoggerMessage(
+           EventId = 5,
+           Level = LogLevel.Information,
+           Message = "Reference {Reference} for {Owner}/{Repository} updates dependency {Dependency} which is not trusted by its owner.")]
+        public static partial void UntrustedDependencyOwnerUpdated(
+            ILogger logger,
+            string? reference,
+            string owner,
+            string repository,
+            string dependency);
     }
 }

--- a/src/Costellobot/Registries/GitHubActionsPackageRegistry.cs
+++ b/src/Costellobot/Registries/GitHubActionsPackageRegistry.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Octokit;
+
+namespace MartinCostello.Costellobot.Registries;
+
+public sealed class GitHubActionsPackageRegistry : IPackageRegistry
+{
+    private readonly IGitHubClient _client;
+
+    public GitHubActionsPackageRegistry(IGitHubClientForInstallation client)
+    {
+        _client = client;
+    }
+
+    public DependencyEcosystem Ecosystem => DependencyEcosystem.GitHubActions;
+
+    public async Task<IReadOnlyList<string>> GetPackageOwnersAsync(
+        string owner,
+        string repository,
+        string id,
+        string version)
+    {
+        string[] parts = id.Split('/');
+
+        if (parts.Length == 2)
+        {
+            string actionOwner = parts[0];
+            string actionName = parts[1];
+
+            // GitHub Actions tags that are versions are usually prefixed with
+            // a 'v' but the version extracted from the commit message will just
+            // have the version number. Based on what we find, prefer searching
+            // for a tag prefixed with 'v' before looking for the verbatim tag.
+            bool hasVersionPrefix = version.StartsWith('v');
+
+            string[] refs;
+
+            if (hasVersionPrefix)
+            {
+                refs = new[] { version, version[1..] };
+            }
+            else
+            {
+                refs = new[] { $"v{version}", version };
+            }
+
+            foreach (var reference in refs)
+            {
+                if (await ExistsAsync(() => _client.Git.Reference.Get(actionOwner, actionName, $"tags/{reference}")))
+                {
+                    return new[] { actionOwner };
+                }
+            }
+
+            // If we didn't find the tag(s), maybe it's a sha to a specific commit
+            if (await ExistsAsync(() => _client.Git.Commit.Get(actionOwner, actionName, version)))
+            {
+                return new[] { actionOwner };
+            }
+        }
+
+        return Array.Empty<string>();
+
+        static async Task<bool> ExistsAsync<T>(Func<Task<T>> resource)
+        {
+            try
+            {
+                _ = await resource();
+                return true;
+            }
+            catch (NotFoundException)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/Costellobot/Registries/GitSubmodulePackageRegistry.cs
+++ b/src/Costellobot/Registries/GitSubmodulePackageRegistry.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Octokit;
+
+namespace MartinCostello.Costellobot.Registries;
+
+public sealed class GitSubmodulePackageRegistry : IPackageRegistry
+{
+    private readonly IGitHubClient _client;
+
+    public GitSubmodulePackageRegistry(IGitHubClientForInstallation client)
+    {
+        _client = client;
+    }
+
+    public DependencyEcosystem Ecosystem => DependencyEcosystem.Submodules;
+
+    public async Task<IReadOnlyList<string>> GetPackageOwnersAsync(
+        string owner,
+        string repository,
+        string id,
+        string version)
+    {
+        IReadOnlyList<RepositoryContent> items;
+
+        try
+        {
+            items = await _client.Repository.Content.GetAllContents(owner, repository, id);
+        }
+        catch (NotFoundException)
+        {
+            items = Array.Empty<RepositoryContent>();
+        }
+
+        if (items.Count is 1 &&
+            items[0] is { SubmoduleGitUrl: not null } item)
+        {
+            string url = item.SubmoduleGitUrl;
+            string urlWithoutRepoName = string.Join('/', url.Split('/').SkipLast(1));
+
+            return new[] { urlWithoutRepoName };
+        }
+
+        return Array.Empty<string>();
+    }
+}

--- a/src/Costellobot/Registries/IPackageRegistry.cs
+++ b/src/Costellobot/Registries/IPackageRegistry.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Costellobot.Registries;
+
+public interface IPackageRegistry
+{
+    DependencyEcosystem Ecosystem { get; }
+
+    Task<IReadOnlyList<string>> GetPackageOwnersAsync(
+        string owner,
+        string repository,
+        string id,
+        string version);
+}

--- a/src/Costellobot/Registries/NpmPackageRegistry.cs
+++ b/src/Costellobot/Registries/NpmPackageRegistry.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Net;
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.Costellobot.Registries;
+
+public sealed class NpmPackageRegistry : PackageRegistry
+{
+    private static readonly Uri BaseAddress = new("https://registry.npmjs.org");
+
+    public NpmPackageRegistry(HttpClient client)
+        : base(client)
+    {
+    }
+
+    public override DependencyEcosystem Ecosystem => DependencyEcosystem.Npm;
+
+    public override async Task<IReadOnlyList<string>> GetPackageOwnersAsync(
+        string owner,
+        string repository,
+        string id,
+        string version)
+    {
+        var escapedId = Uri.EscapeDataString(id);
+        var escapedVersion = Uri.EscapeDataString(version);
+
+        // https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#package-metadata
+        var uri = new Uri(BaseAddress, $"{escapedId}/{escapedVersion}");
+
+        Package? package;
+
+        try
+        {
+            package = await Client.GetFromJsonAsync<Package>(uri);
+        }
+        catch (HttpRequestException ex) when (IsNotFound(ex))
+        {
+            package = null;
+        }
+
+        if (package?.User?.Name is { } name &&
+            !string.IsNullOrWhiteSpace(name) &&
+            string.Equals(package.Name, id, StringComparison.Ordinal) &&
+            string.Equals(package.Version, version, StringComparison.Ordinal))
+        {
+            return new[] { name };
+        }
+
+        return Array.Empty<string>();
+
+        static bool IsNotFound(HttpRequestException exception) =>
+            exception.StatusCode switch
+            {
+                HttpStatusCode.NotFound => true,
+                HttpStatusCode.MethodNotAllowed => true, // Returned if version is not x.y.z (e.g. 1.0)
+                _ => false,
+            };
+    }
+
+    private sealed class Package
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("version")]
+        public string Version { get; set; } = string.Empty;
+
+        [JsonPropertyName("_npmUser")]
+        public User? User { get; set; }
+    }
+
+    private sealed class User
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/src/Costellobot/Registries/NuGetPackageRegistry.cs
+++ b/src/Costellobot/Registries/NuGetPackageRegistry.cs
@@ -1,0 +1,171 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace MartinCostello.Costellobot.Registries;
+
+public sealed class NuGetPackageRegistry : PackageRegistry
+{
+    private static readonly Uri ServiceIndexUri = new("https://api.nuget.org/v3/index.json");
+
+    private readonly IMemoryCache _cache;
+
+    public NuGetPackageRegistry(HttpClient client, IMemoryCache cache)
+        : base(client)
+    {
+        _cache = cache;
+    }
+
+    public override DependencyEcosystem Ecosystem => DependencyEcosystem.NuGet;
+
+    public override async Task<IReadOnlyList<string>> GetPackageOwnersAsync(
+        string owner,
+        string repository,
+        string id,
+        string version)
+    {
+        // https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#versioning
+        var baseAddress = await GetBaseAddressAsync("SearchQueryService/3.5.0");
+
+        if (baseAddress is null)
+        {
+            return Array.Empty<string>();
+        }
+
+        // https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#search-for-packages
+        var query = new Dictionary<string, string?>()
+        {
+            ["prerelease"] = "true",
+            ["q"] = $"PackageId:{id}",
+            ["semVerLevel"] = "2.0.0",
+            ["take"] = "1",
+        };
+
+        var uri = QueryHelpers.AddQueryString(baseAddress, query);
+        var response = await Client.GetFromJsonAsync<SearchResponse>(uri);
+
+        if (response is null || response.Data is not { Count: > 0 } data)
+        {
+            return Array.Empty<string>();
+        }
+
+        var package = response.Data
+            .Where((p) => string.Equals(p.Id, id, StringComparison.OrdinalIgnoreCase))
+            .FirstOrDefault();
+
+        if (package is null ||
+            !string.Equals(package.Id, id, StringComparison.OrdinalIgnoreCase))
+        {
+            return Array.Empty<string>();
+        }
+
+        var versionFound = package.Versions
+            .Where((p) => string.Equals(p.Version, version, StringComparison.OrdinalIgnoreCase))
+            .Select((p) => p.Version)
+            .FirstOrDefault(package.Version);
+
+        if (!string.Equals(versionFound, version, StringComparison.OrdinalIgnoreCase))
+        {
+            return Array.Empty<string>();
+        }
+
+        // https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#search-result
+        return package.Owners.ValueKind switch
+        {
+            JsonValueKind.Array => GetPackageOwners(package.Owners),
+            JsonValueKind.String => GetPackageOwner(package.Owners),
+            _ => Array.Empty<string>(),
+        };
+
+        static IReadOnlyList<string> GetPackageOwner(JsonElement owner)
+        {
+            var name = owner.GetString();
+            return new[] { name! };
+        }
+
+        static IReadOnlyList<string> GetPackageOwners(JsonElement owners)
+        {
+            return owners
+                .EnumerateArray()
+                .Select((p) => p.GetString()!)
+                .OrderBy((p) => p)
+                .ToArray();
+        }
+    }
+
+    private async Task<string?> GetBaseAddressAsync(string type)
+    {
+        var index = await GetServiceIndexAsync();
+
+        var resource = index?.Resources?
+            .Where((p) => string.Equals(p.Type, type, StringComparison.Ordinal))
+            .FirstOrDefault();
+
+        string? baseAddress = null;
+
+        if (resource is not null && Uri.TryCreate(resource.Id, UriKind.Absolute, out var uri))
+        {
+            baseAddress = uri.ToString();
+        }
+
+        return baseAddress;
+    }
+
+    private async Task<ServiceIndex?> GetServiceIndexAsync()
+    {
+        return await _cache.GetOrCreateAsync("nuget-service-index", async (entry) =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1);
+            return await Client.GetFromJsonAsync<ServiceIndex>(ServiceIndexUri);
+        });
+    }
+
+    private sealed class PackageVersion
+    {
+        [JsonPropertyName("version")]
+        public string Version { get; set; } = string.Empty;
+    }
+
+    private sealed class Resource
+    {
+        [JsonPropertyName("@id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("@type")]
+        public string Type { get; set; } = string.Empty;
+    }
+
+    private sealed class SearchResponse
+    {
+        [JsonPropertyName("data")]
+        public IList<SearchResult> Data { get; set; } = new List<SearchResult>();
+    }
+
+    private sealed class SearchResult
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("owners")]
+        public JsonElement Owners { get; set; }
+
+        [JsonPropertyName("version")]
+        public string Version { get; set; } = string.Empty;
+
+        [JsonPropertyName("versions")]
+        public IList<PackageVersion> Versions { get; set; } = new List<PackageVersion>();
+    }
+
+    private sealed class ServiceIndex
+    {
+        [JsonPropertyName("version")]
+        public string Version { get; set; } = string.Empty;
+
+        [JsonPropertyName("resources")]
+        public IList<Resource> Resources { get; set; } = new List<Resource>();
+    }
+}

--- a/src/Costellobot/Registries/PackageRegistry.cs
+++ b/src/Costellobot/Registries/PackageRegistry.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Costellobot.Registries;
+
+public abstract class PackageRegistry : IPackageRegistry
+{
+    protected PackageRegistry(HttpClient client)
+    {
+        Client = client;
+    }
+
+    public abstract DependencyEcosystem Ecosystem { get; }
+
+    protected HttpClient Client { get; }
+
+    public abstract Task<IReadOnlyList<string>> GetPackageOwnersAsync(
+        string owner,
+        string repository,
+        string id,
+        string version);
+}

--- a/src/Costellobot/TrustedEntitiesOptions.cs
+++ b/src/Costellobot/TrustedEntitiesOptions.cs
@@ -7,5 +7,7 @@ public sealed class TrustedEntitiesOptions
 {
     public IList<string> Dependencies { get; set; } = new List<string>();
 
+    public IDictionary<DependencyEcosystem, IList<string>> Publishers { get; set; } = new Dictionary<DependencyEcosystem, IList<string>>();
+
     public IList<string> Users { get; set; } = new List<string>();
 }

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -47,40 +47,43 @@
       "Dependencies": [
         "^@actions\/.*$",
         "^@microsoft\/signalr$",
-        "^@octokit\/types$",
-        "^@types\/.*$",
-        "^actions\/.*$",
-        "^Amazon.Lambda\\..*$",
         "^AspNet.Security.OAuth\\..*$",
-        "^AWSSDK\\..*$",
-        "^Azure.Extensions\\..*$",
-        "^Azure.Identity$",
         "^BenchmarkDotNet$",
-        "^JustEat.HttpClientInterception$",
-        "^MartinCostello\\..*$",
-        "^martincostello\/update-dotnet-sdk$",
-        "^Microsoft.ApplicationInsights\\..*$",
         "^Microsoft.AspNetCore\\..*$",
-        "^Microsoft.Azure\\..*$",
         "^Microsoft.EntityFrameworkCore\\..*$",
         "^Microsoft.Extensions\\..*$",
-        "^Microsoft.IdentityModel\\..*$",
         "^Microsoft.NET.Sdk$",
-        "^Microsoft.NET.Test.Sdk$",
-        "^Microsoft.Playwright$",
-        "^Microsoft.SourceLink.GitHub$",
-        "^Microsoft.TypeScript.MSBuild$",
-        "^Newtonsoft.Json$",
-        "^Octokit$",
-        "^Octokit.GraphQL$",
-        "^Octokit.Webhooks.AspNetCore$",
         "^NodaTime$",
-        "^NodaTime.Testing$",
-        "^System.Text.Json$",
-        "^typescript$",
-        "^xunit$",
-        "^xunit.runner.visualstudio$"
+        "^NodaTime.Testing$"
       ],
+      "Publishers": {
+        "GitHubActions": [
+          "actions",
+          "martincostello"
+        ],
+        "Npm": [
+          "microsoft1es",
+          "octokitbot",
+          "types",
+          "typescript-bot"
+        ],
+        "NuGet": [
+          "aspnet",
+          "awsdotnet",
+          "azure-sdk",
+          "dotnetfoundation",
+          "dotnetframework",
+          "EntityFramework",
+          "GitHub",
+          "JUSTEAT_OSS",
+          "martin_costello",
+          "Microsoft",
+          "NodaTime"
+        ],
+        "Submodules": [
+          "https://github.com/martincostello"
+        ]
+      },
       "Users": [
         "costellobot",
         "costellobot[bot]",

--- a/tests/Costellobot.Tests/Builders/CompareResultBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/CompareResultBuilder.cs
@@ -7,11 +7,20 @@ public sealed class CompareResultBuilder : ResponseBuilder
 {
     public IList<GitHubCommitBuilder> Commits { get; set; } = new List<GitHubCommitBuilder>();
 
+    public string Status { get; set; } = "ahead";
+
+    public int AheadBy { get; set; } = 1;
+
+    public int BehindBy { get; set; }
+
     public override object Build()
     {
         return new
         {
             commits = Commits.Build(),
+            status = Status,
+            ahead_by = AheadBy,
+            behind_by = BehindBy,
         };
     }
 }

--- a/tests/Costellobot.Tests/Builders/GitHubFixtures.cs
+++ b/tests/Costellobot.Tests/Builders/GitHubFixtures.cs
@@ -66,6 +66,9 @@ public static class GitHubFixtures
         return builder;
     }
 
+    public static DeploymentBuilder CreateDeployment(GitHubCommitBuilder commit)
+        => CreateDeployment(sha: commit.Sha);
+
     public static DeploymentBuilder CreateDeployment(
         string? environment = null,
         string? sha = null)

--- a/tests/Costellobot.Tests/Builders/GitHubFixtures.cs
+++ b/tests/Costellobot.Tests/Builders/GitHubFixtures.cs
@@ -14,6 +14,8 @@ public static class GitHubFixtures
 
     public const string DependabotBotName = "app/dependabot";
 
+    public const string DependabotCommitter = "dependabot[bot]";
+
     public const string GitHubActionsBotName = "app/github-actions";
 
     public const string InstallationId = "42";
@@ -133,6 +135,9 @@ public static class GitHubFixtures
         return builder;
     }
 
+    public static UserBuilder CreateUserForDependabot()
+        => CreateUser(DependabotCommitter);
+
     public static UserBuilder CreateUser(
         string? login = null,
         int? id = null,
@@ -191,9 +196,9 @@ updated-dependencies:
 
 Signed-off-by: dependabot[bot] <support@github.com>";
 
-    public static string TrustedCommitMessage(string dependency) => $@"
-Bump {dependency} from 5.0.0 to 5.0.1
-Bumps [{dependency}](https://github.com/actions/toolkit/tree/HEAD/packages/github) from 5.0.0 to 5.0.1.
+    public static string TrustedCommitMessage(string dependency, string version = "5.0.1") => $@"
+Bump {dependency} from 5.0.0 to {version}
+Bumps [{dependency}](https://github.com/actions/toolkit/tree/HEAD/packages/github) from 5.0.0 to {version}.
 - [Release notes](https://github.com/actions/toolkit/releases)
 - [Changelog](https://github.com/actions/toolkit/blob/main/packages/github/RELEASES.md)
 - [Commits](https://github.com/actions/toolkit/commits/HEAD/packages/github)

--- a/tests/Costellobot.Tests/Builders/GitHubFixtures.cs
+++ b/tests/Costellobot.Tests/Builders/GitHubFixtures.cs
@@ -21,6 +21,7 @@ public static class GitHubFixtures
     public const string InstallationId = "42";
 
     public static CheckRunBuilder CreateCheckRun(
+        PullRequestBuilder pullRequest,
         string name,
         string status,
         string? conclusion = null,
@@ -35,6 +36,8 @@ public static class GitHubFixtures
         {
             builder.ApplicationName = applicationName;
         }
+
+        builder.PullRequests.Add(pullRequest);
 
         return builder;
     }

--- a/tests/Costellobot.Tests/Builders/PullRequestBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/PullRequestBuilder.cs
@@ -23,6 +23,10 @@ public sealed class PullRequestBuilder : ResponseBuilder
 
     public RepositoryBuilder Repository { get; set; }
 
+    public string RefBase { get; set; } = "main";
+
+    public string RefHead { get; set; } = "dependabot/nuget/Foo-1.2.3";
+
     public string ShaBase { get; set; } = RandomString();
 
     public string ShaHead { get; set; } = RandomString();
@@ -41,13 +45,14 @@ public sealed class PullRequestBuilder : ResponseBuilder
             author_association = AuthorAssociation,
             @base = new
             {
-                @ref = "main",
+                @ref = RefBase,
                 sha = ShaBase,
                 repo = Repository.Build(),
             },
             draft = IsDraft,
             head = new
             {
+                @ref = RefHead,
                 sha = ShaHead,
             },
             html_url = $"https://github.com/{Repository.Owner.Login}/{Repository.Name}/pull/{Number}",

--- a/tests/Costellobot.Tests/Bundles/github-refs.json
+++ b/tests/Costellobot.Tests/Bundles/github-refs.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/main/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "id": "github-refs",
+  "version": 1,
+  "comment": "HTTP bundle for GitHub references.",
+  "items": [
+    {
+      "comment": "actions/checkout ref for tag v3",
+      "uri": "https://api.github.com/repos/actions/checkout/git/refs/tags/v3",
+      "method": "GET",
+      "contentFormat": "json",
+      "contentJson": {
+        "ref": "refs/tags/v3",
+        "node_id": "MDM6UmVmMTk3ODE0NjI5OnJlZnMvdGFncy92Mw==",
+        "url": "https://api.github.com/repos/actions/checkout/git/refs/tags/v3",
+        "object": {
+          "sha": "d0651293c4a5a52e711f25b41b05b2212f385d28",
+          "type": "tag",
+          "url": "https://api.github.com/repos/actions/checkout/git/tags/d0651293c4a5a52e711f25b41b05b2212f385d28"
+        }
+      }
+    },
+    {
+      "comment": "actions/checkout ref for tag 3",
+      "uri": "https://api.github.com/repos/actions/checkout/git/refs/tags/3",
+      "method": "GET",
+      "status": "404",
+      "contentFormat": "json",
+      "contentJson": {
+        "message": "Not Found",
+        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+      }
+    },
+    {
+      "comment": "actions/checkout ref for tag 2541b1294d2704b0964813337f33b291d3f8596b",
+      "uri": "https://api.github.com/repos/actions/checkout/git/refs/tags/2541b1294d2704b0964813337f33b291d3f8596b",
+      "method": "GET",
+      "status": "404",
+      "contentFormat": "json",
+      "contentJson": {
+        "message": "Not Found",
+        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+      }
+    },
+    {
+      "comment": "actions/checkout ref for tag v2541b1294d2704b0964813337f33b291d3f8596b",
+      "uri": "https://api.github.com/repos/actions/checkout/git/refs/tags/v2541b1294d2704b0964813337f33b291d3f8596b",
+      "method": "GET",
+      "status": "404",
+      "contentFormat": "json",
+      "contentJson": {
+        "message": "Not Found",
+        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+      }
+    },
+    {
+      "comment": "foo/bar ref for tag v1",
+      "uri": "https://api.github.com/repos/foo/bar/git/refs/tags/v1",
+      "method": "GET",
+      "status": "404",
+      "contentFormat": "json",
+      "contentJson": {
+        "message": "Not Found",
+        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+      }
+    },
+    {
+      "comment": "foo/bar ref for tag 1",
+      "uri": "https://api.github.com/repos/foo/bar/git/refs/tags/1",
+      "method": "GET",
+      "status": "404",
+      "contentFormat": "json",
+      "contentJson": {
+        "message": "Not Found",
+        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+      }
+    },
+    {
+      "comment": "foo/bar ref for commit v1",
+      "uri": "https://api.github.com/repos/foo/bar/git/commits/v1",
+      "method": "GET",
+      "status": "404",
+      "contentFormat": "json",
+      "contentJson": {
+        "message": "Not Found",
+        "documentation_url": "https://docs.github.com/rest/reference/git#get-a-reference"
+      }
+    },
+    {
+      "comment": "actions/checkout commit for 2541b1294d2704b0964813337f33b291d3f8596b",
+      "uri": "https://api.github.com/repos/actions/checkout/git/commits/2541b1294d2704b0964813337f33b291d3f8596b",
+      "method": "GET",
+      "contentFormat": "json",
+      "contentJson": {
+        "sha": "2541b1294d2704b0964813337f33b291d3f8596b",
+        "node_id": "C_kwDOC8ppZdoAKDI1NDFiMTI5NGQyNzA0YjA5NjQ4MTMzMzdmMzNiMjkxZDNmODU5NmI",
+        "url": "https://api.github.com/repos/actions/checkout/git/commits/2541b1294d2704b0964813337f33b291d3f8596b",
+        "html_url": "https://github.com/actions/checkout/commit/2541b1294d2704b0964813337f33b291d3f8596b",
+        "author": {
+          "name": "Tingluo Huang",
+          "email": "tingluohuang@github.com",
+          "date": "2022-04-21T14:29:04Z"
+        },
+        "committer": {
+          "name": "GitHub",
+          "email": "noreply@github.com",
+          "date": "2022-04-21T14:29:04Z"
+        },
+        "tree": {
+          "sha": "6d353f968fc9fef16beee1b8720266ca4c177006",
+          "url": "https://api.github.com/repos/actions/checkout/git/trees/6d353f968fc9fef16beee1b8720266ca4c177006"
+        },
+        "message": "Prepare changelog for v3.0.2. (#777)",
+        "parents": [
+          {
+            "sha": "0ffe6f9c5599e73776da5b7f113e994bc0a76ede",
+            "url": "https://api.github.com/repos/actions/checkout/git/commits/0ffe6f9c5599e73776da5b7f113e994bc0a76ede",
+            "html_url": "https://github.com/actions/checkout/commit/0ffe6f9c5599e73776da5b7f113e994bc0a76ede"
+          }
+        ],
+        "verification": {
+          "verified": true,
+          "reason": "valid",
+          "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsBcBAABCAAQBQJiYWowCRBK7hj4Ov3rIwAAgQwIAJTPPEYL2EKQp4zQ+QAHTVqF\nFjHh7B2v0nZ35z3hFo6CYthO16oKGRJTTKnAajsD3nXk+B7p9ufpdLvXDBbjUE9V\nS0/wKFGht8YV9KLud6KfdhGeZM9flhhCtC4rbJLsSpxQBgm2fag13OHSkzJ1zwIE\nUYEwDZnvMwh85L2CL0qTqnvAw9WcJJftyaCC4qg3HjBzLnxGwYi0bzdPPyXy0tm0\nIVMcxXWARICuNeoS6QTmyp/ZV2dupHdf2agEnn8hSQ+2P0APE3DM+db1zz3k6bEu\noz2XdwH0MleSMHpFhkkTpqXTh8j26lJdSjKaAPe2JnTBCSZ7n/PfZ+YcN3lADN0=\n=5dU9\n-----END PGP SIGNATURE-----\n",
+          "payload": "tree 6d353f968fc9fef16beee1b8720266ca4c177006\nparent 0ffe6f9c5599e73776da5b7f113e994bc0a76ede\nauthor Tingluo Huang <tingluohuang@github.com> 1650551344 -0400\ncommitter GitHub <noreply@github.com> 1650551344 -0400\n\nPrepare changelog for v3.0.2. (#777)\n\n"
+        }
+      }
+    }
+  ]
+}

--- a/tests/Costellobot.Tests/Bundles/github-submodules.json
+++ b/tests/Costellobot.Tests/Bundles/github-submodules.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/main/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "id": "github-submodules",
+  "version": 1,
+  "comment": "HTTP bundle for GitHub submodule content.",
+  "items": [
+    {
+      "comment": "dotnet/aspnetcore content for src/submodules/foo",
+      "uri": "https://api.github.com/repos/dotnet/aspnetcore/contents/src/submodules/foo",
+      "contentFormat": "json",
+      "contentJson": {
+        "message": "Not Found",
+        "documentation_url": "https://docs.github.com/rest/reference/repos#get-repository-content"
+      }
+    },
+    {
+      "comment": "dotnet/aspnetcore content for src/submodules/googletest",
+      "uri": "https://api.github.com/repos/dotnet/aspnetcore/contents/src/submodules/googletest",
+      "contentFormat": "json",
+      "contentJson": {
+        "name": "googletest",
+        "path": "src/submodules/googletest",
+        "sha": "7735334a46da480a749945c0f645155d90d73855",
+        "size": 0,
+        "url": "https://api.github.com/repos/dotnet/aspnetcore/contents/src/submodules/googletest?ref=main",
+        "html_url": "https://github.com/google/googletest/tree/7735334a46da480a749945c0f645155d90d73855",
+        "git_url": "https://api.github.com/repos/google/googletest/git/trees/7735334a46da480a749945c0f645155d90d73855",
+        "download_url": null,
+        "type": "submodule",
+        "submodule_git_url": "https://github.com/google/googletest",
+        "_links": {
+          "self": "https://api.github.com/repos/dotnet/aspnetcore/contents/src/submodules/googletest?ref=main",
+          "git": "https://api.github.com/repos/google/googletest/git/trees/7735334a46da480a749945c0f645155d90d73855",
+          "html": "https://github.com/google/googletest/tree/7735334a46da480a749945c0f645155d90d73855"
+        }
+      }
+    }
+  ]
+}

--- a/tests/Costellobot.Tests/Bundles/npm-registry.json
+++ b/tests/Costellobot.Tests/Bundles/npm-registry.json
@@ -1,0 +1,479 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/main/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "id": "npm-registry",
+  "version": 1,
+  "comment": "HTTP bundle for npm packages.",
+  "items": [
+    {
+      "comment": "The package for typescript v4.6.3",
+      "uri": "https://registry.npmjs.org/typescript/4.6.3",
+      "method": "GET",
+      "contentFormat": "json",
+      "contentJson": {
+        "name": "typescript",
+        "author": "Microsoft Corp.",
+        "homepage": "https://www.typescriptlang.org/",
+        "version": "4.6.3",
+        "license": "Apache-2.0",
+        "description": "TypeScript is a language for application scale JavaScript development",
+        "keywords": [ "TypeScript", "Microsoft", "compiler", "language", "javascript" ],
+        "bugs": { "url": "https://github.com/Microsoft/TypeScript/issues" },
+        "repository": {
+          "type": "git",
+          "url": "https://github.com/Microsoft/TypeScript.git"
+        },
+        "main": "./lib/typescript.js",
+        "typings": "./lib/typescript.d.ts",
+        "bin": {
+          "tsc": "bin/tsc",
+          "tsserver": "bin/tsserver"
+        },
+        "engines": { "node": ">=4.2.0" },
+        "packageManager": "npm@6.14.15",
+        "devDependencies": {
+          "@octokit/rest": "latest",
+          "@types/browserify": "latest",
+          "@types/chai": "latest",
+          "@types/convert-source-map": "latest",
+          "@types/glob": "latest",
+          "@types/gulp": "^4.0.9",
+          "@types/gulp-concat": "latest",
+          "@types/gulp-newer": "latest",
+          "@types/gulp-rename": "0.0.33",
+          "@types/gulp-sourcemaps": "0.0.32",
+          "@types/jake": "latest",
+          "@types/merge2": "latest",
+          "@types/microsoft__typescript-etw": "latest",
+          "@types/minimatch": "latest",
+          "@types/minimist": "latest",
+          "@types/mkdirp": "latest",
+          "@types/mocha": "latest",
+          "@types/ms": "latest",
+          "@types/node": "latest",
+          "@types/node-fetch": "^2.3.4",
+          "@types/q": "latest",
+          "@types/source-map-support": "latest",
+          "@types/through2": "latest",
+          "@types/xml2js": "^0.4.0",
+          "@typescript-eslint/eslint-plugin": "^4.28.0",
+          "@typescript-eslint/experimental-utils": "^4.28.0",
+          "@typescript-eslint/parser": "^4.28.0",
+          "async": "latest",
+          "azure-devops-node-api": "^11.0.1",
+          "browser-resolve": "^1.11.2",
+          "browserify": "latest",
+          "chai": "latest",
+          "chalk": "^4.1.2",
+          "convert-source-map": "latest",
+          "del": "5.1.0",
+          "diff": "^4.0.2",
+          "eslint": "7.12.1",
+          "eslint-formatter-autolinkable-stylish": "1.1.4",
+          "eslint-plugin-import": "2.22.1",
+          "eslint-plugin-jsdoc": "30.7.6",
+          "eslint-plugin-no-null": "1.0.2",
+          "fancy-log": "latest",
+          "fs-extra": "^9.0.0",
+          "glob": "latest",
+          "gulp": "^4.0.0",
+          "gulp-concat": "latest",
+          "gulp-insert": "latest",
+          "gulp-newer": "latest",
+          "gulp-rename": "latest",
+          "gulp-sourcemaps": "latest",
+          "merge2": "latest",
+          "minimist": "latest",
+          "mkdirp": "latest",
+          "mocha": "latest",
+          "mocha-fivemat-progress-reporter": "latest",
+          "ms": "^2.1.3",
+          "node-fetch": "^2.6.1",
+          "plugin-error": "latest",
+          "pretty-hrtime": "^1.0.3",
+          "prex": "^0.4.3",
+          "q": "latest",
+          "source-map-support": "latest",
+          "through2": "latest",
+          "typescript": "^4.5.5",
+          "vinyl": "latest",
+          "vinyl-sourcemaps-apply": "latest",
+          "xml2js": "^0.4.19"
+        },
+        "scripts": {
+          "prepare": "gulp build-eslint-rules",
+          "pretest": "gulp tests",
+          "test": "gulp runtests-parallel --light=false",
+          "test:eslint-rules": "gulp run-eslint-rules-tests",
+          "build": "npm run build:compiler && npm run build:tests",
+          "build:compiler": "gulp local",
+          "build:tests": "gulp tests",
+          "start": "node lib/tsc",
+          "clean": "gulp clean",
+          "gulp": "gulp",
+          "jake": "gulp",
+          "lint": "gulp lint",
+          "lint:ci": "gulp lint --ci",
+          "lint:compiler": "gulp lint-compiler",
+          "lint:scripts": "gulp lint-scripts",
+          "setup-hooks": "node scripts/link-hooks.js"
+        },
+        "browser": {
+          "fs": false,
+          "os": false,
+          "path": false,
+          "crypto": false,
+          "buffer": false,
+          "@microsoft/typescript-etw": false,
+          "source-map-support": false,
+          "inspector": false
+        },
+        "volta": { "node": "14.15.5" },
+        "_id": "typescript@4.6.3",
+        "_integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+        "_resolved": "/home/vsts/work/r1/a/typescript.tgz",
+        "_from": "file:/home/vsts/work/r1/a/typescript.tgz",
+        "_nodeVersion": "16.14.0",
+        "_npmVersion": "8.3.1",
+        "dist": {
+          "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+          "shasum": "eefeafa6afdd31d725584c67a0eaba80f6fc6c6c",
+          "tarball": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+          "fileCount": 183,
+          "unpackedSize": 64715549,
+          "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v4.10.10\r\nComment: https://openpgpjs.org\r\n\r\nwsFzBAEBCAAGBQJiPPEQACEJED1NWxICdlZqFiEECWMYAoorWMhJKdjhPU1b\r\nEgJ2Vmq/Vg//V+dYtlW+QD3lT2MEt7HY0RX7xqKed6fdoCo0JPy9TLpASHWl\r\nuUkMLq/TWRmhwfFjrQCQ1DxuI1Ec5oArzjk3BapsRzpY2kqSgu5WACwnNcA1\r\nar65jnlbslf2KwYTWkl4y0TEoA1kSYLdFkn+DAZXp2FO9x10aqDs8F5PDpKe\r\no6Pf/2TN0buvzFskYkharLfNBL4JR2X3RK/oNcNzdmYHjJinL2g2hQPOURQl\r\nSF20n8Mt5ajcpuo1Nc0TNZ4Ca25lioBHIc+mCTSmgqoTU1AEynCuwhuFGYOs\r\nnr6Eshx+jeaQmmDPzu/vA39D/QXBXR7xv5iNr6V8ci5CzclN1IqPZQjGeOxX\r\nIQa+pPG5oceT1JSWl6MOwkYObKT3zCXiy2GcmjW+gKjxa0Je6pCvQSrC5M77\r\nKAUFQSJYmptXafkLqf5oyGseVv4s+VQUV4n75Kj02gvE08iR9uBbo+cZMyaU\r\nWGAYpds5YtZxs+ocGFWmS+ZYVpmfCYOXx/f7BKm6zcUTlD3wascCx3yvptoU\r\nsshrVVESGsYt/Zw4g6iDKVl7GzWaOT8dsUmyuIxZXUKH3vbDHi4e6E60jWXZ\r\nexb6900qpceMt58DfhXYLgzz2LspTi8EEbqQItqfL3kbqz2EeqPAEnXYQmt6\r\n+XgxowuXVVdsWUWXUOLb4ITknZqPyONdcp4=\r\n=RGTD\r\n-----END PGP SIGNATURE-----\r\n",
+          "signatures": [
+            {
+              "keyid": "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
+              "sig": "MEYCIQC2nE+S21l9av4qUReQA6d4U7kRpn26FPohwhMwe+DlbwIhAOxpIvPQVfKj0R7j158f5hLdYchFfQYDAI13AMGWZcn/"
+            }
+          ]
+        },
+        "_npmUser": {
+          "name": "typescript-bot",
+          "email": "typescript@microsoft.com"
+        },
+        "directories": {},
+        "maintainers": [
+          {
+            "name": "typescript-bot",
+            "email": "typescript@microsoft.com"
+          },
+          {
+            "name": "weswigham",
+            "email": "wwigham@gmail.com"
+          },
+          {
+            "name": "sanders_n",
+            "email": "ncsander@indiana.edu"
+          },
+          {
+            "name": "andrewbranch",
+            "email": "andrew@wheream.io"
+          },
+          {
+            "name": "minestarks",
+            "email": "mineyalc@microsoft.com"
+          },
+          {
+            "name": "rbuckton",
+            "email": "rbuckton@chronicles.org"
+          },
+          {
+            "name": "sheetalkamat",
+            "email": "shkamat@microsoft.com"
+          },
+          {
+            "name": "typescript-deploys",
+            "email": "typescript-design@microsoft.com"
+          }
+        ],
+        "_npmOperationalInternal": {
+          "host": "s3://npm-registry-packages",
+          "tmp": "tmp/typescript_4.6.3_1648161039993_0.36016311652567445"
+        },
+        "_hasShrinkwrap": false
+      }
+    },
+    {
+      "comment": "The package for @types/node v18.6.2",
+      "uri": "https://registry.npmjs.org/%40types%2Fnode/18.6.2",
+      "method": "GET",
+      "contentFormat": "json",
+      "contentJson": {
+        "name": "@types/node",
+        "version": "18.6.2",
+        "description": "TypeScript definitions for Node.js",
+        "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node",
+        "license": "MIT",
+        "contributors": [
+          {
+            "name": "Microsoft TypeScript",
+            "url": "https://github.com/Microsoft",
+            "githubUsername": "Microsoft"
+          },
+          {
+            "name": "DefinitelyTyped",
+            "url": "https://github.com/DefinitelyTyped",
+            "githubUsername": "DefinitelyTyped"
+          },
+          {
+            "name": "Alberto Schiabel",
+            "url": "https://github.com/jkomyno",
+            "githubUsername": "jkomyno"
+          },
+          {
+            "name": "Alvis HT Tang",
+            "url": "https://github.com/alvis",
+            "githubUsername": "alvis"
+          },
+          {
+            "name": "Andrew Makarov",
+            "url": "https://github.com/r3nya",
+            "githubUsername": "r3nya"
+          },
+          {
+            "name": "Benjamin Toueg",
+            "url": "https://github.com/btoueg",
+            "githubUsername": "btoueg"
+          },
+          {
+            "name": "Chigozirim C.",
+            "url": "https://github.com/smac89",
+            "githubUsername": "smac89"
+          },
+          {
+            "name": "David Junger",
+            "url": "https://github.com/touffy",
+            "githubUsername": "touffy"
+          },
+          {
+            "name": "Deividas Bakanas",
+            "url": "https://github.com/DeividasBakanas",
+            "githubUsername": "DeividasBakanas"
+          },
+          {
+            "name": "Eugene Y. Q. Shen",
+            "url": "https://github.com/eyqs",
+            "githubUsername": "eyqs"
+          },
+          {
+            "name": "Hannes Magnusson",
+            "url": "https://github.com/Hannes-Magnusson-CK",
+            "githubUsername": "Hannes-Magnusson-CK"
+          },
+          {
+            "name": "Huw",
+            "url": "https://github.com/hoo29",
+            "githubUsername": "hoo29"
+          },
+          {
+            "name": "Kelvin Jin",
+            "url": "https://github.com/kjin",
+            "githubUsername": "kjin"
+          },
+          {
+            "name": "Klaus Meinhardt",
+            "url": "https://github.com/ajafff",
+            "githubUsername": "ajafff"
+          },
+          {
+            "name": "Lishude",
+            "url": "https://github.com/islishude",
+            "githubUsername": "islishude"
+          },
+          {
+            "name": "Mariusz Wiktorczyk",
+            "url": "https://github.com/mwiktorczyk",
+            "githubUsername": "mwiktorczyk"
+          },
+          {
+            "name": "Mohsen Azimi",
+            "url": "https://github.com/mohsen1",
+            "githubUsername": "mohsen1"
+          },
+          {
+            "name": "Nicolas Even",
+            "url": "https://github.com/n-e",
+            "githubUsername": "n-e"
+          },
+          {
+            "name": "Nikita Galkin",
+            "url": "https://github.com/galkin",
+            "githubUsername": "galkin"
+          },
+          {
+            "name": "Parambir Singh",
+            "url": "https://github.com/parambirs",
+            "githubUsername": "parambirs"
+          },
+          {
+            "name": "Sebastian Silbermann",
+            "url": "https://github.com/eps1lon",
+            "githubUsername": "eps1lon"
+          },
+          {
+            "name": "Simon Schick",
+            "url": "https://github.com/SimonSchick",
+            "githubUsername": "SimonSchick"
+          },
+          {
+            "name": "Thomas den Hollander",
+            "url": "https://github.com/ThomasdenH",
+            "githubUsername": "ThomasdenH"
+          },
+          {
+            "name": "Wilco Bakker",
+            "url": "https://github.com/WilcoBakker",
+            "githubUsername": "WilcoBakker"
+          },
+          {
+            "name": "wwwy3y3",
+            "url": "https://github.com/wwwy3y3",
+            "githubUsername": "wwwy3y3"
+          },
+          {
+            "name": "Samuel Ainsworth",
+            "url": "https://github.com/samuela",
+            "githubUsername": "samuela"
+          },
+          {
+            "name": "Kyle Uehlein",
+            "url": "https://github.com/kuehlein",
+            "githubUsername": "kuehlein"
+          },
+          {
+            "name": "Thanik Bhongbhibhat",
+            "url": "https://github.com/bhongy",
+            "githubUsername": "bhongy"
+          },
+          {
+            "name": "Marcin Kopacz",
+            "url": "https://github.com/chyzwar",
+            "githubUsername": "chyzwar"
+          },
+          {
+            "name": "Trivikram Kamat",
+            "url": "https://github.com/trivikr",
+            "githubUsername": "trivikr"
+          },
+          {
+            "name": "Junxiao Shi",
+            "url": "https://github.com/yoursunny",
+            "githubUsername": "yoursunny"
+          },
+          {
+            "name": "Ilia Baryshnikov",
+            "url": "https://github.com/qwelias",
+            "githubUsername": "qwelias"
+          },
+          {
+            "name": "ExE Boss",
+            "url": "https://github.com/ExE-Boss",
+            "githubUsername": "ExE-Boss"
+          },
+          {
+            "name": "Piotr Błażejewicz",
+            "url": "https://github.com/peterblazejewicz",
+            "githubUsername": "peterblazejewicz"
+          },
+          {
+            "name": "Anna Henningsen",
+            "url": "https://github.com/addaleax",
+            "githubUsername": "addaleax"
+          },
+          {
+            "name": "Victor Perin",
+            "url": "https://github.com/victorperin",
+            "githubUsername": "victorperin"
+          },
+          {
+            "name": "Yongsheng Zhang",
+            "url": "https://github.com/ZYSzys",
+            "githubUsername": "ZYSzys"
+          },
+          {
+            "name": "NodeJS Contributors",
+            "url": "https://github.com/NodeJS",
+            "githubUsername": "NodeJS"
+          },
+          {
+            "name": "Linus Unnebäck",
+            "url": "https://github.com/LinusU",
+            "githubUsername": "LinusU"
+          },
+          {
+            "name": "wafuwafu13",
+            "url": "https://github.com/wafuwafu13",
+            "githubUsername": "wafuwafu13"
+          },
+          {
+            "name": "Matteo Collina",
+            "url": "https://github.com/mcollina",
+            "githubUsername": "mcollina"
+          }
+        ],
+        "main": "",
+        "types": "index.d.ts",
+        "repository": {
+          "type": "git",
+          "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+          "directory": "types/node"
+        },
+        "scripts": {},
+        "dependencies": {},
+        "typesPublisherContentHash": "a7df569b45848b5af802c513c0bac5e342b40f2297a1492597939b74c0033e42",
+        "typeScriptVersion": "4.0",
+        "_id": "@types/node@18.6.2",
+        "dist": {
+          "integrity": "sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ==",
+          "shasum": "ffc5f0f099d27887c8d9067b54e55090fcd54126",
+          "tarball": "https://registry.npmjs.org/@types/node/-/node-18.6.2.tgz",
+          "fileCount": 61,
+          "unpackedSize": 1732637,
+          "signatures": [
+            {
+              "keyid": "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
+              "sig": "MEUCIQD9MoLB9GR4hzQgjJRGWZtnLqBm5ZcCWksCCLSXIpOdJAIgG2wByPTVhyCOAqxxLCQggUvphvI55fkxeugRAinMavU="
+            }
+          ],
+          "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v4.10.10\r\nComment: https://openpgpjs.org\r\n\r\nwsFzBAEBCAAGBQJi4fVBACEJED1NWxICdlZqFiEECWMYAoorWMhJKdjhPU1b\r\nEgJ2VmpA5Q/+LXEL8sCUEP0q/hG1pkGlib7WymBd/S1aDXmwEynof9ZsGKVb\r\nSyWe7s4oE7YnFA4shzfjVclb1CIm6gqsn40FU9JzImPT8t9Hj6yQijpRXjY8\r\nSQ2hd0VbKk+Fs5X5+zG3fB1Rw67OikKOF8EUfJWAM94BmEMGuDrMSbz44y/5\r\nvGdISoRdqDHSROPwLbVqeZ3AjUvU+2GrIS386w1zhfxv0EQWtRUZD/MjrH6B\r\nDeHwo1HqpIGsI9DU4T2YBPnrapLe40/0+aIG+rO2ZdRGi5dHai/wiuRBfuap\r\nb/uP5LFE5tJH7IMdXTax84JbN0X081mUBFkgosPeSHOR4zaaw0sFE0sadUE8\r\nGv5oSDta0/Tr3VkyfVa3GvL8RMRXmhKNRBYDiav8e+l9+Ez1KRwQoERosSzW\r\no2U51i2YjcuPmn+N/8akbYvPXyXj4treaCkxibr42+u/w7dDHtOsBX/0wJ8B\r\nJ76y4fZaaJQiRue9cY8jX7Y1DV6706aR9kNWINYy2pwooHGBTrkc9oAUi7YU\r\nE5g4aiOadXpQpAqfR26SVFFbWzG23l94VGSycveUC9v1sCQnDGkzRqtI0Fdn\r\nIcI2UsdOGTh03CR7FRPp4ezVjAtY9dkyVUUOoWsLCZ/B4HIxs2CDmPk4BGAb\r\nQoiW1FGs3/m5GjuF7rt50npLeu04MgrYqvA=\r\n=WiW+\r\n-----END PGP SIGNATURE-----\r\n"
+        },
+        "_npmUser": {
+          "name": "types",
+          "email": "ts-npm-types@microsoft.com"
+        },
+        "directories": {},
+        "maintainers": [
+          {
+            "name": "types",
+            "email": "ts-npm-types@microsoft.com"
+          }
+        ],
+        "_npmOperationalInternal": {
+          "host": "s3://npm-registry-packages",
+          "tmp": "tmp/node_18.6.2_1658975553745_0.44494289227152306"
+        },
+        "_hasShrinkwrap": false
+      }
+    },
+    {
+      "comment": "A package that does not exist",
+      "uri": "https://registry.npmjs.org/foo/0.0.0",
+      "method": "GET",
+      "status": "404",
+      "contentFormat": "string",
+      "contentString": "version not found: 10.0.0"
+    },
+    {
+      "comment": "A package with an invalid version number",
+      "uri": "https://registry.npmjs.org/foo/0.0",
+      "method": "GET",
+      "status": "405",
+      "contentFormat": "json",
+      "contentJson": {
+        "code": "MethodNotAllowedError",
+        "message": "GET is not allowed"
+      }
+    }
+  ]
+}

--- a/tests/Costellobot.Tests/Bundles/nuget-search.json
+++ b/tests/Costellobot.Tests/Bundles/nuget-search.json
@@ -1,0 +1,430 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/main/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "id": "nuget-search",
+  "version": 1,
+  "comment": "HTTP bundle for NuGet package search.",
+  "items": [
+    {
+      "comment": "NuGet service index",
+      "uri": "https://api.nuget.org/v3/index.json",
+      "method": "GET",
+      "contentFormat": "json",
+      "contentJson": {
+        "version": "3.0.0",
+        "resources": [
+          {
+            "@id": "https://azuresearch-usnc.nuget.org/query",
+            "@type": "SearchQueryService",
+            "comment": "Query endpoint of NuGet Search service (primary)"
+          },
+          {
+            "@id": "https://azuresearch-ussc.nuget.org/query",
+            "@type": "SearchQueryService",
+            "comment": "Query endpoint of NuGet Search service (secondary)"
+          },
+          {
+            "@id": "https://azuresearch-usnc.nuget.org/autocomplete",
+            "@type": "SearchAutocompleteService",
+            "comment": "Autocomplete endpoint of NuGet Search service (primary)"
+          },
+          {
+            "@id": "https://azuresearch-ussc.nuget.org/autocomplete",
+            "@type": "SearchAutocompleteService",
+            "comment": "Autocomplete endpoint of NuGet Search service (secondary)"
+          },
+          {
+            "@id": "https://azuresearch-usnc.nuget.org/",
+            "@type": "SearchGalleryQueryService/3.0.0-rc",
+            "comment": "Azure Website based Search Service used by Gallery (primary)"
+          },
+          {
+            "@id": "https://azuresearch-ussc.nuget.org/",
+            "@type": "SearchGalleryQueryService/3.0.0-rc",
+            "comment": "Azure Website based Search Service used by Gallery (secondary)"
+          },
+          {
+            "@id": "https://api.nuget.org/v3/registration5-semver1/",
+            "@type": "RegistrationsBaseUrl",
+            "comment": "Base URL of Azure storage where NuGet package registration info is stored"
+          },
+          {
+            "@id": "https://api.nuget.org/v3-flatcontainer/",
+            "@type": "PackageBaseAddress/3.0.0",
+            "comment": "Base URL of where NuGet packages are stored, in the format https://api.nuget.org/v3-flatcontainer/{id-lower}/{version-lower}/{id-lower}.{version-lower}.nupkg"
+          },
+          {
+            "@id": "https://www.nuget.org/api/v2",
+            "@type": "LegacyGallery"
+          },
+          {
+            "@id": "https://www.nuget.org/api/v2",
+            "@type": "LegacyGallery/2.0.0"
+          },
+          {
+            "@id": "https://www.nuget.org/api/v2/package",
+            "@type": "PackagePublish/2.0.0"
+          },
+          {
+            "@id": "https://www.nuget.org/api/v2/symbolpackage",
+            "@type": "SymbolPackagePublish/4.9.0",
+            "comment": "The gallery symbol publish endpoint."
+          },
+          {
+            "@id": "https://azuresearch-usnc.nuget.org/query",
+            "@type": "SearchQueryService/3.0.0-rc",
+            "comment": "Query endpoint of NuGet Search service (primary) used by RC clients"
+          },
+          {
+            "@id": "https://azuresearch-ussc.nuget.org/query",
+            "@type": "SearchQueryService/3.0.0-rc",
+            "comment": "Query endpoint of NuGet Search service (secondary) used by RC clients"
+          },
+          {
+            "@id": "https://azuresearch-usnc.nuget.org/query",
+            "@type": "SearchQueryService/3.5.0",
+            "comment": "Query endpoint of NuGet Search service (primary) that supports package type filtering"
+          },
+          {
+            "@id": "https://azuresearch-ussc.nuget.org/query",
+            "@type": "SearchQueryService/3.5.0",
+            "comment": "Query endpoint of NuGet Search service (secondary) that supports package type filtering"
+          },
+          {
+            "@id": "https://azuresearch-usnc.nuget.org/autocomplete",
+            "@type": "SearchAutocompleteService/3.0.0-rc",
+            "comment": "Autocomplete endpoint of NuGet Search service (primary) used by RC clients"
+          },
+          {
+            "@id": "https://azuresearch-ussc.nuget.org/autocomplete",
+            "@type": "SearchAutocompleteService/3.0.0-rc",
+            "comment": "Autocomplete endpoint of NuGet Search service (secondary) used by RC clients"
+          },
+          {
+            "@id": "https://azuresearch-usnc.nuget.org/autocomplete",
+            "@type": "SearchAutocompleteService/3.5.0",
+            "comment": "Autocomplete endpoint of NuGet Search service (primary) that supports package type filtering"
+          },
+          {
+            "@id": "https://azuresearch-ussc.nuget.org/autocomplete",
+            "@type": "SearchAutocompleteService/3.5.0",
+            "comment": "Autocomplete endpoint of NuGet Search service (secondary) that supports package type filtering"
+          },
+          {
+            "@id": "https://api.nuget.org/v3/registration5-semver1/",
+            "@type": "RegistrationsBaseUrl/3.0.0-rc",
+            "comment": "Base URL of Azure storage where NuGet package registration info is stored used by RC clients. This base URL does not include SemVer 2.0.0 packages."
+          },
+          {
+            "@id": "https://www.nuget.org/packages/{id}/{version}/ReportAbuse",
+            "@type": "ReportAbuseUriTemplate/3.0.0-rc",
+            "comment": "URI template used by NuGet Client to construct Report Abuse URL for packages used by RC clients"
+          },
+          {
+            "@id": "https://api.nuget.org/v3/registration5-semver1/{id-lower}/index.json",
+            "@type": "PackageDisplayMetadataUriTemplate/3.0.0-rc",
+            "comment": "URI template used by NuGet Client to construct display metadata for Packages using ID"
+          },
+          {
+            "@id": "https://api.nuget.org/v3/registration5-semver1/{id-lower}/{version-lower}.json",
+            "@type": "PackageVersionDisplayMetadataUriTemplate/3.0.0-rc",
+            "comment": "URI template used by NuGet Client to construct display metadata for Packages using ID, Version"
+          },
+          {
+            "@id": "https://azuresearch-usnc.nuget.org/query",
+            "@type": "SearchQueryService/3.0.0-beta",
+            "comment": "Query endpoint of NuGet Search service (primary) used by beta clients"
+          },
+          {
+            "@id": "https://azuresearch-ussc.nuget.org/query",
+            "@type": "SearchQueryService/3.0.0-beta",
+            "comment": "Query endpoint of NuGet Search service (secondary) used by beta clients"
+          },
+          {
+            "@id": "https://azuresearch-usnc.nuget.org/autocomplete",
+            "@type": "SearchAutocompleteService/3.0.0-beta",
+            "comment": "Autocomplete endpoint of NuGet Search service (primary) used by beta clients"
+          },
+          {
+            "@id": "https://azuresearch-ussc.nuget.org/autocomplete",
+            "@type": "SearchAutocompleteService/3.0.0-beta",
+            "comment": "Autocomplete endpoint of NuGet Search service (secondary) used by beta clients"
+          },
+          {
+            "@id": "https://api.nuget.org/v3/registration5-semver1/",
+            "@type": "RegistrationsBaseUrl/3.0.0-beta",
+            "comment": "Base URL of Azure storage where NuGet package registration info is stored used by Beta clients. This base URL does not include SemVer 2.0.0 packages."
+          },
+          {
+            "@id": "https://www.nuget.org/packages/{id}/{version}/ReportAbuse",
+            "@type": "ReportAbuseUriTemplate/3.0.0-beta",
+            "comment": "URI template used by NuGet Client to construct Report Abuse URL for packages"
+          },
+          {
+            "@id": "https://www.nuget.org/packages/{id}/{version}?_src=template",
+            "@type": "PackageDetailsUriTemplate/5.1.0",
+            "comment": "URI template used by NuGet Client to construct details URL for packages"
+          },
+          {
+            "@id": "https://api.nuget.org/v3/registration5-gz-semver1/",
+            "@type": "RegistrationsBaseUrl/3.4.0",
+            "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL does not include SemVer 2.0.0 packages."
+          },
+          {
+            "@id": "https://api.nuget.org/v3/registration5-gz-semver2/",
+            "@type": "RegistrationsBaseUrl/3.6.0",
+            "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL includes SemVer 2.0.0 packages."
+          },
+          {
+            "@id": "https://api.nuget.org/v3/registration5-gz-semver2/",
+            "@type": "RegistrationsBaseUrl/Versioned",
+            "clientVersion": "4.3.0-alpha",
+            "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL includes SemVer 2.0.0 packages."
+          },
+          {
+            "@id": "https://api.nuget.org/v3-index/repository-signatures/4.7.0/index.json",
+            "@type": "RepositorySignatures/4.7.0",
+            "comment": "The endpoint for discovering information about this package source's repository signatures."
+          },
+          {
+            "@id": "https://api.nuget.org/v3-index/repository-signatures/5.0.0/index.json",
+            "@type": "RepositorySignatures/5.0.0",
+            "comment": "The endpoint for discovering information about this package source's repository signatures."
+          },
+          {
+            "@id": "https://api.nuget.org/v3/catalog0/index.json",
+            "@type": "Catalog/3.0.0",
+            "comment": "Index of the NuGet package catalog."
+          }
+        ],
+        "@context": {
+          "@vocab": "http://schema.nuget.org/services#",
+          "comment": "http://www.w3.org/2000/01/rdf-schema#comment"
+        }
+      }
+    },
+    {
+      "comment": "NuGet search result for AWSSDK.S3",
+      "uri": "https://azuresearch-usnc.nuget.org/query?prerelease=true&q=PackageId%3AAWSSDK.S3&semVerLevel=2.0.0&take=1",
+      "contentFormat": "json",
+      "contentJson": {
+        "@context": {
+          "@vocab": "http://schema.nuget.org/schema#",
+          "@base": "https://api.nuget.org/v3/registration5-gz-semver2/"
+        },
+        "totalHits": 1,
+        "data": [
+          {
+            "@id": "https://api.nuget.org/v3/registration5-gz-semver2/awssdk.s3/index.json",
+            "@type": "Package",
+            "registration": "https://api.nuget.org/v3/registration5-gz-semver2/awssdk.s3/index.json",
+            "id": "AWSSDK.S3",
+            "version": "3.7.9.32",
+            "description": "Amazon Simple Storage Service (Amazon S3), provides developers and IT teams with secure, durable, highly-scalable object storage.",
+            "summary": "",
+            "title": "AWSSDK - Amazon Simple Storage Service",
+            "iconUrl": "https://api.nuget.org/v3-flatcontainer/awssdk.s3/3.7.9.32/icon",
+            "licenseUrl": "http://aws.amazon.com/apache2.0/",
+            "projectUrl": "https://github.com/aws/aws-sdk-net/",
+            "tags": [ "AWS", "Amazon", "cloud", "S3", "aws-sdk-v3" ],
+            "authors": [ "Amazon Web Services" ],
+            "owners": [ "awsdotnet" ],
+            "totalDownloads": 104224060,
+            "verified": true,
+            "packageTypes": [ { "name": "Dependency" } ]
+          }
+        ]
+      }
+    },
+    {
+      "comment": "NuGet search result for JustEat.HttpClientInterception",
+      "uri": "https://azuresearch-usnc.nuget.org/query?prerelease=true&q=PackageId%3AJustEat.HttpClientInterception&semVerLevel=2.0.0&take=1",
+      "contentFormat": "json",
+      "contentJson": {
+        "@context": {
+          "@vocab": "http://schema.nuget.org/schema#",
+          "@base": "https://api.nuget.org/v3/registration5-gz-semver2/"
+        },
+        "totalHits": 1,
+        "data": [
+          {
+            "@id": "https://api.nuget.org/v3/registration5-gz-semver2/justeat.httpclientinterception/index.json",
+            "@type": "Package",
+            "registration": "https://api.nuget.org/v3/registration5-gz-semver2/justeat.httpclientinterception/index.json",
+            "id": "JustEat.HttpClientInterception",
+            "version": "3.1.1",
+            "description": "A .NET library for intercepting server-side HTTP dependencies.",
+            "summary": "",
+            "title": "JustEat.HttpClientInterception",
+            "iconUrl": "https://api.nuget.org/v3-flatcontainer/justeat.httpclientinterception/3.1.1/icon",
+            "licenseUrl": "https://www.nuget.org/packages/JustEat.HttpClientInterception/3.1.1/license",
+            "projectUrl": "https://github.com/justeat/httpclient-interception",
+            "tags": [ "http", "httpclient", "interception", "testing" ],
+            "authors": [ "JUSTEAT_OSS" ],
+            "owners": [ "JUSTEAT_OSS" ],
+            "totalDownloads": 425557,
+            "verified": true,
+            "packageTypes": [ { "name": "Dependency" } ]
+          }
+        ]
+      }
+    },
+    {
+      "comment": "MartinCostello.Logging.XUnit",
+      "uri": "https://azuresearch-usnc.nuget.org/query?prerelease=true&q=PackageId%3AMartinCostello.Logging.XUnit&semVerLevel=2.0.0&take=1",
+      "contentFormat": "json",
+      "contentJson": {
+        "@context": {
+          "@vocab": "http://schema.nuget.org/schema#",
+          "@base": "https://api.nuget.org/v3/registration5-gz-semver2/"
+        },
+        "totalHits": 1,
+        "data": [
+          {
+            "@id": "https://api.nuget.org/v3/registration5-gz-semver2/martincostello.logging.xunit/index.json",
+            "@type": "Package",
+            "registration": "https://api.nuget.org/v3/registration5-gz-semver2/martincostello.logging.xunit/index.json",
+            "id": "MartinCostello.Logging.XUnit",
+            "version": "0.3.0",
+            "description": "Extensions for Microsoft.Extensions.Logging for xunit.",
+            "summary": "",
+            "title": "xunit Logging Extensions",
+            "licenseUrl": "https://www.nuget.org/packages/MartinCostello.Logging.XUnit/0.3.0/license",
+            "projectUrl": "https://github.com/martincostello/xunit-logging",
+            "tags": [ "xunit", "logging" ],
+            "authors": [ "martin_costello" ],
+            "owners": "martin_costello",
+            "totalDownloads": 1730708,
+            "verified": false,
+            "packageTypes": [ { "name": "Dependency" } ]
+          }
+        ]
+      }
+    },
+    {
+      "comment": "NuGet search result for Microsoft.AspNetCore.Mvc.Testing",
+      "uri": "https://azuresearch-usnc.nuget.org/query?prerelease=true&q=PackageId%3AMicrosoft.AspNetCore.Mvc.Testing&semVerLevel=2.0.0&take=1",
+      "contentFormat": "json",
+      "contentJson": {
+        "@context": {
+          "@vocab": "http://schema.nuget.org/schema#",
+          "@base": "https://api.nuget.org/v3/registration5-gz-semver2/"
+        },
+        "totalHits": 1,
+        "data": [
+          {
+            "@id": "https://api.nuget.org/v3/registration5-gz-semver2/microsoft.aspnetcore.mvc.testing/index.json",
+            "@type": "Package",
+            "registration": "https://api.nuget.org/v3/registration5-gz-semver2/microsoft.aspnetcore.mvc.testing/index.json",
+            "id": "Microsoft.AspNetCore.Mvc.Testing",
+            "version": "7.0.0-preview.6.22330.3",
+            "description": "Support for writing functional tests for MVC applications.\n\nThis package was built from the source code at https://github.com/dotnet/aspnetcore/tree/ab1f1c636afa3a6607f2d67bc387b586596d1d38",
+            "summary": "",
+            "title": "Microsoft.AspNetCore.Mvc.Testing",
+            "iconUrl": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.mvc.testing/7.0.0-preview.6.22330.3/icon",
+            "licenseUrl": "https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Testing/7.0.0-preview.6.22330.3/license",
+            "projectUrl": "https://asp.net/",
+            "tags": [ "aspnetcore", "aspnetcoremvc", "aspnetcoremvctesting" ],
+            "authors": [ "Microsoft" ],
+            "owners": [ "aspnet", "Microsoft" ],
+            "totalDownloads": 47046049,
+            "verified": true,
+            "packageTypes": [ { "name": "Dependency" } ],
+            "versions": [
+              {
+                "version": "6.0.7",
+                "downloads": 42,
+                "@id": "https://api.nuget.org/v3/registration5-gz-semver2/microsoft.aspnetcore.mvc.testing/6.0.7.json"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "comment": "NuGet search result for Newtonsoft.Json",
+      "uri": "https://azuresearch-usnc.nuget.org/query?prerelease=true&q=PackageId%3ANewtonsoft.Json&semVerLevel=2.0.0&take=1",
+      "contentFormat": "json",
+      "contentJson": {
+        "@context": {
+          "@vocab": "http://schema.nuget.org/schema#",
+          "@base": "https://api.nuget.org/v3/registration5-gz-semver2/"
+        },
+        "totalHits": 1,
+        "data": [
+          {
+            "@id": "https://api.nuget.org/v3/registration5-gz-semver2/newtonsoft.json/index.json",
+            "@type": "Package",
+            "registration": "https://api.nuget.org/v3/registration5-gz-semver2/newtonsoft.json/index.json",
+            "id": "Newtonsoft.Json",
+            "version": "13.0.2-beta1",
+            "description": "Json.NET is a popular high-performance JSON framework for .NET",
+            "summary": "",
+            "title": "Json.NET",
+            "iconUrl": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.2-beta1/icon",
+            "licenseUrl": "https://www.nuget.org/packages/Newtonsoft.Json/13.0.2-beta1/license",
+            "projectUrl": "https://www.newtonsoft.com/json",
+            "tags": [ "json" ],
+            "authors": [ "James Newton-King" ],
+            "owners": [ "dotnetfoundation", "jamesnk", "newtonsoft" ],
+            "totalDownloads": 2113898152,
+            "verified": true,
+            "packageTypes": [ { "name": "Dependency" } ],
+            "versions": [
+              {
+                "version": "13.0.1",
+                "downloads": 42,
+                "@id": "https://api.nuget.org/v3/registration5-gz-semver2/newtonsoft.json/13.0.1.json"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "comment": "NuGet search result for Octokit.GraphQL",
+      "uri": "https://azuresearch-usnc.nuget.org/query?prerelease=true&q=PackageId%3AOctokit.GraphQL&semVerLevel=2.0.0&take=1",
+      "contentFormat": "json",
+      "contentJson": {
+        "@context": {
+          "@vocab": "http://schema.nuget.org/schema#",
+          "@base": "https://api.nuget.org/v3/registration5-gz-semver2/"
+        },
+        "totalHits": 1,
+        "data": [
+          {
+            "@id": "https://api.nuget.org/v3/registration5-gz-semver2/octokit.graphql/index.json",
+            "@type": "Package",
+            "registration": "https://api.nuget.org/v3/registration5-gz-semver2/octokit.graphql/index.json",
+            "id": "Octokit.GraphQL",
+            "version": "0.1.9-beta",
+            "description": "An async-based GitHub GraphQL client library for .NET",
+            "summary": "",
+            "title": "Octokit.GraphQL",
+            "iconUrl": "https://api.nuget.org/v3-flatcontainer/octokit.graphql/0.1.9-beta/icon",
+            "licenseUrl": "https://github.com/octokit/octokit.graphql.net/blob/HEAD/LICENSE.md",
+            "projectUrl": "https://github.com/octokit/octokit.graphql.net",
+            "tags": [ "GitHub", "API", "Octokit", "GraphQL" ],
+            "authors": [ "GitHub" ],
+            "owners": [ "GitHub", "grokys", "jcansdale", "nickfloyd", "StanleyGoldman" ],
+            "totalDownloads": 829650,
+            "verified": true,
+            "packageTypes": [ { "name": "Dependency" } ]
+          }
+        ]
+      }
+    },
+    {
+      "comment": "NuGet search result for foo",
+      "uri": "https://azuresearch-usnc.nuget.org/query?prerelease=true&q=PackageId%3Afoo&semVerLevel=2.0.0&take=1",
+      "contentFormat": "json",
+      "contentJson": {
+        "@context": {
+          "@vocab": "http://schema.nuget.org/schema#",
+          "@base": "https://api.nuget.org/v3/registration5-gz-semver2/"
+        },
+        "totalHits": 0,
+        "data": []
+      }
+    }
+  ]
+}

--- a/tests/Costellobot.Tests/Bundles/oauth-http-bundle.json
+++ b/tests/Costellobot.Tests/Bundles/oauth-http-bundle.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/main/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
-  "id": "oauth",
+  "id": "oauth-http-bundle",
   "version": 1,
   "comment": "HTTP bundle for GitHub OAuth authentication.",
   "items": [

--- a/tests/Costellobot.Tests/Drivers/CheckSuiteDriver.cs
+++ b/tests/Costellobot.Tests/Drivers/CheckSuiteDriver.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using MartinCostello.Costellobot.Builders;
+
+using static MartinCostello.Costellobot.Builders.GitHubFixtures;
+
+namespace MartinCostello.Costellobot.Drivers;
+
+public sealed class CheckSuiteDriver
+{
+    public CheckSuiteDriver(string? login = null, string? conclusion = null)
+    {
+        Owner = CreateUser(login);
+        Repository = Owner.CreateRepository();
+        PullRequest = Repository.CreatePullRequest();
+        WorkflowRun = Repository.CreateWorkflowRun();
+        CheckSuite = CreateCheckSuite(conclusion);
+    }
+
+    public IList<CheckRunBuilder> CheckRuns { get; set; } = new List<CheckRunBuilder>();
+
+    public CheckSuiteBuilder CheckSuite { get; set; }
+
+    public UserBuilder Owner { get; set; }
+
+    public PullRequestBuilder PullRequest { get; set; }
+
+    public RepositoryBuilder Repository { get; set; }
+
+    public WorkflowRunBuilder WorkflowRun { get; set; }
+
+    public CheckSuiteDriver WithCheckRun(Func<PullRequestBuilder, CheckRunBuilder> configure)
+    {
+        CheckRuns.Add(configure(this.PullRequest));
+        return this;
+    }
+
+    public object CreateWebhook(string action)
+    {
+        return new
+        {
+            action,
+            check_suite = CheckSuite.Build(),
+            repository = CheckSuite.Repository.Build(),
+            installation = new
+            {
+                id = long.Parse(InstallationId, CultureInfo.InvariantCulture),
+            },
+        };
+    }
+
+    private CheckSuiteBuilder CreateCheckSuite(
+        string? conclusion = null,
+        bool rerequestable = true)
+    {
+        return new(Repository, "completed", conclusion ?? "failure")
+        {
+            Rerequestable = rerequestable,
+        };
+    }
+}

--- a/tests/Costellobot.Tests/Drivers/DeploymentStatusDriver.cs
+++ b/tests/Costellobot.Tests/Drivers/DeploymentStatusDriver.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using MartinCostello.Costellobot.Builders;
+
+using static MartinCostello.Costellobot.Builders.GitHubFixtures;
+
+namespace MartinCostello.Costellobot.Drivers;
+
+public sealed class DeploymentStatusDriver
+{
+    public DeploymentStatusDriver(
+        Func<RepositoryBuilder, GitHubCommitBuilder>? baseCommit = null,
+        Func<RepositoryBuilder, GitHubCommitBuilder>? headCommit = null)
+    {
+        Owner = CreateUser();
+        Repository = Owner.CreateRepository();
+        WorkflowRun = Repository.CreateWorkflowRun();
+        BaseCommit = baseCommit?.Invoke(Repository) ?? Repository.CreateCommit();
+        HeadCommit = headCommit?.Invoke(Repository) ?? Repository.CreateCommit();
+        Commits.Add(HeadCommit);
+    }
+
+    public GitHubCommitBuilder BaseCommit { get; set; }
+
+    public GitHubCommitBuilder HeadCommit { get; set; }
+
+    public IList<GitHubCommitBuilder> Commits { get; } = new List<GitHubCommitBuilder>();
+
+    public DeploymentBuilder? ActiveDeployment { get; set; }
+
+    public IList<DeploymentBuilder> InactiveDeployments { get; } = new List<DeploymentBuilder>();
+
+    public DeploymentBuilder? PendingDeployment { get; set; }
+
+    public DeploymentBuilder? SkippedDeployment { get; set; }
+
+    public DeploymentStatusBuilder? PendingDeploymentStatus { get; set; }
+
+    public UserBuilder Owner { get; set; }
+
+    public RepositoryBuilder Repository { get; set; }
+
+    public WorkflowRunBuilder WorkflowRun { get; set; }
+
+    [MemberNotNull(nameof(ActiveDeployment))]
+    public DeploymentStatusDriver WithActiveDeployment(string? environmentName = null)
+    {
+        ActiveDeployment = CreateDeployment(environmentName ?? PendingDeployment!.Environment, BaseCommit.Sha);
+        return this;
+    }
+
+    public DeploymentStatusDriver WithInactiveDeployment(
+        string? environmentName = null,
+        Func<RepositoryBuilder, GitHubCommitBuilder>? commitFactory = null)
+    {
+        var commit = commitFactory?.Invoke(Repository) ?? Repository.CreateCommit();
+        var deployment = CreateDeployment(environmentName ?? PendingDeployment!.Environment, commit?.Sha);
+
+        InactiveDeployments.Add(deployment);
+
+        return this;
+    }
+
+    [MemberNotNull(nameof(PendingDeployment))]
+    [MemberNotNull(nameof(PendingDeploymentStatus))]
+    public DeploymentStatusDriver WithPendingDeployment(
+        Func<GitHubCommitBuilder, DeploymentBuilder>? deploymentFactory = null,
+        Func<DeploymentStatusBuilder>? statusFactory = null)
+    {
+        PendingDeployment = deploymentFactory?.Invoke(HeadCommit) ?? CreateDeployment();
+        PendingDeploymentStatus = statusFactory?.Invoke() ?? CreateDeploymentStatus();
+
+        return this;
+    }
+
+    [MemberNotNull(nameof(SkippedDeployment))]
+    public DeploymentStatusDriver WithSkippedDeployment(
+        string? environmentName = null,
+        Func<RepositoryBuilder, GitHubCommitBuilder>? commitFactory = null)
+    {
+        var commit = commitFactory?.Invoke(Repository);
+        SkippedDeployment = CreateDeployment(environmentName ?? PendingDeployment!.Environment, commit?.Sha);
+        return this;
+    }
+
+    public DeploymentStatusDriver WithPendingCommit(GitHubCommitBuilder commit)
+    {
+        Commits.Add(commit);
+        return this;
+    }
+
+    public CompareResultBuilder Comparison()
+        => CreateComparison(Commits.ToArray());
+
+    public object CreateWebhook(string action)
+    {
+        return new
+        {
+            action,
+            deployment_status = PendingDeploymentStatus!.Build(),
+            deployment = PendingDeployment!.Build(),
+            check_run = new { },
+            workflow = new { },
+            workflow_run = WorkflowRun.Build(),
+            repository = Repository.Build(),
+            installation = new
+            {
+                id = long.Parse(InstallationId, CultureInfo.InvariantCulture),
+            },
+        };
+    }
+}

--- a/tests/Costellobot.Tests/Drivers/PullRequestDriver.cs
+++ b/tests/Costellobot.Tests/Drivers/PullRequestDriver.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using MartinCostello.Costellobot.Builders;
+
+using static MartinCostello.Costellobot.Builders.GitHubFixtures;
+
+namespace MartinCostello.Costellobot.Drivers;
+
+public sealed class PullRequestDriver
+{
+    public PullRequestDriver(string? login = null)
+    {
+        User = CreateUser(login);
+        Owner = CreateUser();
+        Repository = Owner.CreateRepository();
+        PullRequest = Repository.CreatePullRequest(User);
+        Commit = PullRequest.CreateCommit();
+    }
+
+    public GitHubCommitBuilder Commit { get; set; }
+
+    public UserBuilder Owner { get; set; }
+
+    public PullRequestBuilder PullRequest { get; set; }
+
+    public RepositoryBuilder Repository { get; set; }
+
+    public UserBuilder User { get; set; }
+
+    public static PullRequestDriver ForDependabot()
+        => new PullRequestDriver(DependabotCommitter);
+
+    public PullRequestDriver WithCommitMessage(string message)
+    {
+        Commit.Message = message;
+        return this;
+    }
+
+    public object CreateWebhook(string action)
+    {
+        return new
+        {
+            action,
+            number = PullRequest.Number,
+            pull_request = PullRequest.Build(),
+            repository = PullRequest.Repository.Build(),
+            installation = new
+            {
+                id = long.Parse(InstallationId, CultureInfo.InvariantCulture),
+            },
+        };
+    }
+}

--- a/tests/Costellobot.Tests/Drivers/PullRequestDriver.cs
+++ b/tests/Costellobot.Tests/Drivers/PullRequestDriver.cs
@@ -29,7 +29,7 @@ public sealed class PullRequestDriver
     public UserBuilder User { get; set; }
 
     public static PullRequestDriver ForDependabot()
-        => new PullRequestDriver(DependabotCommitter);
+        => new(DependabotCommitter);
 
     public PullRequestDriver WithCommitMessage(string message)
     {

--- a/tests/Costellobot.Tests/GitCommitAnalyzerTests.cs
+++ b/tests/Costellobot.Tests/GitCommitAnalyzerTests.cs
@@ -2,7 +2,11 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using MartinCostello.Costellobot.Infrastructure;
+using MartinCostello.Costellobot.Registries;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
 using static MartinCostello.Costellobot.Builders.GitHubFixtures;
 
 namespace MartinCostello.Costellobot;
@@ -15,36 +19,209 @@ public class GitCommitAnalyzerTests : IntegrationTests<AppFixture>
     {
     }
 
+    [Fact]
+    public static void Version_Is_Extracted_From_NuGet_Package_Update_Commit_Message()
+    {
+        string commitMessage = @"Bump AWSSDK.S3 from 3.7.9.32 to 3.7.9.33
+Bumps [AWSSDK.S3](https://github.com/aws/aws-sdk-net) from 3.7.9.32 to 3.7.9.33.
+- [Release notes](https://github.com/aws/aws-sdk-net/releases)
+- [Commits](https://github.com/aws/aws-sdk-net/commits)
+
+---
+updated-dependencies:
+- dependency-name: AWSSDK.S3
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>";
+
+        // Act
+        bool result = GitCommitAnalyzer.TryParseVersionNumber(commitMessage, out var actual);
+
+        // Assert
+        result.ShouldBeTrue();
+        actual.ShouldBe("3.7.9.33");
+    }
+
+    [Fact]
+    public static void Version_Is_Extracted_From_Submodule_Update_Commit_Message()
+    {
+        string commitMessage = @"Bump src/submodules/dependabot-helper from 697aaa7 to aca93c2
+Bumps [src/submodules/dependabot-helper](https://github.com/martincostello/dependabot-helper) from `697aaa7` to `aca93c2`.
+- [Release notes](https://github.com/martincostello/dependabot-helper/releases)
+- [Commits](https://github.com/martincostello/dependabot-helper/compare/697aaa778e5e0a27c7ba6a2c82f83cd5ddf9ae55...aca93c280ec51a3e7ffd9314de799d805cf7a407)
+
+---
+updated-dependencies:
+- dependency-name: src/submodules/dependabot-helper
+  dependency-type: direct:production
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>";
+
+        // Act
+        bool result = GitCommitAnalyzer.TryParseVersionNumber(commitMessage, out var actual);
+
+        // Assert
+        result.ShouldBeTrue();
+        actual.ShouldBe("aca93c2");
+    }
+
     [Theory]
-    [InlineData("@actions/github", true)]
-    [InlineData("actions/checkout", true)]
-    [InlineData("martincostello/update-dotnet-sdk", true)]
-    [InlineData("Microsoft.NET.Sdk", true)]
-    [InlineData("NodaTime", true)]
-    [InlineData("NodaTimee", false)]
-    [InlineData("NodaTime.Testing", true)]
-    [InlineData("NodaTime.Testingg", false)]
-    [InlineData("typescript-hax", false)]
-    public void Commit_Is_Analyzed_Correct(string dependency, bool expected)
+    [InlineData("@actions/github", "dependabot/npm_and_yarn/actions/github-5.0.3", true)]
+    [InlineData("actions/checkout", "dependabot/github_actions/actions/checkout-3", true)]
+    [InlineData("JustEat.HttpClientInterception", "dependabot/nuget/JustEat.HttpClientInterception-3.1.1", true)]
+    [InlineData("martincostello/update-dotnet-sdk", "dependabot/github_actions/martincostello/update-dotnet-sdk-2", true)]
+    [InlineData("Microsoft.NET.Sdk", "update-dotnet-sdk-6.0.302", true)]
+    [InlineData("NodaTime", "dependabot/nuget/NodaTimeVersion-3.1.0", true)]
+    [InlineData("NodaTimee", "dependabot/nuget/NodaTimee-3.1.1", false)]
+    [InlineData("NodaTime.Testing", "dependabot/nuget/NodaTimeVersion-3.1.0", true)]
+    [InlineData("NodaTime.Testingg", "dependabot/nuget/NodaTime.Testingg-3.1.1", false)]
+    [InlineData("typescript-hax", "dependabot/npm_and_yarn/typescript-hax-1.0.0", false)]
+    public async Task Commit_Is_Analyzed_Correctly_With_Trusted_Dependencies(
+        string dependency,
+        string reference,
+        bool expected)
     {
         // Arrange
+        var options = new WebhookOptions()
+        {
+            TrustedEntities = new()
+            {
+                Dependencies = new[]
+                {
+                    @"^@actions\/.*$",
+                    @"^@microsoft\/signalr$",
+                    @"^@octokit\/types$",
+                    @"^@types\/.*$",
+                    @"^actions\/.*$",
+                    @"^Amazon.Lambda\\..*$",
+                    @"^AspNet.Security.OAuth\\..*$",
+                    @"^AWSSDK\\..*$",
+                    @"^Azure.Extensions\\..*$",
+                    @"^Azure.Identity$",
+                    @"^BenchmarkDotNet$",
+                    @"^JustEat.HttpClientInterception$",
+                    @"^MartinCostello\\..*$",
+                    @"^martincostello\/update-dotnet-sdk$",
+                    @"^Microsoft.ApplicationInsights\\..*$",
+                    @"^Microsoft.AspNetCore\\..*$",
+                    @"^Microsoft.Azure\\..*$",
+                    @"^Microsoft.EntityFrameworkCore\\..*$",
+                    @"^Microsoft.Extensions\\..*$",
+                    @"^Microsoft.IdentityModel\\..*$",
+                    @"^Microsoft.NET.Sdk$",
+                    @"^Microsoft.NET.Test.Sdk$",
+                    @"^Microsoft.Playwright$",
+                    @"^Microsoft.SourceLink.GitHub$",
+                    @"^Microsoft.TypeScript.MSBuild$",
+                    @"^Newtonsoft.Json$",
+                    @"^Octokit$",
+                    @"^Octokit.GraphQL$",
+                    @"^Octokit.Webhooks.AspNetCore$",
+                    @"^NodaTime$",
+                    @"^NodaTime.Testing$",
+                    @"^System.Text.Json$",
+                    @"^typescript$",
+                    @"^xunit$",
+                    @"^xunit.runner.visualstudio$",
+                },
+            },
+        };
+
         using var scope = Fixture.Services.CreateScope();
-        var target = scope.ServiceProvider.GetRequiredService<GitCommitAnalyzer>();
+        var target = CreateTarget(scope.ServiceProvider, options);
 
         var owner = CreateUser();
         var repo = owner.CreateRepository();
 
-        string sha = "0304f7fb4e17d674ea52392d70e775761ccf5aed";
-        string commitMessage = TrustedCommitMessage(dependency);
+        var sha = "0304f7fb4e17d674ea52392d70e775761ccf5aed";
+        var commitMessage = TrustedCommitMessage(dependency);
 
         // Act
-        bool actual = target.IsTrustedDependencyUpdate(
+        var actual = await target.IsTrustedDependencyUpdateAsync(
             owner.Login,
             repo.Name,
+            reference,
             sha,
             commitMessage);
 
         // Assert
         actual.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("@actions/github", "dependabot/npm_and_yarn/actions/github-5.0.3", "5.0.3", DependencyEcosystem.Npm, new[] { "thboop" }, false)]
+    [InlineData("actions/checkout", "dependabot/github_actions/actions/checkout-3", "3", DependencyEcosystem.GitHubActions, new[] { "actions" }, true)]
+    [InlineData("JustEat.HttpClientInterception", "dependabot/nuget/JustEat.HttpClientInterception-3.1.1", "3.1.1", DependencyEcosystem.NuGet, new[] { "JUSTEAT_OSS" }, false)]
+    [InlineData("Microsoft.EntityFrameworkCore.SqlServer", "dependabot/nuget/Microsoft.EntityFrameworkCore.SqlServer-7.0.0-preview.6.22329.4", "7.0.0-preview.6.22329.4", DependencyEcosystem.NuGet, new[] { "aspnet", "EntityFramework", "Microsoft" }, true)]
+    [InlineData("Microsoft.NET.Sdk", "update-dotnet-sdk-6.0.302", "6.0.302", DependencyEcosystem.Unknown, new string[0], false)]
+    [InlineData("NodaTime", "dependabot/nuget/NodaTimeVersion-3.1.0", "3.1.0", DependencyEcosystem.NuGet, new[] { "NodaTime" }, false)]
+    [InlineData("python-dotenv", "dependabot/pip/python-dotenv-0.17.1", "0.17.1", DependencyEcosystem.Unsupported, new string[0], false)]
+    [InlineData("src/submodules/dependabot-helper", "dependabot/submodules/src/submodules/dependabot-helper-697aaa7", "697aaa7", DependencyEcosystem.Submodules, new[] { "https://github.com/martincostello" }, true)]
+    [InlineData("typescript", "dependabot/npm_and_yarn/typescript-5.0.1", "5.0.1", DependencyEcosystem.Npm, new[] { "typescript-bot" }, true)]
+    public async Task Commit_Is_Analyzed_Correctly_With_Trusted_Publishers(
+        string dependency,
+        string reference,
+        string version,
+        DependencyEcosystem ecosystem,
+        string[] owners,
+        bool expected)
+    {
+        // Arrange
+        var owner = CreateUser();
+        var repo = owner.CreateRepository();
+
+        var mock = new Mock<IPackageRegistry>();
+
+        mock.Setup((p) => p.Ecosystem)
+            .Returns(ecosystem);
+
+        mock.Setup((p) => p.GetPackageOwnersAsync(owner.Login, repo.Name, dependency, version))
+            .ReturnsAsync(owners);
+
+        var options = new WebhookOptions()
+        {
+            TrustedEntities = new()
+            {
+                Publishers = new Dictionary<DependencyEcosystem, IList<string>>()
+                {
+                    [DependencyEcosystem.GitHubActions] = new[] { "actions" },
+                    [DependencyEcosystem.Npm] = new[] { "types", "typescript-bot" },
+                    [DependencyEcosystem.NuGet] = new[] { "aspnet", "Microsoft" },
+                    [DependencyEcosystem.Submodules] = new[] { "https://github.com/martincostello" },
+                },
+            },
+        };
+
+        using var scope = Fixture.Services.CreateScope();
+        var target = CreateTarget(scope.ServiceProvider, options, new[] { mock.Object });
+
+        var sha = "0304f7fb4e17d674ea52392d70e775761ccf5aed";
+        var commitMessage = TrustedCommitMessage(dependency, version);
+
+        // Act
+        var actual = await target.IsTrustedDependencyUpdateAsync(
+            owner.Login,
+            repo.Name,
+            reference,
+            sha,
+            commitMessage);
+
+        // Assert
+        actual.ShouldBe(expected);
+    }
+
+    private static GitCommitAnalyzer CreateTarget(
+        IServiceProvider serviceProvider,
+        WebhookOptions? options = null,
+        IEnumerable<IPackageRegistry>? registries = null)
+    {
+        registries ??= serviceProvider.GetServices<IPackageRegistry>();
+        var optionsMonitor = options?.ToMonitor() ?? serviceProvider.GetRequiredService<IOptionsMonitor<WebhookOptions>>();
+        var logger = serviceProvider.GetRequiredService<ILogger<GitCommitAnalyzer>>();
+
+        return new(registries, optionsMonitor, logger);
     }
 }

--- a/tests/Costellobot.Tests/Handlers/CheckSuiteHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/CheckSuiteHandlerTests.cs
@@ -158,7 +158,7 @@ public class CheckSuiteHandlerTests : IntegrationTests<AppFixture>
         // Arrange
         Fixture.OverrideConfiguration("Webhook:RerunFailedChecksAttempts", "2");
 
-        var user = CreateUser("dependabot[bot]");
+        var user = CreateUserForDependabot();
         var owner = CreateUser();
         var repository = owner.CreateRepository();
         var pullRequest = repository.CreatePullRequest(user);

--- a/tests/Costellobot.Tests/Handlers/CheckSuiteHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/CheckSuiteHandlerTests.cs
@@ -444,6 +444,19 @@ public class CheckSuiteHandlerTests : IntegrationTests<AppFixture>
             .RegisterWith(Fixture.Interceptor);
     }
 
+    private void RegisterGetWorkflows(
+        CheckSuiteBuilder checkSuite,
+        params WorkflowRunBuilder[] workflows)
+    {
+        CreateDefaultBuilder()
+            .Requests()
+            .ForPath($"/repos/{checkSuite.Repository.Owner.Login}/{checkSuite.Repository.Name}/actions/runs")
+            .ForQuery($"check_suite_id={checkSuite.Id}")
+            .Responds()
+            .WithJsonContent(CreateWorkflowRuns(workflows))
+            .RegisterWith(Fixture.Interceptor);
+    }
+
     private void RegisterRerequestCheckSuite(
         CheckSuiteDriver driver,
         Action<HttpRequestInterceptionBuilder>? configure = null)

--- a/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
@@ -21,7 +21,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     public async Task Deployment_Is_Approved_For_Trusted_User_And_Dependency()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Deploy", bool.TrueString);
+        Fixture.ApproveDeployments();
 
         var owner = CreateUser();
         var repo = owner.CreateRepository();
@@ -81,7 +81,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     public async Task Deployment_Is_Approved_For_Trusted_User_And_Multiple_Dependencies()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Deploy", bool.TrueString);
+        Fixture.ApproveDeployments();
 
         var owner = CreateUser();
         var repo = owner.CreateRepository();
@@ -154,7 +154,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     public async Task Deployment_Is_Approved_For_Trusted_User_And_Dependency_When_Penultimate_Build_Skipped()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Deploy", bool.TrueString);
+        Fixture.ApproveDeployments();
 
         var owner = CreateUser();
         var repo = owner.CreateRepository();
@@ -217,7 +217,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     public async Task Deployment_Approval_Failure_For_Trusted_User_And_Dependency_Is_Handled()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Deploy", bool.TrueString);
+        Fixture.ApproveDeployments();
 
         var owner = CreateUser();
         var repo = owner.CreateRepository();
@@ -286,7 +286,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     public async Task Deployment_Is_Not_Approved_For_Deployment_That_Is_Not_Waiting(string state)
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Deploy", bool.TrueString);
+        Fixture.ApproveDeployments();
 
         var owner = CreateUser();
         var repo = owner.CreateRepository();
@@ -310,7 +310,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     public async Task Deployment_Is_Not_Approved_If_Deployment_Approval_Disabled()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Deploy", bool.FalseString);
+        Fixture.ApproveDeployments(false);
 
         var owner = CreateUser();
         var repo = owner.CreateRepository();
@@ -338,7 +338,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
         string environment)
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Deploy", bool.TrueString);
+        Fixture.ApproveDeployments();
 
         var owner = CreateUser();
         var repo = owner.CreateRepository();
@@ -363,7 +363,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     public async Task Deployment_Is_Not_Approved_If_No_Deployments_Found()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Deploy", bool.TrueString);
+        Fixture.ApproveDeployments();
 
         var owner = CreateUser();
         var repo = owner.CreateRepository();
@@ -391,7 +391,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     public async Task Deployment_Is_Not_Approved_If_No_Other_Deployments_Found()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Deploy", bool.TrueString);
+        Fixture.ApproveDeployments();
 
         var owner = CreateUser();
         var repo = owner.CreateRepository();
@@ -419,7 +419,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     public async Task Deployment_Is_Not_Approved_If_No_Deployment_Statuses_Found()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Deploy", bool.TrueString);
+        Fixture.ApproveDeployments();
 
         var owner = CreateUser();
         var repo = owner.CreateRepository();
@@ -450,7 +450,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     public async Task Deployment_Is_Not_Approved_If_No_Active_Deployment_Statuses_Found()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Deploy", bool.TrueString);
+        Fixture.ApproveDeployments();
 
         var owner = CreateUser();
         var repo = owner.CreateRepository();
@@ -481,7 +481,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     public async Task Deployment_Is_Not_Approved_If_No_Active_Deployment_Found()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Deploy", bool.TrueString);
+        Fixture.ApproveDeployments();
 
         var owner = CreateUser();
         var repo = owner.CreateRepository();
@@ -514,7 +514,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     public async Task Deployment_Is_Not_Approved_For_No_Diff()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Deploy", bool.TrueString);
+        Fixture.ApproveDeployments();
 
         var owner = CreateUser();
         var repo = owner.CreateRepository();
@@ -560,6 +560,8 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     public async Task Deployment_Is_Not_Approved_For_Commits_Behind()
     {
         // Arrange
+        Fixture.ApproveDeployments();
+
         var owner = CreateUser();
         var repo = owner.CreateRepository();
         var workflowRun = repo.CreateWorkflowRun();
@@ -578,7 +580,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
 
         RegisterGetAccessToken();
 
-        var comparison = CreateComparison();
+        var comparison = CreateComparison(commit);
         comparison.Status = "behind";
         comparison.AheadBy = 0;
         comparison.BehindBy = 1;
@@ -607,7 +609,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     public async Task Deployment_Is_Not_Approved_For_Untrusted_User()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Deploy", bool.TrueString);
+        Fixture.ApproveDeployments();
 
         var owner = CreateUser();
         var repo = owner.CreateRepository();
@@ -657,13 +659,17 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     public async Task Deployment_Is_Not_Approved_For_Trusted_User_And_Untrusted_Dependency()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Deploy", bool.TrueString);
+        Fixture.ApproveDeployments();
 
         var owner = CreateUser();
         var repo = owner.CreateRepository();
         var workflowRun = repo.CreateWorkflowRun();
 
         var headCommit = CreateTrustedCommit(repo);
+        var additionalCommit = CreateUntrustedCommit(repo);
+
+        var pullRequestForHead = CreatePullRequestForCommit(headCommit);
+        var pullRequestForAdditional = CreatePullRequestForCommit(additionalCommit);
 
         var pendingDeployment = CreateDeployment(sha: headCommit.Sha);
         var deploymentStatus = CreateDeploymentStatus();
@@ -680,9 +686,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
 
         RegisterGetAccessToken();
 
-        var comparison = CreateComparison(
-            headCommit,
-            CreateUntrustedCommit(repo));
+        var comparison = CreateComparison(headCommit, additionalCommit);
 
         RegisterGetCompare(baseCommit, headCommit, comparison);
 
@@ -692,6 +696,9 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
             pendingDeployment,
             activeDeployment,
             previousDeployment);
+
+        RegisterGetPullRequestsForCommit(repo, headCommit.Sha, pullRequestForHead);
+        RegisterGetPullRequestsForCommit(repo, additionalCommit.Sha, pullRequestForAdditional);
 
         var value = CreateWebhook(repo, pendingDeployment, deploymentStatus, workflowRun);
 
@@ -710,7 +717,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     public async Task Deployment_Is_Not_Approved_If_Not_Exactly_One_Pending_Deployment(int count)
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Deploy", bool.TrueString);
+        Fixture.ApproveDeployments();
 
         var owner = CreateUser();
         var repo = owner.CreateRepository();

--- a/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
@@ -744,6 +744,19 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
             .RegisterWith(Fixture.Interceptor);
     }
 
+    private void RegisterGetDeploymentStatuses(
+        RepositoryBuilder repository,
+        DeploymentBuilder deployment,
+        params DeploymentStatusBuilder[] deploymentStatuses)
+    {
+        CreateDefaultBuilder()
+            .Requests()
+            .ForPath($"/repos/{repository.Owner.Login}/{repository.Name}/deployments/{deployment.Id}/statuses")
+            .Responds()
+            .WithJsonContent(deploymentStatuses)
+            .RegisterWith(Fixture.Interceptor);
+    }
+
     private void RegisterAllDeployments(DeploymentStatusDriver driver)
     {
         var deployments = new List<DeploymentBuilder>();

--- a/tests/Costellobot.Tests/Handlers/HandlerFactoryTests.cs
+++ b/tests/Costellobot.Tests/Handlers/HandlerFactoryTests.cs
@@ -28,6 +28,7 @@ public static class HandlerFactoryTests
         var gitHubClient = Mock.Of<IGitHubClientForInstallation>();
 
         var commitAnalyzer = new GitCommitAnalyzer(
+            Array.Empty<Registries.IPackageRegistry>(),
             webhookOptions,
             NullLoggerFactory.Instance.CreateLogger<GitCommitAnalyzer>());
 

--- a/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
@@ -25,7 +25,7 @@ public class PullRequestHandlerTests : IntegrationTests<AppFixture>
         // Arrange
         Fixture.OverrideConfiguration("Webhook:Approve", bool.TrueString);
 
-        var user = CreateUser("dependabot[bot]");
+        var user = CreateUserForDependabot();
         var pullRequest = CreatePullRequest(user);
 
         var commit = pullRequest.CreateCommit();
@@ -68,7 +68,7 @@ public class PullRequestHandlerTests : IntegrationTests<AppFixture>
         // Arrange
         Fixture.OverrideConfiguration("Webhook:Automerge", bool.TrueString);
 
-        var user = CreateUser("dependabot[bot]");
+        var user = CreateUserForDependabot();
         var owner = CreateUser();
         var repo = owner.CreateRepository();
 
@@ -129,7 +129,7 @@ public class PullRequestHandlerTests : IntegrationTests<AppFixture>
         // Arrange
         Fixture.OverrideConfiguration("Webhook:Automerge", bool.TrueString);
 
-        var user = CreateUser("dependabot[bot]");
+        var user = CreateUserForDependabot();
         var pullRequest = CreatePullRequest(user);
 
         var commit = pullRequest.CreateCommit();
@@ -167,7 +167,7 @@ public class PullRequestHandlerTests : IntegrationTests<AppFixture>
         // Arrange
         Fixture.OverrideConfiguration("Webhook:Approve", bool.TrueString);
 
-        var user = CreateUser("dependabot[bot]");
+        var user = CreateUserForDependabot();
         var pullRequest = CreatePullRequest(user);
 
         var commit = pullRequest.CreateCommit();
@@ -231,7 +231,7 @@ public class PullRequestHandlerTests : IntegrationTests<AppFixture>
         // Arrange
         Fixture.OverrideConfiguration("Webhook:Approve", bool.TrueString);
 
-        var user = CreateUser("dependabot[bot]");
+        var user = CreateUserForDependabot();
         var pullRequest = CreatePullRequest(user);
         var commit = pullRequest.CreateCommit();
 
@@ -277,7 +277,7 @@ public class PullRequestHandlerTests : IntegrationTests<AppFixture>
         // Arrange
         Fixture.OverrideConfiguration("Webhook:Approve", bool.TrueString);
 
-        var user = CreateUser("dependabot[bot]");
+        var user = CreateUserForDependabot();
         var pullRequest = CreatePullRequest(user);
 
         var commit = pullRequest.CreateCommit();
@@ -309,7 +309,7 @@ public class PullRequestHandlerTests : IntegrationTests<AppFixture>
         // Arrange
         Fixture.OverrideConfiguration("Webhook:Approve", bool.TrueString);
 
-        var user = CreateUser("dependabot[bot]");
+        var user = CreateUserForDependabot();
         var pullRequest = CreatePullRequest(user);
 
         pullRequest.IsDraft = true;

--- a/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
@@ -23,7 +23,7 @@ public class PullRequestHandlerTests : IntegrationTests<AppFixture>
     public async Task Pull_Request_Is_Approved_For_Trusted_User_And_Dependency()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Approve", bool.TrueString);
+        Fixture.ApprovePullRequests();
 
         var user = CreateUserForDependabot();
         var pullRequest = CreatePullRequest(user);
@@ -66,7 +66,7 @@ public class PullRequestHandlerTests : IntegrationTests<AppFixture>
         string mergeMethod)
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Automerge", bool.TrueString);
+        Fixture.AutoMergeEnabled();
 
         var user = CreateUserForDependabot();
         var owner = CreateUser();
@@ -127,7 +127,7 @@ public class PullRequestHandlerTests : IntegrationTests<AppFixture>
     public async Task Exception_Is_Not_Thrown_If_Enabling_Automerge_Fails()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Automerge", bool.TrueString);
+        Fixture.AutoMergeEnabled();
 
         var user = CreateUserForDependabot();
         var pullRequest = CreatePullRequest(user);
@@ -165,7 +165,7 @@ public class PullRequestHandlerTests : IntegrationTests<AppFixture>
     public async Task Pull_Request_Is_Not_Approved_For_Trusted_User_But_Untusted_Dependency()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Approve", bool.TrueString);
+        Fixture.ApprovePullRequests();
 
         var user = CreateUserForDependabot();
         var pullRequest = CreatePullRequest(user);
@@ -197,7 +197,7 @@ public class PullRequestHandlerTests : IntegrationTests<AppFixture>
     public async Task Pull_Request_Is_Not_Approved_For_Untrusted_User()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Approve", bool.TrueString);
+        Fixture.ApprovePullRequests();
 
         var user = CreateUser("rando-calrissian");
         var pullRequest = CreatePullRequest(user);
@@ -229,7 +229,7 @@ public class PullRequestHandlerTests : IntegrationTests<AppFixture>
     public async Task Pull_Request_Is_Not_Approved_For_Trusted_User_With_No_Dependencies_Detected()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Approve", bool.TrueString);
+        Fixture.ApprovePullRequests();
 
         var user = CreateUserForDependabot();
         var pullRequest = CreatePullRequest(user);
@@ -275,7 +275,7 @@ public class PullRequestHandlerTests : IntegrationTests<AppFixture>
     public async Task Pull_Request_Is_Not_Approved_For_Ignored_Action(string action)
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Approve", bool.TrueString);
+        Fixture.ApprovePullRequests();
 
         var user = CreateUserForDependabot();
         var pullRequest = CreatePullRequest(user);
@@ -307,7 +307,7 @@ public class PullRequestHandlerTests : IntegrationTests<AppFixture>
     public async Task Pull_Request_Is_Not_Approved_For_Draft()
     {
         // Arrange
-        Fixture.OverrideConfiguration("Webhook:Approve", bool.TrueString);
+        Fixture.ApprovePullRequests();
 
         var user = CreateUserForDependabot();
         var pullRequest = CreatePullRequest(user);

--- a/tests/Costellobot.Tests/Infrastructure/AppFixtureExtensions.cs
+++ b/tests/Costellobot.Tests/Infrastructure/AppFixtureExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Costellobot.Infrastructure;
+
+public static class AppFixtureExtensions
+{
+    public static T ApproveDeployments<T>(this T fixture, bool enabled = true)
+        where T : AppFixture
+    {
+        fixture.OverrideConfiguration("Webhook:Deploy", enabled.ToString());
+        return fixture;
+    }
+
+    public static T ApprovePullRequests<T>(this T fixture, bool enabled = true)
+        where T : AppFixture
+    {
+        fixture.OverrideConfiguration("Webhook:Approve", enabled.ToString());
+        return fixture;
+    }
+
+    public static T AutoMergeEnabled<T>(this T fixture, bool enabled = true)
+        where T : AppFixture
+    {
+        fixture.OverrideConfiguration("Webhook:Automerge", enabled.ToString());
+        return fixture;
+    }
+
+    public static T FailedCheckRerunAttempts<T>(this T fixture, int value)
+        where T : AppFixture
+    {
+        fixture.OverrideConfiguration("Webhook:RerunFailedChecksAttempts", value.ToString(CultureInfo.InvariantCulture));
+        return fixture;
+    }
+}

--- a/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
+++ b/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
@@ -269,6 +269,19 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
             .RegisterWith(Fixture.Interceptor);
     }
 
+    protected void RegisterGetPullRequestsForCommit(
+        RepositoryBuilder repository,
+        string sha,
+        params PullRequestBuilder[] pullRequests)
+    {
+        CreateDefaultBuilder()
+            .Requests()
+            .ForPath($"/repos/{repository.Owner.Login}/{repository.Name}/commits/{sha}/pulls")
+            .Responds()
+            .WithJsonContent(pullRequests)
+            .RegisterWith(Fixture.Interceptor);
+    }
+
     protected void RegisterGetWorkflows(
         CheckSuiteBuilder checkSuite,
         params WorkflowRunBuilder[] workflows)

--- a/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
+++ b/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
@@ -174,33 +174,6 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
             .RegisterWith(Fixture.Interceptor);
     }
 
-    protected void RegisterGetCompare(
-        GitHubCommitBuilder @base,
-        GitHubCommitBuilder head,
-        CompareResultBuilder comparison)
-    {
-        CreateDefaultBuilder()
-            .Requests()
-            .ForPath($"/repos/{@base.Repository.Owner.Login}/{@base.Repository.Name}/compare/{@base.Sha}...{head.Sha}")
-            .Responds()
-            .WithJsonContent(comparison)
-            .RegisterWith(Fixture.Interceptor);
-    }
-
-    protected void RegisterGetDeployments(
-        RepositoryBuilder repository,
-        string environmentName,
-        params DeploymentBuilder[] deployments)
-    {
-        CreateDefaultBuilder()
-            .Requests()
-            .ForPath($"/repos/{repository.Owner.Login}/{repository.Name}/deployments")
-            .ForQuery($"environment={environmentName}")
-            .Responds()
-            .WithJsonContent(deployments)
-            .RegisterWith(Fixture.Interceptor);
-    }
-
     protected void RegisterGetDeploymentStatuses(
         RepositoryBuilder repository,
         DeploymentBuilder deployment,
@@ -211,50 +184,6 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
             .ForPath($"/repos/{repository.Owner.Login}/{repository.Name}/deployments/{deployment.Id}/statuses")
             .Responds()
             .WithJsonContent(deploymentStatuses)
-            .RegisterWith(Fixture.Interceptor);
-    }
-
-    protected void RegisterGetPendingDeployments(
-        RepositoryBuilder repository,
-        long runId,
-        params PendingDeploymentBuilder[] deployments)
-    {
-        CreateDefaultBuilder()
-            .Requests()
-            .ForPath($"/repos/{repository.Owner.Login}/{repository.Name}/actions/runs/{runId}/pending_deployments")
-            .Responds()
-            .WithJsonContent(deployments)
-            .RegisterWith(Fixture.Interceptor);
-    }
-
-    protected void RegisterApprovePendingDeployments(
-        RepositoryBuilder repository,
-        long runId,
-        DeploymentBuilder deployment,
-        Action<HttpRequestInterceptionBuilder>? configure = null)
-    {
-        var builder = CreateDefaultBuilder()
-            .Requests()
-            .ForPost()
-            .ForPath($"/repos/{repository.Owner.Login}/{repository.Name}/actions/runs/{runId}/pending_deployments")
-            .Responds()
-            .WithJsonContent(deployment);
-
-        configure?.Invoke(builder);
-
-        builder.RegisterWith(Fixture.Interceptor);
-    }
-
-    protected void RegisterGetPullRequestsForCommit(
-        RepositoryBuilder repository,
-        string sha,
-        params PullRequestBuilder[] pullRequests)
-    {
-        CreateDefaultBuilder()
-            .Requests()
-            .ForPath($"/repos/{repository.Owner.Login}/{repository.Name}/commits/{sha}/pulls")
-            .Responds()
-            .WithJsonContent(pullRequests)
             .RegisterWith(Fixture.Interceptor);
     }
 

--- a/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
+++ b/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
@@ -120,37 +120,6 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
         return authenticatedClient;
     }
 
-    protected void RegisterEnableAutomerge(
-        PullRequestBuilder pullRequest,
-        Action<HttpRequestInterceptionBuilder>? configure = null)
-    {
-        var response = new
-        {
-            data = new
-            {
-                enablePullRequestAutoMerge = new
-                {
-                    number = new
-                    {
-                        number = pullRequest.Number,
-                    },
-                },
-            },
-        };
-
-        var builder = CreateDefaultBuilder()
-            .Requests()
-            .ForPost()
-            .ForPath("graphql")
-            .Responds()
-            .WithStatus(StatusCodes.Status201Created)
-            .WithSystemTextJsonContent(response);
-
-        configure?.Invoke(builder);
-
-        builder.RegisterWith(Fixture.Interceptor);
-    }
-
     protected void RegisterGetAccessToken(AccessTokenBuilder? accessToken = null)
     {
         accessToken ??= new();
@@ -162,59 +131,6 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
             .Responds()
             .WithJsonContent(accessToken)
             .RegisterWith(Fixture.Interceptor);
-    }
-
-    protected void RegisterGetCommit(GitHubCommitBuilder commit)
-    {
-        CreateDefaultBuilder()
-            .Requests()
-            .ForPath($"/repos/{commit.Repository.Owner.Login}/{commit.Repository.Name}/commits/{commit.Sha}")
-            .Responds()
-            .WithJsonContent(commit)
-            .RegisterWith(Fixture.Interceptor);
-    }
-
-    protected void RegisterGetDeploymentStatuses(
-        RepositoryBuilder repository,
-        DeploymentBuilder deployment,
-        params DeploymentStatusBuilder[] deploymentStatuses)
-    {
-        CreateDefaultBuilder()
-            .Requests()
-            .ForPath($"/repos/{repository.Owner.Login}/{repository.Name}/deployments/{deployment.Id}/statuses")
-            .Responds()
-            .WithJsonContent(deploymentStatuses)
-            .RegisterWith(Fixture.Interceptor);
-    }
-
-    protected void RegisterGetWorkflows(
-        CheckSuiteBuilder checkSuite,
-        params WorkflowRunBuilder[] workflows)
-    {
-        CreateDefaultBuilder()
-            .Requests()
-            .ForPath($"/repos/{checkSuite.Repository.Owner.Login}/{checkSuite.Repository.Name}/actions/runs")
-            .ForQuery($"check_suite_id={checkSuite.Id}")
-            .Responds()
-            .WithJsonContent(CreateWorkflowRuns(workflows))
-            .RegisterWith(Fixture.Interceptor);
-    }
-
-    protected void RegisterPostReview(
-        PullRequestBuilder pullRequest,
-        Action<HttpRequestInterceptionBuilder>? configure = null)
-    {
-        var builder = CreateDefaultBuilder()
-            .Requests()
-            .ForPost()
-            .ForPath($"/repos/{pullRequest.Repository.Owner.Login}/{pullRequest.Repository.Name}/pulls/{pullRequest.Number}/reviews")
-            .Responds()
-            .WithStatus(StatusCodes.Status201Created)
-            .WithSystemTextJsonContent(new { });
-
-        configure?.Invoke(builder);
-
-        builder.RegisterWith(Fixture.Interceptor);
     }
 
     protected async Task<HttpResponseMessage> PostWebhookAsync(

--- a/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
+++ b/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
@@ -56,7 +56,7 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
 
     protected static async Task AssertTaskNotRun(TaskCompletionSource source)
     {
-        await Task.Delay(TimeSpan.FromSeconds(0.1));
+        await Task.Delay(TimeSpan.FromSeconds(0.2));
         source.Task.Status.ShouldBe(TaskStatus.WaitingForActivation);
     }
 
@@ -164,20 +164,6 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
             .RegisterWith(Fixture.Interceptor);
     }
 
-    protected void RegisterGetCheckRuns(
-        RepositoryBuilder repository,
-        int id,
-        params CheckRunBuilder[] checkRuns)
-    {
-        CreateDefaultBuilder()
-            .Requests()
-            .ForPath($"/repos/{repository.Owner.Login}/{repository.Name}/check-suites/{id}/check-runs")
-            .ForQuery("status=completed&filter=all")
-            .Responds()
-            .WithJsonContent(CreateCheckRuns(checkRuns))
-            .RegisterWith(Fixture.Interceptor);
-    }
-
     protected void RegisterGetCommit(GitHubCommitBuilder commit)
     {
         CreateDefaultBuilder()
@@ -259,16 +245,6 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
         builder.RegisterWith(Fixture.Interceptor);
     }
 
-    protected void RegisterGetPullRequest(PullRequestBuilder pullRequest)
-    {
-        CreateDefaultBuilder()
-            .Requests()
-            .ForPath($"/repos/{pullRequest.Repository.Owner.Login}/{pullRequest.Repository.Name}/pulls/{pullRequest.Number}")
-            .Responds()
-            .WithJsonContent(pullRequest)
-            .RegisterWith(Fixture.Interceptor);
-    }
-
     protected void RegisterGetPullRequestsForCommit(
         RepositoryBuilder repository,
         string sha,
@@ -303,40 +279,6 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
             .Requests()
             .ForPost()
             .ForPath($"/repos/{pullRequest.Repository.Owner.Login}/{pullRequest.Repository.Name}/pulls/{pullRequest.Number}/reviews")
-            .Responds()
-            .WithStatus(StatusCodes.Status201Created)
-            .WithSystemTextJsonContent(new { });
-
-        configure?.Invoke(builder);
-
-        builder.RegisterWith(Fixture.Interceptor);
-    }
-
-    protected void RegisterRerequestCheckSuite(
-        CheckSuiteBuilder checkSuite,
-        Action<HttpRequestInterceptionBuilder>? configure = null)
-    {
-        var builder = CreateDefaultBuilder()
-            .Requests()
-            .ForPost()
-            .ForPath($"/repos/{checkSuite.Repository.Owner.Login}/{checkSuite.Repository.Name}/check-suites/{checkSuite.Id}/rerequest")
-            .Responds()
-            .WithStatus(StatusCodes.Status201Created)
-            .WithSystemTextJsonContent(new { });
-
-        configure?.Invoke(builder);
-
-        builder.RegisterWith(Fixture.Interceptor);
-    }
-
-    protected void RegisterRerunFailedJobs(
-        WorkflowRunBuilder workflowRun,
-        Action<HttpRequestInterceptionBuilder>? configure = null)
-    {
-        var builder = CreateDefaultBuilder()
-            .Requests()
-            .ForPost()
-            .ForPath($"/repos/{workflowRun.Repository.Owner.Login}/{workflowRun.Repository.Name}/actions/runs/{workflowRun.Id}/rerun-failed-jobs")
             .Responds()
             .WithStatus(StatusCodes.Status201Created)
             .WithSystemTextJsonContent(new { });

--- a/tests/Costellobot.Tests/Registries/GitHubActionsPackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/GitHubActionsPackageRegistryTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using JustEat.HttpClientInterception;
+using Octokit;
+using Octokit.Internal;
+
+namespace MartinCostello.Costellobot.Registries;
+
+public static class GitHubActionsPackageRegistryTests
+{
+    [Theory]
+    [InlineData("actions/checkout", "3", new[] { "actions" })]
+    [InlineData("actions/checkout", "v3", new[] { "actions" })]
+    [InlineData("actions/checkout", "2541b1294d2704b0964813337f33b291d3f8596b", new[] { "actions" })]
+    [InlineData("foo", "1.0.0", new string[0])]
+    [InlineData("foo/bar", "v1", new string[0])]
+    public static async Task Can_Get_Package_Owners(string id, string version, string[] expected)
+    {
+        // Arrange
+        string owner = "some-org";
+        string repository = "some-repo";
+
+        var options = new HttpClientInterceptorOptions()
+            .RegisterBundle(Path.Combine("Bundles", "github-refs.json"))
+            .ThrowsOnMissingRegistration();
+
+        var httpClient = new HttpClientAdapter(options.CreateHttpMessageHandler);
+        var connection = new Connection(new("costellobot", "1.0.0"), httpClient);
+        var client = new GitHubClientAdapter(connection);
+
+        var target = new GitHubActionsPackageRegistry(client);
+
+        // Act
+        var actual = await target.GetPackageOwnersAsync(
+            owner,
+            repository,
+            id,
+            version);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ShouldBe(expected);
+    }
+}

--- a/tests/Costellobot.Tests/Registries/GitSubmodulePackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/GitSubmodulePackageRegistryTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using JustEat.HttpClientInterception;
+using Octokit;
+
+namespace MartinCostello.Costellobot.Registries;
+
+public static class GitSubmodulePackageRegistryTests
+{
+    [Theory]
+    [InlineData("src/submodules/foo", "deadbee", new string[0])]
+    [InlineData("src/submodules/googletest", "7735334", new[] { "https://github.com/google" })]
+    public static async Task Can_Get_Package_Owners(string id, string version, string[] expected)
+    {
+        // Arrange
+        string owner = "dotnet";
+        string repository = "aspnetcore";
+
+        var options = new HttpClientInterceptorOptions()
+            .RegisterBundle(Path.Combine("Bundles", "github-submodules.json"))
+            .ThrowsOnMissingRegistration();
+
+        var adapter = new Octokit.Internal.HttpClientAdapter(options.CreateHttpMessageHandler);
+        var connection = new Connection(new("costellobot", "1.0.0"), adapter);
+        var client = new GitHubClientAdapter(connection);
+
+        var target = new GitSubmodulePackageRegistry(client);
+
+        // Act
+        var actual = await target.GetPackageOwnersAsync(
+            owner,
+            repository,
+            id,
+            version);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ShouldBe(expected);
+    }
+}

--- a/tests/Costellobot.Tests/Registries/NpmPackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/NpmPackageRegistryTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using JustEat.HttpClientInterception;
+
+namespace MartinCostello.Costellobot.Registries;
+
+public static class NpmPackageRegistryTests
+{
+    [Theory]
+    [InlineData("foo", "0.0", new string[0])]
+    [InlineData("foo", "0.0.0", new string[0])]
+    [InlineData("@types/node", "18.6.2", new[] { "types" })]
+    [InlineData("typescript", "4.6.3", new[] { "typescript-bot" })]
+    public static async Task Can_Get_Package_Owners(string id, string version, string[] expected)
+    {
+        // Arrange
+        string owner = "some-org";
+        string repository = "some-repo";
+
+        var options = new HttpClientInterceptorOptions()
+            .RegisterBundle(Path.Combine("Bundles", "npm-registry.json"))
+            .ThrowsOnMissingRegistration();
+
+        using var client = options.CreateHttpClient();
+
+        var target = new NpmPackageRegistry(client);
+
+        // Act
+        var actual = await target.GetPackageOwnersAsync(
+            owner,
+            repository,
+            id,
+            version);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ShouldBe(expected);
+    }
+}


### PR DESCRIPTION
- Add support for trusted publishers of dependencies from GitHub for Actions and submodules, npmjs.org and nuget.org.
- Do not deploy change automatically if there are changes behind the active deployment.
