### PR TITLE
Configure HSTS

### DIFF
--- a/src/Costellobot/Program.cs
+++ b/src/Costellobot/Program.cs
@@ -13,6 +13,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Host.ConfigureApplication();
 
 builder.Services.AddGitHub(builder.Configuration, builder.Environment);
+builder.Services.AddHsts((options) => options.MaxAge = TimeSpan.FromDays(180));
 builder.Services.AddRazorPages();
 builder.Services.AddResponseCaching();
 


### PR DESCRIPTION
Configure an HSTS max-age of 180 days to get an A+ from Qualys SSL Labs Test.
