### PR TITLE
Swap order of steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,17 +147,17 @@ jobs:
 
     steps:
 
+    - name: Download artifacts
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: webapp
+
     - name: Azure log in
       uses: azure/login@92a5484dfaf04ca78a94597f4f19fea633851fa2 # v1.4.7
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-    - name: Download artifacts
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-      with:
-        name: webapp
 
     - name: Deploy to Azure App Service
       uses: azure/webapps-deploy@fb8292eb575db1bb18a90627e8959cd51dbb355c # v2.2.10


### PR DESCRIPTION
Login to Azure immediately before needing the credentials so that if [downloading the Artifacts takes too long](https://github.com/martincostello/costellobot/actions/runs/5926448401/job/16072395038#step:3:20) the JWT [doesn't expire](https://github.com/martincostello/costellobot/actions/runs/5926448401/job/16072395038#step:4:23).

<!--

Summarise the changes this Pull Request makes.

Please include a reference to a GitHub issue if appropriate.

-->
