### PR TITLE
Simplify [AssemblyMetadata]

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,7 +11,7 @@
     <CommitHash Condition=" '$(CommitHash)' == '' ">$(GITHUB_SHA)</CommitHash>
   </PropertyGroup>
   <Target Name="AddGitMetadaAssemblyAttributes"
-          BeforeTargets="CoreGenerateAssemblyInfo"
+          BeforeTargets="GetAssemblyAttributes"
           Condition=" '$(GenerateGitMetadata)' == 'true' ">
     <Exec Command="git rev-parse HEAD" ConsoleToMSBuild="true" StandardOutputImportance="low" IgnoreExitCode="true" Condition=" '$(CommitHash)' == '' ">
       <Output TaskParameter="ConsoleOutput" PropertyName="CommitHash" />
@@ -20,22 +20,10 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="CommitBranch" />
     </Exec>
     <ItemGroup>
-      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition=" $(BuildId) != '' ">
-        <_Parameter1>BuildId</_Parameter1>
-        <_Parameter2>$(BuildId)</_Parameter2>
-      </AssemblyAttribute>
-      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
-        <_Parameter1>BuildTimestamp</_Parameter1>
-        <_Parameter2>$([System.DateTime]::UtcNow.ToString(yyyy-MM-ddTHH:mm:ssK))</_Parameter2>
-      </AssemblyAttribute>
-      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition=" $(CommitHash) != '' ">
-        <_Parameter1>CommitHash</_Parameter1>
-        <_Parameter2>$(CommitHash)</_Parameter2>
-      </AssemblyAttribute>
-      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition=" $(CommitBranch) != '' ">
-        <_Parameter1>CommitBranch</_Parameter1>
-        <_Parameter2>$(CommitBranch)</_Parameter2>
-      </AssemblyAttribute>
+      <AssemblyMetadata Include="BuildId" Value="$(BuildId)" Condition=" $(BuildId) != ''" />
+      <AssemblyMetadata Include="BuildTimestamp" Value="$([System.DateTime]::UtcNow.ToString(yyyy-MM-ddTHH:mm:ssK))" />
+      <AssemblyMetadata Include="CommitHash" Value="$(CommitHash)" Condition=" $(CommitHash) != '' " />
+      <AssemblyMetadata Include="CommitBranch" Value="$(CommitBranch)" Condition=" $(CommitBranch) != '' " />
     </ItemGroup>
   </Target>
   <PropertyGroup Condition=" '$(CollectCoverage)' == 'true' ">


### PR DESCRIPTION
Simplify setting `[AssemblyMetadata]` attributes via .NET SDK feature.
