### PR TITLE
.NET 8 preparation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ on:
 env:
   APPLICATION_URL_PROD: https://costellobot.martincostello.com
   AZURE_WEBAPP_NAME: costellobotmartincostello
-  AZURE_WEBAPP_PACKAGE_PATH: ./artifacts/publish
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_GENERATE_ASPNET_CERTIFICATE: false
   DOTNET_MULTILEVEL_LOOKUP: 0
@@ -23,6 +22,7 @@ env:
   DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
   FORCE_COLOR: 1
   NUGET_XMLDOC_MODE: skip
+  PUBLISH_RUNTIME: win10-x64
   TERM: xterm
 
 permissions:
@@ -82,7 +82,7 @@ jobs:
 
     - name: Build, Test and Publish
       shell: pwsh
-      run: ./build.ps1 -Runtime win10-x64
+      run: ./build.ps1 -Runtime "${{ env.PUBLISH_RUNTIME }}"
 
     - uses: codecov/codecov-action@40a12dcee2df644d47232dde008099a3e9e4f865 # v3.1.2
       name: Upload coverage to Codecov
@@ -92,10 +92,11 @@ jobs:
 
     - name: Publish artifacts
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-      if: ${{ runner.os == 'Windows' }}
+      if: ${{ runner.os == 'Windows' && success() }}
       with:
         name: webapp
-        path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+        path: ./artifacts/publish
+        if-no-files-found: error
 
     - name: Publish screenshots
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -83,3 +83,4 @@ jobs:
       with:
         name: lighthouse
         path: ${{ github.workspace }}/artifacts
+        if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.artifacts
 .dotnetcli
 .idea
 .metadata

--- a/tests/Costellobot.Tests/Infrastructure/BrowserFixture.cs
+++ b/tests/Costellobot.Tests/Infrastructure/BrowserFixture.cs
@@ -9,6 +9,7 @@ namespace MartinCostello.Costellobot.Infrastructure;
 public class BrowserFixture
 {
     private const string VideosDirectory = "videos";
+    private const string AssetsDirectory = ".";
 
     public BrowserFixture(ITestOutputHelper outputHelper)
         : this(new(), outputHelper)
@@ -72,7 +73,7 @@ public class BrowserFixture
             if (Options.CaptureTrace)
             {
                 string traceName = GenerateFileName(activeTestName, ".zip");
-                string path = Path.Combine("traces", traceName);
+                string path = Path.Combine(AssetsDirectory, "traces", traceName);
 
                 await context.Tracing.StopAsync(new() { Path = path });
             }
@@ -148,7 +149,7 @@ public class BrowserFixture
         try
         {
             string fileName = GenerateFileName(testName, ".png");
-            string path = Path.Combine("screenshots", fileName);
+            string path = Path.Combine(AssetsDirectory, "screenshots", fileName);
 
             await page.ScreenshotAsync(new() { Path = path });
 
@@ -170,7 +171,7 @@ public class BrowserFixture
         try
         {
             string fileName = GenerateFileName(testName, ".webm");
-            string path = Path.Combine(VideosDirectory, fileName);
+            string path = Path.Combine(AssetsDirectory, VideosDirectory, fileName);
 
             await page.CloseAsync();
             await page.Video.SaveAsAsync(path);


### PR DESCRIPTION
Port changes from #429 to minimise differences:

- Remove some environment variables from build scripts.
- Fail build if certain artifacts cannot be found.
- Ignore missing lighthouse artifacts.
