### PR TITLE
Fix trusted publisher for NuGet packages using SemVer 2

### DIFF
--- a/src/Costellobot/Registries/NuGetPackageRegistry.cs
+++ b/src/Costellobot/Registries/NuGetPackageRegistry.cs
@@ -82,9 +82,9 @@ public sealed class NuGetPackageRegistry : PackageRegistry
                     .Where((p) => string.Equals(p, version, StringComparison.OrdinalIgnoreCase))
                     .FirstOrDefault();
             }
-
-            versionFound ??= package.Version;
         }
+
+        versionFound ??= package.Version;
 
         if (!string.Equals(versionFound, version, StringComparison.OrdinalIgnoreCase))
         {

--- a/src/Costellobot/Registries/NuGetPackageRegistry.cs
+++ b/src/Costellobot/Registries/NuGetPackageRegistry.cs
@@ -66,7 +66,25 @@ public sealed class NuGetPackageRegistry : PackageRegistry
         var versionFound = package.Versions
             .Where((p) => string.Equals(p.Version, version, StringComparison.OrdinalIgnoreCase))
             .Select((p) => p.Version)
-            .FirstOrDefault(package.Version);
+            .FirstOrDefault();
+
+        if (versionFound is null)
+        {
+            var semVer2Versions = package.Versions
+                .Where((p) => p.Version.Contains('+', StringComparison.Ordinal))
+                .Select((p) => p.Version.Split('+')[0])
+                .ToArray();
+
+            if (semVer2Versions.Length == semVer2Versions.Distinct().Count())
+            {
+                versionFound = package.Versions
+                    .Select((p) => p.Version.Split('+')[0])
+                    .Where((p) => string.Equals(p, version, StringComparison.OrdinalIgnoreCase))
+                    .FirstOrDefault();
+            }
+
+            versionFound ??= package.Version;
+        }
 
         if (!string.Equals(versionFound, version, StringComparison.OrdinalIgnoreCase))
         {

--- a/src/Costellobot/styles/main.css
+++ b/src/Costellobot/styles/main.css
@@ -83,7 +83,7 @@ textarea.form-payload {
     color: #fff;
 }
 
-@media (min-width: 1200px) {
+@media (width >= 1200px) {
     code.webhook-content {
         font-size: initial;
     }

--- a/tests/Costellobot.Tests/Bundles/nuget-search.json
+++ b/tests/Costellobot.Tests/Bundles/nuget-search.json
@@ -414,6 +414,51 @@
       }
     },
     {
+      "comment": "NuGet search result for Octokit.Webhooks.AspNetCore",
+      "uri": "https://azuresearch-usnc.nuget.org/query?prerelease=true&q=PackageId%3AOctokit.Webhooks.AspNetCore&semVerLevel=2.0.0&take=1",
+      "contentFormat": "json",
+      "contentJson": {
+        "@context": {
+          "@vocab": "http://schema.nuget.org/schema#",
+          "@base": "https://api.nuget.org/v3/registration5-gz-semver2/"
+        },
+        "totalHits": 1,
+        "data": [
+          {
+            "@id": "https://api.nuget.org/v3/registration5-gz-semver2/octokit.webhooks.aspnetcore/index.json",
+            "@type": "Package",
+            "registration": "https://api.nuget.org/v3/registration5-gz-semver2/octokit.webhooks.aspnetcore/index.json",
+            "id": "Octokit.Webhooks.AspNetCore",
+            "version": "1.4.0+build.648",
+            "description": "GitHub webhook events toolset for .NET",
+            "summary": "",
+            "title": "Octokit.Webhooks.AspNetCore",
+            "iconUrl": "https://api.nuget.org/v3-flatcontainer/octokit.webhooks.aspnetcore/1.4.0/icon",
+            "licenseUrl": "https://www.nuget.org/packages/Octokit.Webhooks.AspNetCore/1.4.0/license",
+            "projectUrl": "https://github.com/octokit/webhooks.net",
+            "tags": [ "Octokit", "GitHub", "Webhooks" ],
+            "authors": [ "Octokit Contributors" ],
+            "owners": [ "GitHub", "kfcampbell" ],
+            "totalDownloads": 27573,
+            "verified": true,
+            "packageTypes": [ { "name": "Dependency" } ],
+            "versions": [
+              {
+                "version": "1.3.5+build.378",
+                "downloads": 6347,
+                "@id": "https://api.nuget.org/v3/registration5-gz-semver2/octokit.webhooks.aspnetcore/1.3.5.json"
+              },
+              {
+                "version": "1.4.0+build.648",
+                "downloads": 1,
+                "@id": "https://api.nuget.org/v3/registration5-gz-semver2/octokit.webhooks.aspnetcore/1.4.0.json"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
       "comment": "NuGet search result for foo",
       "uri": "https://azuresearch-usnc.nuget.org/query?prerelease=true&q=PackageId%3Afoo&semVerLevel=2.0.0&take=1",
       "contentFormat": "json",

--- a/tests/Costellobot.Tests/Registries/NuGetPackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/NuGetPackageRegistryTests.cs
@@ -15,6 +15,7 @@ public static class NuGetPackageRegistryTests
     [InlineData("Microsoft.AspNetCore.Mvc.Testing", "6.0.7", new[] { "aspnet", "Microsoft" })]
     [InlineData("Newtonsoft.Json", "13.0.1", new[] { "dotnetfoundation", "jamesnk", "newtonsoft" })]
     [InlineData("Octokit.GraphQL", "0.1.9-beta", new[] { "GitHub", "grokys", "jcansdale", "nickfloyd", "StanleyGoldman" })]
+    [InlineData("Octokit.Webhooks.AspNetCore", "1.4.0", new[] { "GitHub", "kfcampbell" })]
     [InlineData("foo", "1.0.0", new string[0])]
     public static async Task Can_Get_Package_Owners(string id, string version, string[] expected)
     {


### PR DESCRIPTION
If a NuGet package's underlying version uses SemVer 2.0 but it is installed in the project in `x.y.z` format, assume the version is the same as the SemVer 2.0 package for that version if there is exactly one such package so that the package ownership can be determined correctly.
