### PR TITLE
Remove MicrosoftAspNetCoreVersion

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,4 @@
 <Project>
-  <PropertyGroup>
-    <MicrosoftAspNetCoreVersion>7.0.3</MicrosoftAspNetCoreVersion>
-  </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="7.0.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />


### PR DESCRIPTION
Remove `MicrosoftAspNetCoreVersion` MSBuild property that is made redundant by the new .NET SDK update workflow.
