### PR TITLE
Add dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
   open-pull-requests-limit: 99
 - package-ecosystem: npm
   directory: "/src/Costellobot"
+  groups:
+    patterns:
+      - "@babel/*"
+      - "@typescript-eslint/*"
   schedule:
     interval: daily
     time: "08:30"


### PR DESCRIPTION
Group updates for `@babel` and `@typescript-eslint` packages.

See [_Grouped version updates for Dependabot public beta_](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/).
