### PR TITLE
Delete unused variable

### DIFF
--- a/src/Costellobot/Pages/Webhooks/Deliveries.cshtml
+++ b/src/Costellobot/Pages/Webhooks/Deliveries.cshtml
@@ -32,7 +32,6 @@
         <th scope="col">Timestamp</th>
         <th scope="col">Event</th>
         <th scope="col">Action</th>
-        <th scope="col">Installation ID</th>
         <th scope="col">Repository ID</th>
       </tr>
     </thead>
@@ -58,9 +57,6 @@
           </td>
           <td>
             <code class="delivery-action">@(delivery.Action ?? "-")</code>
-          </td>
-          <td>
-            <code class="delivery-installation-id">@(delivery.InstallationId?.ToString(CultureInfo.InvariantCulture) ?? "-")</code>
           </td>
           <td>
             <code class="delivery-repository-id">@(delivery.RepositoryId?.ToString(CultureInfo.InvariantCulture) ?? "-")</code>

--- a/src/Costellobot/Pages/Webhooks/Delivery.cshtml
+++ b/src/Costellobot/Pages/Webhooks/Delivery.cshtml
@@ -69,7 +69,6 @@
       <button class="nav-link" id="response-tab" data-bs-toggle="tab" data-bs-target="#response" type="button" role="tab" aria-controls="response" aria-selected="false">
         Response
         @{
-            int statusCode = Model.Delivery.GetProperty("status_code").GetInt32();
             string @class = Model.ResponseStatusCode switch
             {
               int value when value >= 200 && value < 300 => "bg-success",

--- a/src/Costellobot/Pages/Webhooks/Delivery.cshtml
+++ b/src/Costellobot/Pages/Webhooks/Delivery.cshtml
@@ -108,8 +108,11 @@
       <pre id="request-payload" class="hook-delivery-container">@(Model.RequestPayload)</pre>
     </div>
     <div class="tab-pane fade" id="response" role="tabpanel" aria-labelledby="response-tab">
-      <h3>Headers</h3>
-      <pre class="hook-delivery-container">@foreach ((var key, var value) in Model.ResponseHeaders){<strong>@(key):</strong> @(value)<br/>}</pre>
+      @if (Model.ResponseHeaders.Count > 0)
+      {
+        <h3>Headers</h3>
+        <pre class="hook-delivery-container">@foreach ((var key, var value) in Model.ResponseHeaders){<strong>@(key):</strong> @(value)<br/>}</pre>
+      }
       @if (!string.IsNullOrWhiteSpace(Model.ResponseBody))
       {
         <h3>Body</h3>

--- a/src/Costellobot/Pages/Webhooks/Delivery.cshtml
+++ b/src/Costellobot/Pages/Webhooks/Delivery.cshtml
@@ -33,12 +33,6 @@
         </td>
       </tr>
       <tr>
-        <td>Installation ID</td>
-        <td>
-          <code id="installation-id">@(Model.InstallationId)</code>
-        </td>
-      </tr>
-      <tr>
         <td>Repository ID</td>
         <td>
           <code id="repository-id">@(Model.RepositoryId)</code>

--- a/src/Costellobot/Pages/Webhooks/Delivery.cshtml.cs
+++ b/src/Costellobot/Pages/Webhooks/Delivery.cshtml.cs
@@ -55,7 +55,7 @@ public sealed partial class DeliveryModel : PageModel
 
     public int ResponseStatusCode => Delivery.GetProperty("status_code").GetInt32();
 
-    public JsonElement Delivery { get; private set; }
+    private JsonElement Delivery { get; set; }
 
     public async Task<IActionResult> OnGet([FromRoute(Name = "id")] long id)
     {

--- a/src/Costellobot/Pages/Webhooks/Delivery.cshtml.cs
+++ b/src/Costellobot/Pages/Webhooks/Delivery.cshtml.cs
@@ -37,8 +37,6 @@ public sealed partial class DeliveryModel : PageModel
 
     public string Event => Delivery.GetProperty("event").GetString() ?? "-";
 
-    public string InstallationId { get; set; } = "-";
-
     public bool Redelivery => Delivery.GetProperty("redelivery").GetBoolean();
 
     public string RepositoryId { get; set; } = "-";
@@ -96,16 +94,9 @@ public sealed partial class DeliveryModel : PageModel
 
         ResponseBody = response.GetProperty("payload").ToString();
 
-        if (Delivery.TryGetProperty("installation_id", out var installationId) &&
-            installationId.ValueKind != JsonValueKind.Null &&
-            installationId.TryGetInt64(out var value))
-        {
-            InstallationId = value.ToString(CultureInfo.InvariantCulture);
-        }
-
         if (Delivery.TryGetProperty("repository_id", out var repositoryId) &&
             repositoryId.ValueKind != JsonValueKind.Null &&
-            repositoryId.TryGetInt64(out value))
+            repositoryId.TryGetInt64(out var value))
         {
             RepositoryId = value.ToString(CultureInfo.InvariantCulture);
         }

--- a/src/Costellobot/Pages/Webhooks/Delivery.cshtml.cs
+++ b/src/Costellobot/Pages/Webhooks/Delivery.cshtml.cs
@@ -76,10 +76,7 @@ public sealed partial class DeliveryModel : PageModel
 
         var request = Delivery.GetProperty("request");
 
-        foreach (var property in request.GetProperty("headers").EnumerateObject().OrderBy((p) => p.Name, StringComparer.OrdinalIgnoreCase))
-        {
-            RequestHeaders[property.Name] = property.Value.ToString();
-        }
+        TryPopulateHeaders(request.GetProperty("headers"), RequestHeaders);
 
         RequestPayload = JsonSerializer.Serialize(
             request.GetProperty("payload"),
@@ -87,10 +84,7 @@ public sealed partial class DeliveryModel : PageModel
 
         var response = Delivery.GetProperty("response");
 
-        foreach (var property in response.GetProperty("headers").EnumerateObject().OrderBy((p) => p.Name, StringComparer.OrdinalIgnoreCase))
-        {
-            ResponseHeaders[property.Name] = property.Value.ToString();
-        }
+        TryPopulateHeaders(response.GetProperty("headers"), ResponseHeaders);
 
         ResponseBody = response.GetProperty("payload").ToString();
 
@@ -102,6 +96,17 @@ public sealed partial class DeliveryModel : PageModel
         }
 
         return Page();
+
+        static void TryPopulateHeaders(JsonElement element, IDictionary<string, string> headers)
+        {
+            if (element.ValueKind != JsonValueKind.Null)
+            {
+                foreach (var property in element.EnumerateObject().OrderBy((p) => p.Name, StringComparer.OrdinalIgnoreCase))
+                {
+                    headers[property.Name] = property.Value.ToString();
+                }
+            }
+        }
     }
 
     public async Task<IActionResult> OnPost()

--- a/tests/Costellobot.Tests/Pages/DeliveriesPage.cs
+++ b/tests/Costellobot.Tests/Pages/DeliveriesPage.cs
@@ -57,9 +57,6 @@ public sealed class DeliveriesPage : AppPage
         public async Task<string> IdAsync()
             => await StringAsync(Selectors.DeliveryId);
 
-        public async Task<string> InstallationIdAsync()
-            => await StringAsync(Selectors.DeliveryInstallationId);
-
         public async Task<string> RepositoryIdAsync()
             => await StringAsync(Selectors.DeliveryRepositoryId);
 
@@ -95,7 +92,6 @@ public sealed class DeliveriesPage : AppPage
         internal const string DeliveryEvent = "[class*='delivery-event']";
         internal const string DeliveryGuid = "[class*='delivery-guid']";
         internal const string DeliveryId = "[class*='delivery-id']";
-        internal const string DeliveryInstallationId = "[class*='delivery-installation-id']";
         internal const string DeliveryRepositoryId = "[class*='delivery-repository-id']";
         internal const string DeliveryItem = "[class*='webhook-delivery']";
         internal const string FindDeliveryInput = "id=delivery-id";

--- a/tests/Costellobot.Tests/WebhookTests.cs
+++ b/tests/Costellobot.Tests/WebhookTests.cs
@@ -44,21 +44,18 @@ public class WebhookTests : UITests
             await items[0].EventAsync().ShouldBe("issues");
             await items[0].GuidAsync().ShouldBe(third.Guid.ToString());
             await items[0].IdAsync().ShouldBe(third.Id.ToString(CultureInfo.InvariantCulture));
-            await items[0].InstallationIdAsync().ShouldBe("-");
             await items[0].RepositoryIdAsync().ShouldBe("-");
 
             await items[1].ActionAsync().ShouldBe("opened");
             await items[1].EventAsync().ShouldBe("issues");
             await items[1].GuidAsync().ShouldBe(second.Guid.ToString());
             await items[1].IdAsync().ShouldBe(second.Id.ToString(CultureInfo.InvariantCulture));
-            await items[1].InstallationIdAsync().ShouldBe("123");
             await items[1].RepositoryIdAsync().ShouldBe("456");
 
             await items[2].ActionAsync().ShouldBe("-");
             await items[2].EventAsync().ShouldBe("status");
             await items[2].GuidAsync().ShouldBe(first.Guid.ToString());
             await items[2].IdAsync().ShouldBe(first.Id.ToString(CultureInfo.InvariantCulture));
-            await items[2].InstallationIdAsync().ShouldBe("-");
             await items[2].RepositoryIdAsync().ShouldBe("-");
         });
     }
@@ -178,7 +175,6 @@ public class WebhookTests : UITests
             await items[0].EventAsync().ShouldBe(delivery.Event);
             await items[0].GuidAsync().ShouldBe(delivery.Guid.ToString());
             await items[0].IdAsync().ShouldBe(delivery.Id.ToString(CultureInfo.InvariantCulture));
-            await items[0].InstallationIdAsync().ShouldBe("-");
             await items[0].RepositoryIdAsync().ShouldBe("-");
         });
     }


### PR DESCRIPTION
* Remove leftover variable that isn't used.
* Remove the installation ID from the webhooks UI as it's always the same.
* Fix HTTP 500 rendering deliveries that have no headers (e.g. HTTP 504).
