### PR TITLE
Bump Octokit.GraphQL to 0.2.0-beta

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageVersion Include="NodaTime" Version="3.1.6" />
     <PackageVersion Include="Octokit" Version="4.0.3" />
-    <PackageVersion Include="Octokit.GraphQL" Version="0.1.8-beta" />
+    <PackageVersion Include="Octokit.GraphQL" Version="0.2.0-beta" />
     <PackageVersion Include="Octokit.Webhooks.AspNetCore" Version="1.3.5" />
     <PackageVersion Include="Polly" Version="7.2.3" />
     <PackageVersion Include="ReportGenerator" Version="5.1.13" />


### PR DESCRIPTION
Update to the latest version of Octokit.GraphQL.
