### PR TITLE
Add OpenTelemetry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,9 +89,13 @@ jobs:
           ~/.cache/ms-playwright
           ~/Library/Caches/ms-playwright
 
+    - name: Install .NET Workloads
+      shell: pwsh
+      run: dotnet workload restore
+
     - name: Build, Test and Publish
       shell: pwsh
-      run: ./build.ps1 -Runtime "${{ env.PUBLISH_RUNTIME }}"
+      run: ./build.ps1 -Runtime ${env:PUBLISH_RUNTIME}
 
     - uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4.3.0
       name: Upload coverage to Codecov

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,6 +35,7 @@ jobs:
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
+      if: matrix.language == 'csharp'
 
     - name: Setup Node
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
@@ -56,6 +57,7 @@ jobs:
 
     - name: Setup NuGet cache
       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      if: matrix.language == 'csharp'
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props') }}
@@ -69,6 +71,13 @@ jobs:
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@c7f9125735019aa87cfc361530512d50ea439c71 # v3.25.1
+      if: matrix.language != 'csharp'
+
+    - name: Build .NET code
+      if: matrix.language == 'csharp'
+      run: |
+        dotnet workload restore
+        dotnet build --configuration Release
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@c7f9125735019aa87cfc361530512d50ea439c71 # v3.25.1

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "EditorConfig.EditorConfig",
-    "k--kato.docomment",
+    "github.vscode-github-actions",
     "ms-dotnettools.csharp",
     "ms-vscode.PowerShell"
   ]

--- a/Costellobot.sln
+++ b/Costellobot.sln
@@ -66,6 +66,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Costellobot.Tests", "tests\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Costellobot.EndToEndTests", "tests\Costellobot.EndToEndTests\Costellobot.EndToEndTests.csproj", "{4195D1F1-C9CC-45E2-8401-DE2E6B6747E3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Costellobot.AppHost", "src\Costellobot.AppHost\Costellobot.AppHost.csproj", "{D35AB20F-6BE9-42AD-8B87-067794F24827}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -84,6 +86,10 @@ Global
 		{4195D1F1-C9CC-45E2-8401-DE2E6B6747E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4195D1F1-C9CC-45E2-8401-DE2E6B6747E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4195D1F1-C9CC-45E2-8401-DE2E6B6747E3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D35AB20F-6BE9-42AD-8B87-067794F24827}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D35AB20F-6BE9-42AD-8B87-067794F24827}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D35AB20F-6BE9-42AD-8B87-067794F24827}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D35AB20F-6BE9-42AD-8B87-067794F24827}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -96,6 +102,7 @@ Global
 		{A6846A80-457A-40A0-AA48-2DAD55F194AD} = {03DB7DB6-48FD-48EC-A5F4-6BC668B804F4}
 		{DABA5554-941C-479B-A3BC-E6EA60AF94A3} = {712BC61D-F6BE-4D1A-80A4-E88B69262999}
 		{4195D1F1-C9CC-45E2-8401-DE2E6B6747E3} = {712BC61D-F6BE-4D1A-80A4-E88B69262999}
+		{D35AB20F-6BE9-42AD-8B87-067794F24827} = {03DB7DB6-48FD-48EC-A5F4-6BC668B804F4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5F668B0C-5D69-41B4-A2D2-38B58A8FF46C}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.3" />
     <PackageVersion Include="Azure.Identity" Version="1.11.0" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.0" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
@@ -27,6 +28,12 @@
     <PackageVersion Include="Octokit" Version="11.0.0" />
     <PackageVersion Include="Octokit.GraphQL" Version="0.4.0-beta" />
     <PackageVersion Include="Octokit.Webhooks.AspNetCore" Version="2.1.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
+    <PackageVersion Include="OpenTelemetry.ResourceDetectors.Azure" Version="1.0.0-beta.6" />
     <PackageVersion Include="Polly.Core" Version="8.3.1" />
     <PackageVersion Include="Polly.Extensions" Version="8.3.1" />
     <PackageVersion Include="Polly.RateLimiting" Version="8.3.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
     <GlobalPackageReference Include="ReferenceTrimmer" Version="3.3.6" />
   </ItemGroup>
   <ItemGroup>
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="8.0.0-preview.5.24201.12" />
     <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="8.0.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.3" />

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ following set of commands:
 ```powershell
 git clone https://github.com/martincostello/costellobot.git
 cd costellobot
+
+# Restore Aspire workload on first usage (requires elevation on Windows if not installed)
+dotnet workload restore
+
+# Build and test the application
 ./build.ps1
 ```
 

--- a/src/Costellobot.AppHost/Costellobot.AppHost.csproj
+++ b/src/Costellobot.AppHost/Costellobot.AppHost.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsAspireHost>true</IsAspireHost>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Costellobot\Costellobot.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Costellobot.AppHost/Program.cs
+++ b/src/Costellobot.AppHost/Program.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddProject<Projects.Costellobot>("Costellobot");
+
+var app = builder.Build();
+
+app.Run();

--- a/src/Costellobot.AppHost/Properties/launchSettings.json
+++ b/src/Costellobot.AppHost/Properties/launchSettings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "AppHost": {
+      "commandName": "Project",
+      "applicationUrl": "https://localhost:15288;http://localhost:15289",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16099",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037"
+      }
+    }
+  }
+}

--- a/src/Costellobot.AppHost/appsettings.Development.json
+++ b/src/Costellobot.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Costellobot.AppHost/appsettings.json
+++ b/src/Costellobot.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Aspire.Hosting.Dcp": "Warning",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Costellobot/ApplicationTelemetry.cs
+++ b/src/Costellobot/ApplicationTelemetry.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace MartinCostello.Costellobot;
+
+public static class ApplicationTelemetry
+{
+    public static readonly string ServiceName = "Costellobot";
+    public static readonly string ServiceVersion = GitMetadata.Version.Split('+')[0];
+    public static readonly ActivitySource ActivitySource = new(ServiceName, ServiceVersion);
+}

--- a/src/Costellobot/Costellobot.csproj
+++ b/src/Costellobot/Costellobot.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />
     <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
     <PackageReference Include="Humanizer" />
     <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
@@ -24,6 +25,12 @@
     <PackageReference Include="Octokit" />
     <PackageReference Include="Octokit.GraphQL" />
     <PackageReference Include="Octokit.Webhooks.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.Azure" />
     <PackageReference Include="Polly.Core" />
     <PackageReference Include="Polly.Extensions" />
     <PackageReference Include="Polly.RateLimiting" />

--- a/src/Costellobot/ILoggingBuilderExtensions.cs
+++ b/src/Costellobot/ILoggingBuilderExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using OpenTelemetry.Logs;
+
 namespace MartinCostello.Costellobot;
 
 public static class ILoggingBuilderExtensions
@@ -9,5 +11,19 @@ public static class ILoggingBuilderExtensions
     {
         builder.Services.AddSingleton<ILoggerProvider, ClientLoggingProvider>();
         return builder;
+    }
+
+    public static ILoggingBuilder AddTelemetry(this ILoggingBuilder builder)
+    {
+        return builder.AddOpenTelemetry((p) =>
+        {
+            p.IncludeFormattedMessage = true;
+            p.IncludeScopes = true;
+
+            if (TelemetryExtensions.IsOtlpCollectorConfigured())
+            {
+                p.AddOtlpExporter();
+            }
+        });
     }
 }

--- a/src/Costellobot/Program.cs
+++ b/src/Costellobot/Program.cs
@@ -16,6 +16,7 @@ builder.Services.AddGitHub(builder.Configuration, builder.Environment);
 builder.Services.AddHsts((options) => options.MaxAge = TimeSpan.FromDays(180));
 builder.Services.AddRazorPages();
 builder.Services.AddResponseCaching();
+builder.Services.AddTelemetry(builder.Environment);
 
 builder.Services.AddResponseCompression((options) =>
 {
@@ -27,6 +28,7 @@ builder.Services.AddSignalR();
 builder.Services.AddSingleton<ClientLogQueue>();
 builder.Services.AddHostedService<ClientLogBroadcastService>();
 
+builder.Logging.AddTelemetry();
 builder.Logging.AddSignalR();
 
 builder.Services.ConfigureHttpJsonOptions((options) =>

--- a/src/Costellobot/Registries/NpmPackageRegistry.cs
+++ b/src/Costellobot/Registries/NpmPackageRegistry.cs
@@ -9,8 +9,6 @@ namespace MartinCostello.Costellobot.Registries;
 
 public sealed partial class NpmPackageRegistry(HttpClient client) : PackageRegistry(client)
 {
-    private static readonly Uri BaseAddress = new("https://registry.npmjs.org");
-
     public override DependencyEcosystem Ecosystem => DependencyEcosystem.Npm;
 
     public override async Task<IReadOnlyList<string>> GetPackageOwnersAsync(
@@ -23,7 +21,7 @@ public sealed partial class NpmPackageRegistry(HttpClient client) : PackageRegis
         var escapedVersion = Uri.EscapeDataString(version);
 
         // https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#package-metadata
-        var uri = new Uri(BaseAddress, $"{escapedId}/{escapedVersion}");
+        var uri = new Uri($"{escapedId}/{escapedVersion}", UriKind.Relative);
 
         Package? package;
 

--- a/src/Costellobot/Registries/NuGetPackageRegistry.cs
+++ b/src/Costellobot/Registries/NuGetPackageRegistry.cs
@@ -11,8 +11,6 @@ namespace MartinCostello.Costellobot.Registries;
 
 public sealed partial class NuGetPackageRegistry(HttpClient client, IMemoryCache cache) : PackageRegistry(client)
 {
-    private static readonly Uri ServiceIndexUri = new("https://api.nuget.org/v3/index.json");
-
     public override DependencyEcosystem Ecosystem => DependencyEcosystem.NuGet;
 
     public override async Task<IReadOnlyList<string>> GetPackageOwnersAsync(
@@ -113,7 +111,7 @@ public sealed partial class NuGetPackageRegistry(HttpClient client, IMemoryCache
         return await cache.GetOrCreateAsync("nuget-service-index", async (entry) =>
         {
             entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1);
-            return await Client.GetFromJsonAsync(ServiceIndexUri, NuGetJsonSerializerContext.Default.ServiceIndex);
+            return await Client.GetFromJsonAsync("/v3/index.json", NuGetJsonSerializerContext.Default.ServiceIndex);
         });
     }
 

--- a/src/Costellobot/RegistryOptions.cs
+++ b/src/Costellobot/RegistryOptions.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Costellobot;
+
+public sealed class RegistryOptions
+{
+    public Uri BaseAddress { get; set; } = default!;
+
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(5);
+}

--- a/src/Costellobot/TelemetryExtensions.cs
+++ b/src/Costellobot/TelemetryExtensions.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Azure.Identity;
+using Azure.Monitor.OpenTelemetry.AspNetCore;
+using Microsoft.Extensions.Options;
+using OpenTelemetry.Instrumentation.Http;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.ResourceDetectors.Azure;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace MartinCostello.Costellobot;
+
+public static class TelemetryExtensions
+{
+    private static readonly ConcurrentDictionary<string, string> ServiceMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["api.github.com"] = "GitHub",
+        ["github.com"] = "GitHub",
+        ["raw.githubusercontent.com"] = "GitHub",
+    };
+
+    public static void AddTelemetry(this IServiceCollection services, IWebHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var resourceBuilder = ResourceBuilder.CreateDefault()
+            .AddService(ApplicationTelemetry.ServiceName, serviceVersion: ApplicationTelemetry.ServiceVersion)
+            .AddDetector(new AppServiceResourceDetector());
+
+        var telemetry = services
+            .AddOpenTelemetry()
+            .WithMetrics((builder) =>
+            {
+                builder.SetResourceBuilder(resourceBuilder)
+                       .AddAspNetCoreInstrumentation()
+                       .AddHttpClientInstrumentation()
+                       .AddRuntimeInstrumentation();
+
+                if (IsOtlpCollectorConfigured())
+                {
+                    builder.AddOtlpExporter();
+                }
+            })
+            .WithTracing((builder) =>
+            {
+                builder.SetResourceBuilder(resourceBuilder)
+                       .AddAspNetCoreInstrumentation()
+                       .AddHttpClientInstrumentation()
+                       .AddSource(ApplicationTelemetry.ServiceName);
+
+                if (environment.IsDevelopment())
+                {
+                    builder.SetSampler(new AlwaysOnSampler());
+                }
+
+                if (IsOtlpCollectorConfigured())
+                {
+                    builder.AddOtlpExporter();
+                }
+            });
+
+        if (IsAzureMonitorConfigured())
+        {
+            telemetry.UseAzureMonitor((p) => p.Credential = new DefaultAzureCredential());
+        }
+
+        services.AddOptions<HttpClientTraceInstrumentationOptions>()
+                .Configure<IServiceProvider>((options, provider) =>
+                {
+                    AddServiceMappings(ServiceMap, provider);
+
+                    options.EnrichWithHttpRequestMessage = EnrichHttpActivity;
+                    options.RecordException = true;
+                });
+    }
+
+    internal static bool IsOtlpCollectorConfigured()
+        => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT"));
+
+    private static bool IsAzureMonitorConfigured()
+        => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING"));
+
+    private static void EnrichHttpActivity(Activity activity, HttpRequestMessage request)
+    {
+        TryEnrichWithPeerService(activity);
+
+        static void TryEnrichWithPeerService(Activity activity)
+        {
+            if (GetTag("server.address", activity.Tags) is { Length: > 0 } hostName)
+            {
+                if (!ServiceMap.TryGetValue(hostName, out var service))
+                {
+                    service = hostName;
+                }
+
+                activity.AddTag("peer.service", service);
+            }
+        }
+
+        static string? GetTag(string name, IEnumerable<KeyValuePair<string, string?>> tags)
+            => tags.FirstOrDefault((p) => p.Key == name).Value;
+    }
+
+    private static void AddServiceMappings(ConcurrentDictionary<string, string> mappings, IServiceProvider serviceProvider)
+    {
+        var github = serviceProvider.GetRequiredService<IOptions<GitHubOptions>>().Value;
+        var webhook = serviceProvider.GetRequiredService<IOptions<WebhookOptions>>().Value;
+
+        if (github.EnterpriseDomain is { Length: > 0 } ghes)
+        {
+            mappings[ghes] = "GitHub Enterprise";
+        }
+
+        foreach ((string registry, var endpoint) in webhook.Registries)
+        {
+            mappings[endpoint.BaseAddress.Host] = registry;
+        }
+    }
+}

--- a/src/Costellobot/WebhookOptions.cs
+++ b/src/Costellobot/WebhookOptions.cs
@@ -23,6 +23,8 @@ public sealed class WebhookOptions
 
     public IList<string> IgnoreRepositories { get; set; } = [];
 
+    public IDictionary<string, RegistryOptions> Registries { get; set; } = new Dictionary<string, RegistryOptions>();
+
     public IList<string> RerunFailedChecks { get; set; } = [];
 
     public int RerunFailedChecksAttempts { get; set; }

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -22,6 +22,7 @@
       "Microsoft.AspNetCore.DataProtection.Repositories.EphemeralXmlRepository": "Error",
       "Microsoft.AspNetCore.DataProtection.Repositories.FileSystemXmlRepository": "Error",
       "Microsoft.Hosting.Lifetime": "Information",
+      "Polly": "Warning",
       "System": "Warning"
     }
   },
@@ -41,6 +42,14 @@
     "IgnoreRepositories": [
       "martincostello/dotnet-patch-automation-sample"
     ],
+    "Registries": {
+      "Npm": {
+        "BaseAddress": "https://registry.npmjs.org"
+      },
+      "NuGet": {
+        "BaseAddress": "https://api.nuget.org"
+      }
+    },
     "RerunFailedChecks": [
       "^code-ql(\\s\\(csharp\\))?$",
       "^lighthouse$",

--- a/tests/Costellobot.Tests/Registries/NpmPackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/NpmPackageRegistryTests.cs
@@ -23,6 +23,7 @@ public static class NpmPackageRegistryTests
             .RegisterBundleAsync(Path.Combine("Bundles", "npm-registry.json"));
 
         using var client = options.CreateHttpClient();
+        client.BaseAddress = new Uri("https://registry.npmjs.org");
 
         var target = new NpmPackageRegistry(client);
 

--- a/tests/Costellobot.Tests/Registries/NuGetPackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/NuGetPackageRegistryTests.cs
@@ -28,6 +28,8 @@ public static class NuGetPackageRegistryTests
             .RegisterBundleAsync(Path.Combine("Bundles", "nuget-search.json"));
 
         using var client = options.CreateHttpClient();
+        client.BaseAddress = new Uri("https://api.nuget.org");
+
         using var cache = new MemoryCache(new MemoryCacheOptions());
 
         var target = new NuGetPackageRegistry(client, cache);


### PR DESCRIPTION
- Add OpenTelemetry for logging, metrics and tracing with support for Azure Monitor and OLTP exporter.
- Add an Aspire AppHost to use for local development.
- Make registry URLs configurable.
- Log Polly at warning level.
