### PR TITLE
Trust actions from aws-actions

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -62,6 +62,7 @@
       "Publishers": {
         "GitHubActions": [
           "actions",
+          "aws-actions",
           "azure",
           "martincostello"
         ],


### PR DESCRIPTION
Trust AWS-published GitHub Actions.
