### PR TITLE
Add ref and sha to client payload

### DIFF
--- a/src/Costellobot/Handlers/PushHandler.cs
+++ b/src/Costellobot/Handlers/PushHandler.cs
@@ -53,7 +53,7 @@ public sealed partial class PushHandler : IHandler
         if (DependencyFileChanged(filesChanged))
         {
             Log.CreatedRepositoryDispatchForPush(_logger, repo.Owner.Login, repo.Name, push.Ref);
-            await CreateDispatchAsync(repo.FullName);
+            await CreateDispatchAsync(repo.FullName, push.Ref, push.After);
         }
     }
 
@@ -81,13 +81,18 @@ public sealed partial class PushHandler : IHandler
         }
     }
 
-    private async Task CreateDispatchAsync(string repository)
+    private async Task CreateDispatchAsync(string repository, string reference, string sha)
     {
         // See https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event
         var dispatch = new
         {
             event_type = "dotnet_dependencies_updated",
-            client_payload = new { repository },
+            client_payload = new
+            {
+                repository,
+                @ref = reference,
+                sha,
+            },
         };
 
         var uri = new Uri($"repos/{DispatchDestination}/dispatches", UriKind.Relative);

--- a/tests/Costellobot.Tests/Drivers/PushDriver.cs
+++ b/tests/Costellobot.Tests/Drivers/PushDriver.cs
@@ -16,6 +16,8 @@ public sealed class PushDriver
         Repository.Language = language;
     }
 
+    public string After { get; set; } = Guid.NewGuid().ToString();
+
     public bool Created { get; set; }
 
     public IList<GitCommitBuilder> Commits { get; set; } = new List<GitCommitBuilder>();
@@ -39,6 +41,7 @@ public sealed class PushDriver
         return new
         {
             @ref = Ref,
+            after = After,
             repository = Repository.Build(),
             installation = new
             {

--- a/tests/Costellobot.Tests/Handlers/PushHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PushHandlerTests.cs
@@ -152,8 +152,13 @@ public class PushHandlerTests : IntegrationTests<AppFixture>
                 }
 
                 var repository = clientPayload.GetProperty("repository").GetString();
+                var reference = clientPayload.GetProperty("ref").GetString();
+                var sha = clientPayload.GetProperty("sha").GetString();
 
-                return string.Equals(repository, $"{driver.Owner.Login}/{driver.Repository.Name}", StringComparison.Ordinal);
+                return
+                    string.Equals(repository, $"{driver.Owner.Login}/{driver.Repository.Name}", StringComparison.Ordinal) &&
+                    string.Equals(reference, "refs/heads/main", StringComparison.Ordinal) &&
+                    string.Equals(sha, driver.After, StringComparison.Ordinal);
             })
             .Responds()
             .WithStatus(HttpStatusCode.NoContent)


### PR DESCRIPTION
Add the ref and SHA for the push to the payload of the `dotnet_dependencies_updated` dispatches.
