### PR TITLE
Enable config binding source gen

### DIFF
--- a/src/Costellobot/Costellobot.csproj
+++ b/src/Costellobot/Costellobot.csproj
@@ -1,14 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <!--
-      HACK Disable configuration binding source generator due to issues in RC.1 that will be fixed in RC.2:
-      - https://github.com/dotnet/runtime/issues/90851
-      - https://github.com/dotnet/runtime/issues/90987
-      - https://github.com/dotnet/runtime/issues/91258
-    -->
-    <!--
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
-    -->
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
     <IsPackable>false</IsPackable>
     <RootNamespace>MartinCostello.Costellobot</RootNamespace>


### PR DESCRIPTION
Enable the configuration binding source generator as it should work in RC2.
