### PR TITLE
Avoid ObjectDisposedException

### DIFF
--- a/src/Costellobot/GitHubWebhookService.cs
+++ b/src/Costellobot/GitHubWebhookService.cs
@@ -70,16 +70,23 @@ public sealed partial class GitHubWebhookService(
 
     private async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        while (true)
+        while (!stoppingToken.IsCancellationRequested)
         {
-            var message = await queue.DequeueAsync(stoppingToken);
+            try
+            {
+                var message = await queue.DequeueAsync(stoppingToken);
 
-            if (message is null)
+                if (message is null)
+                {
+                    break;
+                }
+
+                await ProcessAsync(message);
+            }
+            catch (OperationCanceledException ex) when (ex.CancellationToken == stoppingToken)
             {
                 break;
             }
-
-            await ProcessAsync(message);
         }
     }
 

--- a/src/Costellobot/Program.cs
+++ b/src/Costellobot/Program.cs
@@ -74,6 +74,9 @@ builder.WebHost.ConfigureKestrel((p) => p.AddServerHeader = false);
 
 var app = builder.Build();
 
+// Give the webhook queue a chance to drain before the application stops
+app.Lifetime.ApplicationStopping.Register(() => Thread.Sleep(TimeSpan.FromSeconds(10)));
+
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/error");


### PR DESCRIPTION
Avoid `ObjectDisposedException` from processing the webhook queue when the application is shutting down.
