### PR TITLE
Improve logging

### DIFF
--- a/src/Costellobot/ClientLogMessage.cs
+++ b/src/Costellobot/ClientLogMessage.cs
@@ -16,4 +16,6 @@ public sealed class ClientLogMessage
     public string Message { get; init; } = string.Empty;
 
     public DateTimeOffset Timestamp { get; init; }
+
+    public string Exception { get; init; } = string.Empty;
 }

--- a/src/Costellobot/ClientLogger.cs
+++ b/src/Costellobot/ClientLogger.cs
@@ -60,6 +60,7 @@ public sealed class ClientLogger : ILogger
             Level = levelString,
             EventId = eventId.Id,
             EventName = eventId.Name,
+            Exception = exception?.ToString().ReplaceLineEndings("\n") ?? string.Empty,
             Message = formatter(state, exception),
             Timestamp = _clock.GetCurrentInstant().ToDateTimeOffset(),
         };

--- a/src/Costellobot/Pages/Webhooks/Debug.cshtml
+++ b/src/Costellobot/Pages/Webhooks/Debug.cshtml
@@ -9,6 +9,7 @@
       <label for="webhook-event" class="form-label">Event</label>
       <select id="webhook-event" class="form-select text-webhook" autofocus="autofocus" aria-label="Event" aria-describedby="webhook-event-help">
         <option value="check_suite">check_suite</option>
+        <option value="deployment_protection_rule">deployment_protection_rule</option>
         <option value="deployment_status">deployment_status</option>
         <option value="installation">installation</option>
         <option value="pull_request" selected>pull_request</option>

--- a/src/Costellobot/scripts/App.ts
+++ b/src/Costellobot/scripts/App.ts
@@ -216,6 +216,12 @@ export class App {
         const timestampString = timestamp.toISOString();
         this.logsContainer.textContent += `${timestampString} [${logEntry.level}] ${logEntry.category}[${event}]: ${logEntry.message}`;
 
+        if (logEntry.exception !== '') {
+            this.logsContainer.textContent += '\n';
+            this.logsContainer.textContent += logEntry.exception;
+            this.logsContainer.textContent += '\n';
+        }
+
         if (this.logsAutoscroll.checked) {
             this.logsContainer.scrollTop = this.logsContainer.scrollHeight;
         }
@@ -273,6 +279,7 @@ interface LogEntry {
     level: string;
     eventId: number;
     eventName?: string;
+    exception?: string;
     message: string;
     timestamp: string;
 }


### PR DESCRIPTION
- Include exceptions in the SignalR log messages as they aren't being included by the default formatter.
- Add `deployment_protection_rule` to the dropdown of event payload types.