### PR TITLE
Revert "Bump martincostello/update-dotnet-sdk from 2.1.4 to 2.2.0"

### DIFF
--- a/.github/workflows/update-dotnet-sdk.yml
+++ b/.github/workflows/update-dotnet-sdk.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   update-sdk:
-    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@6cfd047b0c2ce72ea0e22708bc1918a3d912c050 # v2.2.0
+    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@bba9c5d796cf9e84046ae0cb42f7dd33bde568f3 # v2.1.4
     with:
       labels: "dependencies,.NET"
       user-email: ${{ vars.GIT_COMMIT_USER_EMAIL }}


### PR DESCRIPTION
Reverts martincostello/costellobot#578 so I can test an automated flow to check for a bug with deployment protection hooks.