### PR TITLE
Add tests for deployment_protection_rule

### DIFF
--- a/tests/Costellobot.Tests/Drivers/DeploymentProtectionRuleDriver.cs
+++ b/tests/Costellobot.Tests/Drivers/DeploymentProtectionRuleDriver.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography;
+using MartinCostello.Costellobot.Builders;
+
+using static MartinCostello.Costellobot.Builders.GitHubFixtures;
+
+namespace MartinCostello.Costellobot.Drivers;
+
+public sealed class DeploymentProtectionRuleDriver
+{
+    public DeploymentProtectionRuleDriver(DeploymentBuilder deployment)
+    {
+        Owner = CreateUser();
+        Repository = Owner.CreateRepository();
+        Deployment = deployment;
+        Environment = Deployment.Environment ?? "production";
+    }
+
+    public DeploymentBuilder Deployment { get; set; }
+
+    public string Environment { get; set; }
+
+    public string Event { get; set; } = "push";
+
+    public UserBuilder Owner { get; set; }
+
+    public IList<PullRequestBuilder> PullRequests { get; set; } = new List<PullRequestBuilder>();
+
+    public RepositoryBuilder Repository { get; set; }
+
+    public long RunId { get; set; } = RandomNumberGenerator.GetInt32(int.MaxValue);
+
+    public object CreateWebhook(string action)
+    {
+        return new
+        {
+            action,
+            environment = Environment,
+            @event = Event,
+            deployment_callback_url = $"https://api.github.com/repos/{Repository.Owner.Login}/{Repository.Name}/actions/runs/{RunId}/deployment_protection_rule",
+            deployment = Deployment.Build(),
+            pull_requests = PullRequests.Build(),
+            repository = Repository.Build(),
+            installation = new
+            {
+                id = long.Parse(InstallationId, CultureInfo.InvariantCulture),
+            },
+        };
+    }
+}

--- a/tests/Costellobot.Tests/Handlers/DeploymentProtectionRuleHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/DeploymentProtectionRuleHandlerTests.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Net;
+using JustEat.HttpClientInterception;
+using MartinCostello.Costellobot.Drivers;
+using MartinCostello.Costellobot.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using static MartinCostello.Costellobot.Builders.GitHubFixtures;
+
+namespace MartinCostello.Costellobot.Handlers;
+
+[Collection(AppCollection.Name)]
+public sealed class DeploymentProtectionRuleHandlerTests : IntegrationTests<AppFixture>
+{
+    public DeploymentProtectionRuleHandlerTests(AppFixture fixture, ITestOutputHelper outputHelper)
+        : base(fixture, outputHelper)
+    {
+    }
+
+    [Fact]
+    public async Task Deployment_Is_Approved()
+    {
+        // Arrange
+        Fixture.ApproveDeployments();
+
+        var deployment = CreateDeployment("production");
+        var driver = new DeploymentProtectionRuleDriver(deployment);
+
+        RegisterGetAccessToken();
+        var deploymentApproved = RegisterApprovePendingDeployment(driver);
+
+        // Act
+        using var response = await PostWebhookAsync(driver);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await deploymentApproved.Task.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task Deployment_Is_Not_Approved_If_Deployment_Approval_Disabled()
+    {
+        // Arrange
+        Fixture.ApproveDeployments(false);
+
+        var deployment = CreateDeployment("production");
+        var driver = new DeploymentProtectionRuleDriver(deployment);
+
+        var deploymentApproved = RegisterApprovePendingDeployment(driver);
+
+        // Act
+        using var response = await PostWebhookAsync(driver);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await AssertTaskNotRun(deploymentApproved);
+    }
+
+    [Fact]
+    public async Task Handler_Ignores_Events_That_Are_Not_Deployment_Statuses()
+    {
+        // Arrange
+        var target = Fixture.Services.GetRequiredService<DeploymentProtectionRuleHandler>();
+        var message = new Octokit.Webhooks.Events.IssueComment.IssueCommentCreatedEvent();
+
+        // Act
+        await Should.NotThrowAsync(() => target.HandleAsync(message));
+    }
+
+    private async Task<HttpResponseMessage> PostWebhookAsync(DeploymentProtectionRuleDriver driver, string action = "requested")
+    {
+        var value = driver.CreateWebhook(action);
+        return await PostWebhookAsync("deployment_protection_rule", value);
+    }
+
+    private TaskCompletionSource RegisterApprovePendingDeployment(DeploymentProtectionRuleDriver driver)
+    {
+        var deploymentApproved = new TaskCompletionSource();
+
+        RegisterApproveDeploymentProtectionRule(
+            driver,
+            (p) => p.WithInterceptionCallback((_) => deploymentApproved.SetResult()));
+
+        return deploymentApproved;
+    }
+
+    private void RegisterApproveDeploymentProtectionRule(
+        DeploymentProtectionRuleDriver driver,
+        Action<HttpRequestInterceptionBuilder> configure)
+    {
+        var builder = CreateDefaultBuilder()
+            .Requests()
+            .ForPost()
+            .ForPath($"/repos/{driver.Repository.Owner.Login}/{driver.Repository.Name}/actions/runs/{driver.RunId}/deployment_protection_rule")
+            .Responds()
+            .WithStatus(HttpStatusCode.NoContent);
+
+        configure(builder);
+
+        builder.RegisterWith(Fixture.Interceptor);
+    }
+}

--- a/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
@@ -27,10 +27,9 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
 
         var driver = new DeploymentStatusDriver(
             (repo) => repo.CreateCommit(),
-            (repo) => CreateTrustedCommit(repo));
+            CreateTrustedCommit);
 
-        driver.WithPendingDeployment(
-            (commit) => CreateDeployment(commit));
+        driver.WithPendingDeployment(CreateDeployment);
 
         driver.WithActiveDeployment();
         driver.WithInactiveDeployment();
@@ -60,10 +59,9 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
 
         var driver = new DeploymentStatusDriver(
             (repo) => repo.CreateCommit(),
-            (repo) => CreateTrustedCommit(repo));
+            CreateTrustedCommit);
 
-        driver.WithPendingDeployment(
-            (commit) => CreateDeployment(commit));
+        driver.WithPendingDeployment(CreateDeployment);
 
         driver.WithActiveDeployment();
         driver.WithInactiveDeployment();
@@ -103,10 +101,9 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
 
         var driver = new DeploymentStatusDriver(
             (repo) => repo.CreateCommit(),
-            (repo) => CreateTrustedCommit(repo));
+            CreateTrustedCommit);
 
-        driver.WithPendingDeployment(
-            (commit) => CreateDeployment(commit));
+        driver.WithPendingDeployment(CreateDeployment);
 
         driver.WithActiveDeployment();
         driver.WithInactiveDeployment();
@@ -143,10 +140,9 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
 
         var driver = new DeploymentStatusDriver(
             (repo) => repo.CreateCommit(),
-            (repo) => CreateTrustedCommit(repo));
+            CreateTrustedCommit);
 
-        driver.WithPendingDeployment(
-            (commit) => CreateDeployment(commit));
+        driver.WithPendingDeployment(CreateDeployment);
 
         driver.WithActiveDeployment();
         driver.WithInactiveDeployment();
@@ -186,10 +182,10 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
 
         var driver = new DeploymentStatusDriver(
             (repo) => repo.CreateCommit(),
-            (repo) => CreateTrustedCommit(repo));
+            CreateTrustedCommit);
 
         driver.WithPendingDeployment(
-            (commit) => CreateDeployment(commit),
+            CreateDeployment,
             () => CreateDeploymentStatus(state));
 
         var deploymentApproved = RegisterApprovePendingDeployment(driver);
@@ -211,8 +207,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
 
         var driver = new DeploymentStatusDriver();
 
-        driver.WithPendingDeployment(
-            (commit) => CreateDeployment(commit));
+        driver.WithPendingDeployment(CreateDeployment);
 
         var deploymentApproved = RegisterApprovePendingDeployment(driver);
 
@@ -385,11 +380,10 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
         Fixture.ApproveDeployments();
 
         var driver = new DeploymentStatusDriver(
-            (repo) => CreateTrustedCommit(repo),
-            (repo) => CreateTrustedCommit(repo));
+            CreateTrustedCommit,
+            CreateTrustedCommit);
 
-        driver.WithPendingDeployment(
-            (commit) => CreateDeployment(commit));
+        driver.WithPendingDeployment(CreateDeployment);
 
         driver.WithActiveDeployment();
         driver.WithInactiveDeployment();
@@ -417,11 +411,10 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
         Fixture.ApproveDeployments();
 
         var driver = new DeploymentStatusDriver(
-            (repo) => CreateTrustedCommit(repo),
-            (repo) => CreateTrustedCommit(repo));
+            CreateTrustedCommit,
+            CreateTrustedCommit);
 
-        driver.WithPendingDeployment(
-            (commit) => CreateDeployment(commit));
+        driver.WithPendingDeployment(CreateDeployment);
 
         driver.WithActiveDeployment();
         driver.WithInactiveDeployment();
@@ -462,8 +455,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
                 return commit;
             });
 
-        driver.WithPendingDeployment(
-            (commit) => CreateDeployment(commit));
+        driver.WithPendingDeployment(CreateDeployment);
 
         driver.WithActiveDeployment();
         driver.WithInactiveDeployment();
@@ -497,11 +489,10 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
         Fixture.ApproveDeployments();
 
         var driver = new DeploymentStatusDriver(
-            (repo) => CreateTrustedCommit(repo),
-            (repo) => CreateTrustedCommit(repo));
+            CreateTrustedCommit,
+            CreateTrustedCommit);
 
-        driver.WithPendingDeployment(
-            (commit) => CreateDeployment(commit));
+        driver.WithPendingDeployment(CreateDeployment);
 
         driver.WithActiveDeployment();
         driver.WithInactiveDeployment();
@@ -541,10 +532,9 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
 
         var driver = new DeploymentStatusDriver(
             (repo) => repo.CreateCommit(),
-            (repo) => CreateTrustedCommit(repo));
+            CreateTrustedCommit);
 
-        driver.WithPendingDeployment(
-            (commit) => CreateDeployment(commit));
+        driver.WithPendingDeployment(CreateDeployment);
 
         driver.WithActiveDeployment();
         driver.WithInactiveDeployment();


### PR DESCRIPTION
- Add integration tests for `deployment_protection_rule`.
- Add log message when deployment approved.
- Only approve deployments when approval is enabled.
- Tidy-up some Visual Studio code suggestions.
