### PR TITLE
Handle the push webhook

### DIFF
--- a/src/Costellobot/GitHubExtensions.cs
+++ b/src/Costellobot/GitHubExtensions.cs
@@ -86,6 +86,7 @@ public static class GitHubExtensions
         services.AddTransient<DeploymentProtectionRuleHandler>();
         services.AddTransient<DeploymentStatusHandler>();
         services.AddTransient<PullRequestHandler>();
+        services.AddTransient<PushHandler>();
 
         services.AddHostedService<GitHubWebhookService>();
 

--- a/src/Costellobot/Handlers/HandlerFactory.cs
+++ b/src/Costellobot/Handlers/HandlerFactory.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using Octokit.Webhooks;
+
 namespace MartinCostello.Costellobot.Handlers;
 
 public sealed class HandlerFactory : IHandlerFactory
@@ -16,10 +18,11 @@ public sealed class HandlerFactory : IHandlerFactory
     {
         return eventType switch
         {
-            "check_suite" => _serviceProvider.GetRequiredService<CheckSuiteHandler>(),
-            "deployment_protection_rule" => _serviceProvider.GetRequiredService<DeploymentProtectionRuleHandler>(),
-            "deployment_status" => _serviceProvider.GetRequiredService<DeploymentStatusHandler>(),
-            "pull_request" => _serviceProvider.GetRequiredService<PullRequestHandler>(),
+            WebhookEventType.CheckSuite => _serviceProvider.GetRequiredService<CheckSuiteHandler>(),
+            WebhookEventType.DeploymentProtectionRule => _serviceProvider.GetRequiredService<DeploymentProtectionRuleHandler>(),
+            WebhookEventType.DeploymentStatus => _serviceProvider.GetRequiredService<DeploymentStatusHandler>(),
+            WebhookEventType.PullRequest => _serviceProvider.GetRequiredService<PullRequestHandler>(),
+            WebhookEventType.Push => _serviceProvider.GetRequiredService<PushHandler>(),
             _ => NullHandler.Instance,
         };
     }

--- a/src/Costellobot/Handlers/PushHandler.cs
+++ b/src/Costellobot/Handlers/PushHandler.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Octokit;
+using Octokit.Webhooks;
+using Octokit.Webhooks.Events;
+
+namespace MartinCostello.Costellobot.Handlers;
+
+public sealed partial class PushHandler : IHandler
+{
+    private const string DefaultBranch = "refs/heads/main";
+    private const string DispatchDestination = "martincostello/github-automation";
+
+    private readonly IGitHubClient _client;
+    private readonly ILogger _logger;
+
+    public PushHandler(
+        IGitHubClientForInstallation client,
+        ILogger<PushHandler> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    public async Task HandleAsync(WebhookEvent message)
+    {
+        if (message is not PushEvent push ||
+            push.Repository is not { } repo ||
+            push.Commits is not { } commits ||
+            push.Created ||
+            push.Deleted ||
+            !string.Equals(push.Ref, DefaultBranch, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var filesChanged = new HashSet<string>();
+
+        foreach (var commit in commits)
+        {
+            foreach (var file in commit.Added)
+            {
+                filesChanged.Add(file);
+            }
+
+            foreach (var file in commit.Modified)
+            {
+                filesChanged.Add(file);
+            }
+        }
+
+        if (DotNetDependencyFileChanged(filesChanged))
+        {
+            Log.CreatedRepositoryDispatchForPush(_logger, repo.Owner.Login, repo.Name, push.Ref);
+            await CreateDispatchAsync(repo.FullName);
+        }
+    }
+
+    private static bool DotNetDependencyFileChanged(HashSet<string> filesChanged)
+    {
+        if (filesChanged.Contains("global.json"))
+        {
+            // .NET SDK updated
+            return true;
+        }
+
+        /*
+        if (filesChanged.Contains("Directory.Packages.props"))
+        {
+            // NuGet package(s) added/removed or version(s) updated
+            return true;
+        }
+
+        if (filesChanged.Any((p) => p.EndsWith(".csproj", StringComparison.Ordinal)))
+        {
+            // NuGet dependencies possibly changed
+            return true;
+        }
+        */
+
+        return false;
+    }
+
+    private async Task CreateDispatchAsync(string repository)
+    {
+        // See https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event
+        var dispatch = new
+        {
+            event_type = "dotnet_dependencies_updated",
+            client_payload = new { repository },
+        };
+
+        var uri = new Uri($"repos/{DispatchDestination}/dispatches", UriKind.Relative);
+        var status = await _client.Connection.Post(uri, dispatch, "application/vnd.github+json");
+
+        if (status is not System.Net.HttpStatusCode.NoContent)
+        {
+            throw new ApiException($"Failed to create repository dispatch event for push to {repository}.", status);
+        }
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    private static partial class Log
+    {
+        [LoggerMessage(
+           EventId = 1,
+           Level = LogLevel.Information,
+           Message = "Creating repository dispatch for push to {Owner}/{Repository} for ref {Reference}.")]
+        public static partial void CreatedRepositoryDispatchForPush(
+            ILogger logger,
+            string? owner,
+            string? repository,
+            string? reference);
+    }
+}

--- a/tests/Costellobot.Tests/Builders/GitCommitBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/GitCommitBuilder.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Costellobot.Builders;
+
+public sealed class GitCommitBuilder : ResponseBuilder
+{
+    public GitCommitBuilder(UserBuilder author)
+    {
+        Author = author;
+    }
+
+    public IList<string> Added { get; set; } = new List<string>();
+
+    public UserBuilder Author { get; set; }
+
+    public UserBuilder? Committer { get; set; }
+
+    public string TreeId { get; set; } = RandomString();
+
+    public string Message { get; set; } = RandomString();
+
+    public IList<string> Modified { get; set; } = new List<string>();
+
+    public IList<string> Removed { get; set; } = new List<string>();
+
+    public override object Build()
+    {
+        return new
+        {
+            id = Id.ToString(CultureInfo.InvariantCulture),
+            tree_id = TreeId,
+            message = Message,
+            author = Author.Build(),
+            committer = (Committer ?? Author).Build(),
+            added = Added,
+            removed = Removed,
+            modified = Modified,
+        };
+    }
+}

--- a/tests/Costellobot.Tests/Builders/GitHubCommitBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/GitHubCommitBuilder.cs
@@ -12,6 +12,8 @@ public sealed class GitHubCommitBuilder : ResponseBuilder
 
     public UserBuilder? Author { get; set; }
 
+    public UserBuilder? Committer { get; set; }
+
     public string Message { get; set; } = RandomString();
 
     public IList<string> Parents { get; set; } = new List<string>();
@@ -25,10 +27,7 @@ public sealed class GitHubCommitBuilder : ResponseBuilder
         return new
         {
             author = (Author ?? Repository.Owner).Build(),
-            commit = new
-            {
-                message = Message,
-            },
+            commit = new GitCommitBuilder(Author ?? Repository.Owner) { Message = Message }.Build(),
             parents = Parents.Select((p) => new { sha = p }).ToArray(),
             sha = Sha,
         };

--- a/tests/Costellobot.Tests/Drivers/PushDriver.cs
+++ b/tests/Costellobot.Tests/Drivers/PushDriver.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using MartinCostello.Costellobot.Builders;
+
+using static MartinCostello.Costellobot.Builders.GitHubFixtures;
+
+namespace MartinCostello.Costellobot.Drivers;
+
+public sealed class PushDriver
+{
+    public PushDriver()
+    {
+        Owner = Sender = User = CreateUser();
+        Repository = Owner.CreateRepository();
+    }
+
+    public bool Created { get; set; }
+
+    public IList<GitCommitBuilder> Commits { get; set; } = new List<GitCommitBuilder>();
+
+    public bool Deleted { get; set; }
+
+    public bool Forced { get; set; }
+
+    public UserBuilder Owner { get; set; }
+
+    public string Ref { get; set; } = "refs/heads/main";
+
+    public RepositoryBuilder Repository { get; set; }
+
+    public UserBuilder Sender { get; set; }
+
+    public UserBuilder User { get; set; }
+
+    public object CreateWebhook()
+    {
+        return new
+        {
+            @ref = Ref,
+            repository = Repository.Build(),
+            installation = new
+            {
+                id = long.Parse(InstallationId, CultureInfo.InvariantCulture),
+            },
+            sender = Sender.Build(),
+            created = Created,
+            deleted = Deleted,
+            forced = Forced,
+            commits = Commits.Build(),
+        };
+    }
+}

--- a/tests/Costellobot.Tests/Handlers/HandlerFactoryTests.cs
+++ b/tests/Costellobot.Tests/Handlers/HandlerFactoryTests.cs
@@ -20,6 +20,7 @@ public static class HandlerFactoryTests
     [InlineData("issues", typeof(NullHandler))]
     [InlineData("ping", typeof(NullHandler))]
     [InlineData("pull_request", typeof(PullRequestHandler))]
+    [InlineData("push", typeof(PushHandler))]
     public static void Create_Creates_Correct_Handler_Type(string? eventType, Type expected)
     {
         // Arrange
@@ -73,6 +74,14 @@ public static class HandlerFactoryTests
                     commitAnalyzer,
                     webhookOptions,
                     NullLoggerFactory.Instance.CreateLogger<PullRequestHandler>());
+            });
+
+        mock.Setup((p) => p.GetService(typeof(PushHandler)))
+            .Returns(() =>
+            {
+                return new PushHandler(
+                    gitHubClient,
+                    NullLoggerFactory.Instance.CreateLogger<PushHandler>());
             });
 
         var target = new HandlerFactory(mock.Object);

--- a/tests/Costellobot.Tests/Handlers/PushHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PushHandlerTests.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Net;
+using System.Text.Json;
+using JustEat.HttpClientInterception;
+using MartinCostello.Costellobot.Drivers;
+using MartinCostello.Costellobot.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MartinCostello.Costellobot.Handlers;
+
+[Collection(AppCollection.Name)]
+public class PushHandlerTests : IntegrationTests<AppFixture>
+{
+    public PushHandlerTests(AppFixture fixture, ITestOutputHelper outputHelper)
+        : base(fixture, outputHelper)
+    {
+    }
+
+    [Theory]
+    [InlineData(new string[0], new[] { "global.json" })]
+    [InlineData(new[] { "global.json" }, new string[0])]
+    public async Task Repository_Dispatch_Is_Created_If_DotNet_Dependency_File_Added_Or_Modified_On_Main_Branch(string[] added, string[] modified)
+    {
+        // Arrange
+        var driver = new PushDriver();
+        driver.Commits.Add(new(new("some-person"))
+        {
+            Added = added,
+            Modified = modified,
+        });
+
+        RegisterGetAccessToken();
+
+        var dispatched = RegisterDispatch(driver);
+
+        // Act
+        using var response = await PostWebhookAsync(driver);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await dispatched.Task.WaitAsync(TimeSpan.FromSeconds(1));
+    }
+
+    [Theory]
+    [InlineData("refs/heads/main", false, false, new string[0], new string[0], new[] { "global.json" })]
+    [InlineData("refs/heads/some-branch", false, false, new string[0], new[] { "global.json" }, new string[0])]
+    [InlineData("refs/heads/main", true, false, new string[0], new[] { "global.json" }, new string[0])]
+    [InlineData("refs/heads/main", false, true, new string[0], new[] { "global.json" }, new string[0])]
+    [InlineData("refs/heads/main", false, false, new string[0], new[] { "something.json" }, new string[0])]
+    [InlineData("refs/heads/main", false, false, new[] { "tests/assets/global.json" }, new string[0], new string[0])]
+    [InlineData("refs/heads/main", false, false, new string[0], new[] { "tests/assets/global.json" }, new string[0])]
+    public async Task Repository_Dispatch_Is_Not_Created_If_DotNet_Dependency_File_Added_Or_Modified_On_Main_Branch(
+        string reference,
+        bool created,
+        bool deleted,
+        string[] added,
+        string[] modified,
+        string[] removed)
+    {
+        // Arrange
+        var driver = new PushDriver()
+        {
+            Ref = reference,
+            Created = created,
+            Deleted = deleted,
+        };
+
+        driver.Commits.Add(new(new("some-person"))
+        {
+            Added = added,
+            Modified = modified,
+            Removed = removed,
+        });
+
+        RegisterGetAccessToken();
+
+        var dispatched = RegisterDispatch(driver);
+
+        // Act
+        using var response = await PostWebhookAsync(driver);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await AssertTaskNotRun(dispatched);
+    }
+
+    [Fact]
+    public async Task Handler_Ignores_Events_That_Are_Not_Pushes()
+    {
+        // Arrange
+        var target = Fixture.Services.GetRequiredService<PushHandler>();
+        var message = new Octokit.Webhooks.Events.IssueComment.IssueCommentCreatedEvent();
+
+        // Act
+        await Should.NotThrowAsync(() => target.HandleAsync(message));
+    }
+
+    private async Task<HttpResponseMessage> PostWebhookAsync(PushDriver driver)
+    {
+        var value = driver.CreateWebhook();
+        return await PostWebhookAsync("push", value);
+    }
+
+    private TaskCompletionSource RegisterDispatch(PushDriver driver)
+    {
+        var dispatched = new TaskCompletionSource();
+
+        CreateDefaultBuilder()
+            .Requests()
+            .ForPost()
+            .ForPath($"/repos/martincostello/github-automation/dispatches")
+            .ForContent(async (request) =>
+            {
+                request.ShouldNotBeNull();
+
+                byte[] body = await request.ReadAsByteArrayAsync();
+                using var document = JsonDocument.Parse(body);
+
+                var eventType = document.RootElement.GetProperty("event_type").GetString();
+
+                if (!string.Equals(eventType, "dotnet_dependencies_updated", StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                var clientPayload = document.RootElement.GetProperty("client_payload");
+
+                if (clientPayload.ValueKind != JsonValueKind.Object)
+                {
+                    return false;
+                }
+
+                var repository = clientPayload.GetProperty("repository").GetString();
+
+                return string.Equals(repository, $"{driver.Owner.Login}/{driver.Repository.Name}", StringComparison.Ordinal);
+            })
+            .Responds()
+            .WithStatus(HttpStatusCode.NoContent)
+            .WithInterceptionCallback((_) => dispatched.SetResult())
+            .RegisterWith(Fixture.Interceptor);
+
+        return dispatched;
+    }
+}


### PR DESCRIPTION
- Handle the push webhook to send a repository dispatch event to the `martincostello/github-automation` repository if the `global.json` file is added or edited in a repository that the bot has access to.
- Use `WebhookEventType` constants.
