### PR TITLE
.NET 8 preparation

### DIFF
--- a/src/Costellobot/Program.cs
+++ b/src/Costellobot/Program.cs
@@ -4,6 +4,7 @@
 #pragma warning disable CA1852
 
 using System.IO.Compression;
+using System.Text.Json.Nodes;
 using MartinCostello.Costellobot;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.ResponseCompression;
@@ -97,19 +98,19 @@ app.UseAuthorization();
 app.MapAuthenticationRoutes();
 app.MapGitHubWebhooks("/github-webhook", app.Configuration["GitHub:WebhookSecret"] ?? string.Empty);
 
-app.MapGet("/version", () => new
+app.MapGet("/version", () => new JsonObject()
 {
-    branch = GitMetadata.Branch,
-    build = GitMetadata.BuildId,
-    commit = GitMetadata.Commit,
-    version = GitMetadata.Version,
-    _links = new
+    ["branch"] = GitMetadata.Branch,
+    ["build"] = GitMetadata.BuildId,
+    ["commit"] = GitMetadata.Commit,
+    ["version"] = GitMetadata.Version,
+    ["_links"] = new JsonObject()
     {
-        self = new { href = "https://costellobot.martincostello.com" },
-        repo = new { href = "https://github.com/martincostello/costellobot" },
-        branch = new { href = $"https://github.com/martincostello/costellobot/tree/{GitMetadata.Branch}" },
-        commit = new { href = $"https://github.com/martincostello/costellobot/commit/{GitMetadata.Commit}" },
-        deploy = new { href = $"https://github.com/martincostello/costellobot/actions/runs/{GitMetadata.BuildId}" },
+        ["self"] = new JsonObject() { ["href"] = "https://costellobot.martincostello.com" },
+        ["repo"] = new JsonObject() { ["href"] = "https://github.com/martincostello/costellobot" },
+        ["branch"] = new JsonObject() { ["href"] = $"https://github.com/martincostello/costellobot/tree/{GitMetadata.Branch}" },
+        ["commit"] = new JsonObject() { ["href"] = $"https://github.com/martincostello/costellobot/commit/{GitMetadata.Commit}" },
+        ["deploy"] = new JsonObject() { ["href"] = $"https://github.com/martincostello/costellobot/actions/runs/{GitMetadata.BuildId}" },
     },
 }).AllowAnonymous();
 

--- a/tests/Costellobot.Tests/Costellobot.Tests.csproj
+++ b/tests/Costellobot.Tests/Costellobot.Tests.csproj
@@ -37,7 +37,7 @@
     <CoverletOutput>$([System.IO.Path]::Combine($(OutputPath), 'coverage', 'coverage'))</CoverletOutput>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[*Tests]*,[xunit.*]*</Exclude>
-    <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
+    <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
     <Threshold>70</Threshold>
   </PropertyGroup>
 </Project>

--- a/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
@@ -48,7 +48,7 @@ public class PullRequestHandlerTests : IntegrationTests<AppFixture>
     {
         // Arrange
         Fixture.ApprovePullRequests();
-        Fixture.Interceptor.RegisterBundle(Path.Combine("Bundles", "nuget-search.json"));
+        await Fixture.Interceptor.RegisterBundleAsync(Path.Combine("Bundles", "nuget-search.json"));
 
         var driver = PullRequestDriver.ForDependabot()
             .WithCommitMessage(TrustedCommitMessage("Newtonsoft.Json", "13.0.1"));

--- a/tests/Costellobot.Tests/Registries/GitHubActionsPackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/GitHubActionsPackageRegistryTests.cs
@@ -22,9 +22,9 @@ public static class GitHubActionsPackageRegistryTests
         string owner = "some-org";
         string repository = "some-repo";
 
-        var options = new HttpClientInterceptorOptions()
-            .RegisterBundle(Path.Combine("Bundles", "github-refs.json"))
-            .ThrowsOnMissingRegistration();
+        var options = await new HttpClientInterceptorOptions()
+            .ThrowsOnMissingRegistration()
+            .RegisterBundleAsync(Path.Combine("Bundles", "github-refs.json"));
 
         var httpClient = new HttpClientAdapter(options.CreateHttpMessageHandler);
         var connection = new Connection(new("costellobot", "1.0.0"), httpClient);

--- a/tests/Costellobot.Tests/Registries/GitSubmodulePackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/GitSubmodulePackageRegistryTests.cs
@@ -18,9 +18,9 @@ public static class GitSubmodulePackageRegistryTests
         string owner = "dotnet";
         string repository = "aspnetcore";
 
-        var options = new HttpClientInterceptorOptions()
-            .RegisterBundle(Path.Combine("Bundles", "github-submodules.json"))
-            .ThrowsOnMissingRegistration();
+        var options = await new HttpClientInterceptorOptions()
+            .ThrowsOnMissingRegistration()
+            .RegisterBundleAsync(Path.Combine("Bundles", "github-submodules.json"));
 
         var adapter = new Octokit.Internal.HttpClientAdapter(options.CreateHttpMessageHandler);
         var connection = new Connection(new("costellobot", "1.0.0"), adapter);

--- a/tests/Costellobot.Tests/Registries/NpmPackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/NpmPackageRegistryTests.cs
@@ -18,9 +18,9 @@ public static class NpmPackageRegistryTests
         string owner = "some-org";
         string repository = "some-repo";
 
-        var options = new HttpClientInterceptorOptions()
-            .RegisterBundle(Path.Combine("Bundles", "npm-registry.json"))
-            .ThrowsOnMissingRegistration();
+        var options = await new HttpClientInterceptorOptions()
+            .ThrowsOnMissingRegistration()
+            .RegisterBundleAsync(Path.Combine("Bundles", "npm-registry.json"));
 
         using var client = options.CreateHttpClient();
 

--- a/tests/Costellobot.Tests/Registries/NuGetPackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/NuGetPackageRegistryTests.cs
@@ -23,9 +23,9 @@ public static class NuGetPackageRegistryTests
         string owner = "some-org";
         string repository = "some-repo";
 
-        var options = new HttpClientInterceptorOptions()
-            .RegisterBundle(Path.Combine("Bundles", "nuget-search.json"))
-            .ThrowsOnMissingRegistration();
+        var options = await new HttpClientInterceptorOptions()
+            .ThrowsOnMissingRegistration()
+            .RegisterBundleAsync(Path.Combine("Bundles", "nuget-search.json"));
 
         using var client = options.CreateHttpClient();
         using var cache = new MemoryCache(new MemoryCacheOptions());


### PR DESCRIPTION
- Use JsonNode to support AOT in the future.
- Exclude generated code from coverage metrics.
- Fix code analysis warnings identified in #725.
