### PR TITLE
Exclude coverage from publish

### DIFF
--- a/src/Costellobot/Costellobot.csproj
+++ b/src/Costellobot/Costellobot.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Polly" />
   </ItemGroup>
   <ItemGroup>
-    <Content Update=".prettierrc.json;package.json;package-lock.json;tsconfig.json" CopyToPublishDirectory="Never" />
+    <Content Update=".prettierrc.json;coverage\**;package.json;package-lock.json;tsconfig.json" CopyToPublishDirectory="Never" />
     <None Remove="scripts\ts\**\*.ts" />
     <TypeScriptCompile Include="scripts\ts\**\*.ts" />
   </ItemGroup>


### PR DESCRIPTION
Do not include the JavaScript coverage in the publish output.
