### PR TITLE
Bump Octokit.GraphQL to 0.2.1-beta

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NodaTime" Version="3.1.9" />
     <PackageVersion Include="Octokit" Version="7.0.1" />
-    <PackageVersion Include="Octokit.GraphQL" Version="0.2.0-beta" />
+    <PackageVersion Include="Octokit.GraphQL" Version="0.2.1-beta" />
     <PackageVersion Include="Octokit.Webhooks.AspNetCore" Version="2.0.1" />
     <PackageVersion Include="Polly" Version="7.2.4" />
     <PackageVersion Include="ReportGenerator" Version="5.1.23" />


### PR DESCRIPTION
Bump the Octokit.GraphQL package to 0.2.1-beta.
