### PR TITLE
Approve deployments

### DIFF
--- a/src/Costellobot/Octokit/IWorkflowRunsClient.cs
+++ b/src/Costellobot/Octokit/IWorkflowRunsClient.cs
@@ -9,4 +9,8 @@ public interface IWorkflowRunsClient
         string owner,
         string name,
         long runId);
+
+    Task ReviewCustomProtectionRuleAsync(
+        string deploymentCallbackUrl,
+        ReviewDeploymentProtectionRule review);
 }

--- a/src/Costellobot/Octokit/ReviewDeploymentProtectionRule.cs
+++ b/src/Costellobot/Octokit/ReviewDeploymentProtectionRule.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace Octokit;
+
+public sealed class ReviewDeploymentProtectionRule
+{
+    public ReviewDeploymentProtectionRule(string environmentName, PendingDeploymentReviewState? state, string? comment)
+    {
+        EnvironmentName = environmentName;
+        State = state;
+        Comment = comment;
+    }
+
+    public string EnvironmentName { get; }
+
+    public StringEnum<PendingDeploymentReviewState>? State { get; }
+
+    public string? Comment { get; }
+}

--- a/src/Costellobot/Octokit/WorkflowRunsClient.cs
+++ b/src/Costellobot/Octokit/WorkflowRunsClient.cs
@@ -21,4 +21,18 @@ public sealed class WorkflowRunsClient : IWorkflowRunsClient
         var uri = new Uri($"repos/{owner}/{name}/actions/runs/{runId}/pending_deployments", UriKind.Relative);
         return await _connection.GetAll<PendingDeployment>(uri);
     }
+
+    public async Task ReviewCustomProtectionRuleAsync(
+        string deploymentCallbackUrl,
+        ReviewDeploymentProtectionRule review)
+    {
+        // See https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#review-custom-deployment-protection-rules-for-a-workflow-run
+        var uri = new Uri(deploymentCallbackUrl, UriKind.Absolute);
+        var status = await _connection.Connection.Post(uri, review, "application/vnd.github+json");
+
+        if (status is not System.Net.HttpStatusCode.NoContent)
+        {
+            throw new ApiException("Failed to review custom deployment protection rule.", status);
+        }
+    }
 }


### PR DESCRIPTION
Unconditionally approve any deployments associated with a `deployment_protection_rule` payload.

This is currently just for test purposes, hence why it's unconditional.
