### PR TITLE
Add .npmrc file

### DIFF
--- a/src/Costellobot/.npmrc
+++ b/src/Costellobot/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org


### PR DESCRIPTION
Add an `.npmrc` file to ensure the right package registry is always used.
