### PR TITLE
Trust @typescript-eslint packages

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -47,6 +47,8 @@
       "Dependencies": [
         "^@actions\/.*$",
         "^@microsoft\/signalr$",
+        "^@typescript-eslint\/eslint-plugin$",
+        "^@typescript-eslint\/parser$",
         "^AspNet.Security.OAuth\\..*$",
         "^BenchmarkDotNet$",
         "^Microsoft.AspNetCore\\..*$",


### PR DESCRIPTION
Trust updates to `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser`.
