### PR TITLE
Ignore pushes from non-C# repositories

### DIFF
--- a/src/Costellobot/Handlers/PushHandler.cs
+++ b/src/Costellobot/Handlers/PushHandler.cs
@@ -26,7 +26,7 @@ public sealed partial class PushHandler : IHandler
     public async Task HandleAsync(WebhookEvent message)
     {
         if (message is not PushEvent push ||
-            push.Repository is not { Fork: false } repo ||
+            push.Repository is not { Fork: false, Language: "C#" } repo ||
             push.Commits is not { } commits ||
             push.Created ||
             push.Deleted ||

--- a/tests/Costellobot.Tests/Builders/RepositoryBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/RepositoryBuilder.cs
@@ -21,6 +21,8 @@ public sealed class RepositoryBuilder : ResponseBuilder
 
     public bool IsPrivate { get; set; }
 
+    public string Language { get; set; } = "C#";
+
     public string Name { get; set; }
 
     public UserBuilder Owner { get; set; }
@@ -45,6 +47,7 @@ public sealed class RepositoryBuilder : ResponseBuilder
             full_name = $"{Owner.Login}/{Name}",
             html_url = $"https://github.com/{Owner.Login}/{Name}",
             id = Id,
+            language = Language,
             name = Name,
             owner = Owner.Build(),
             @private = IsPrivate,

--- a/tests/Costellobot.Tests/Drivers/PushDriver.cs
+++ b/tests/Costellobot.Tests/Drivers/PushDriver.cs
@@ -9,10 +9,11 @@ namespace MartinCostello.Costellobot.Drivers;
 
 public sealed class PushDriver
 {
-    public PushDriver(bool isFork = false)
+    public PushDriver(bool isFork = false, string language = "C#")
     {
         Owner = Sender = User = CreateUser();
         Repository = Owner.CreateRepository(isFork: isFork);
+        Repository.Language = language;
     }
 
     public bool Created { get; set; }

--- a/tests/Costellobot.Tests/Handlers/PushHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PushHandlerTests.cs
@@ -57,17 +57,19 @@ public class PushHandlerTests : IntegrationTests<AppFixture>
     }
 
     [Theory]
-    [InlineData(false, "refs/heads/main", false, false, new string[0], new string[0], new[] { "global.json" })]
-    [InlineData(false, "refs/heads/some-branch", false, false, new string[0], new[] { "global.json" }, new string[0])]
-    [InlineData(false, "refs/heads/main", true, false, new string[0], new[] { "global.json" }, new string[0])]
-    [InlineData(false, "refs/heads/main", false, true, new string[0], new[] { "global.json" }, new string[0])]
-    [InlineData(false, "refs/heads/main", false, false, new string[0], new[] { "something.json" }, new string[0])]
-    [InlineData(false, "refs/heads/main", false, false, new[] { "tests/assets/global.json" }, new string[0], new string[0])]
-    [InlineData(false, "refs/heads/main", false, false, new string[0], new[] { "tests/assets/Directory.Packages.props" }, new string[0])]
-    [InlineData(false, "refs/heads/main", false, false, new string[0], new[] { "tests/assets/global.json" }, new string[0])]
-    [InlineData(true, "refs/heads/main", false, false, new string[0], new[] { "global.json" }, new string[0])]
-    public async Task Repository_Dispatch_Is_Not_Created_If_DotNet_Dependency_File_Added_Or_Modified_On_Main_Branch_Of_Source_Repository(
+    [InlineData(false, "C#", "refs/heads/main", false, false, new string[0], new string[0], new[] { "global.json" })]
+    [InlineData(false, "C#", "refs/heads/some-branch", false, false, new string[0], new[] { "global.json" }, new string[0])]
+    [InlineData(false, "C#", "refs/heads/main", true, false, new string[0], new[] { "global.json" }, new string[0])]
+    [InlineData(false, "C#", "refs/heads/main", false, true, new string[0], new[] { "global.json" }, new string[0])]
+    [InlineData(false, "C#", "refs/heads/main", false, false, new string[0], new[] { "something.json" }, new string[0])]
+    [InlineData(false, "C#", "refs/heads/main", false, false, new[] { "tests/assets/global.json" }, new string[0], new string[0])]
+    [InlineData(false, "C#", "refs/heads/main", false, false, new string[0], new[] { "tests/assets/Directory.Packages.props" }, new string[0])]
+    [InlineData(false, "C#", "refs/heads/main", false, false, new string[0], new[] { "tests/assets/global.json" }, new string[0])]
+    [InlineData(true, "C#", "refs/heads/main", false, false, new string[0], new[] { "global.json" }, new string[0])]
+    [InlineData(false, "JavaScript", "refs/heads/main", false, false, new string[0], new[] { "global.json" }, new string[0])]
+    public async Task Repository_Dispatch_Is_Not_Created_If_DotNet_Dependency_File_Added_Or_Modified_On_Main_Branch_Of_DotNet_Source_Repository(
         bool isFork,
+        string language,
         string reference,
         bool created,
         bool deleted,
@@ -76,7 +78,7 @@ public class PushHandlerTests : IntegrationTests<AppFixture>
         string[] removed)
     {
         // Arrange
-        var driver = new PushDriver(isFork)
+        var driver = new PushDriver(isFork, language)
         {
             Ref = reference,
             Created = created,


### PR DESCRIPTION
Do not create a `dotnet_dependencies_updated` dispatch for repositories that are not primarily C#.
