### PR TITLE
Fix CA1869 warnings

### DIFF
--- a/src/Costellobot/Pages/Webhooks/Delivery.cshtml.cs
+++ b/src/Costellobot/Pages/Webhooks/Delivery.cshtml.cs
@@ -12,6 +12,7 @@ namespace MartinCostello.Costellobot.Pages;
 [CostellobotAdmin]
 public sealed partial class DeliveryModel : PageModel
 {
+    private static readonly JsonSerializerOptions IndentedOptions = new() { WriteIndented = true };
     private readonly IGitHubClient _client;
 
     public DeliveryModel(IGitHubClientForApp client)
@@ -82,7 +83,7 @@ public sealed partial class DeliveryModel : PageModel
 
         RequestPayload = JsonSerializer.Serialize(
             request.GetProperty("payload"),
-            new JsonSerializerOptions() { WriteIndented = true });
+            IndentedOptions);
 
         var response = Delivery.GetProperty("response");
 

--- a/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
+++ b/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
@@ -18,6 +18,7 @@ namespace MartinCostello.Costellobot.Infrastructure;
 public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
     where T : AppFixture
 {
+    private static readonly JsonSerializerOptions IndentedOptions = new() { WriteIndented = true };
     private readonly IDisposable _scope;
 
     protected IntegrationTests(T fixture, ITestOutputHelper outputHelper)
@@ -175,7 +176,7 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
             webhookSecret = options.WebhookSecret;
         }
 
-        string payload = JsonSerializer.Serialize(value, new JsonSerializerOptions() { WriteIndented = true });
+        string payload = JsonSerializer.Serialize(value, IndentedOptions);
 
         // See https://github.com/terrajobst/Terrajobst.GitHubEvents/blob/cb86100c783373e198cefb1ed7e92526a44833b0/src/Terrajobst.GitHubEvents.AspNetCore/GitHubEventsExtensions.cs#L112-L119
         var encoding = Encoding.UTF8;

--- a/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
+++ b/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
@@ -178,7 +178,7 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
 
         string payload = JsonSerializer.Serialize(value, IndentedOptions);
 
-        // See https://github.com/terrajobst/Terrajobst.GitHubEvents/blob/cb86100c783373e198cefb1ed7e92526a44833b0/src/Terrajobst.GitHubEvents.AspNetCore/GitHubEventsExtensions.cs#L112-L119
+        // See https://github.com/octokit/webhooks.net/blob/1e4110fc02b858c9f0f363ee46c9313cc06caef5/src/Octokit.Webhooks.AspNetCore/GitHubWebhookExtensions.cs#L109-L115
         var encoding = Encoding.UTF8;
 
         byte[] key = encoding.GetBytes(webhookSecret);


### PR DESCRIPTION
- Fix new CA1869 warnings in .NET 8 RC1 SDK.
- Update outdated comment.