### PR TITLE
Avoid HTTPS redirection warning

### DIFF
--- a/src/Costellobot/ILoggingBuilderExtensions.cs
+++ b/src/Costellobot/ILoggingBuilderExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using Azure.Monitor.OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
 
 namespace MartinCostello.Costellobot;
@@ -20,11 +19,6 @@ public static class ILoggingBuilderExtensions
         {
             p.IncludeFormattedMessage = true;
             p.IncludeScopes = true;
-
-            if (TelemetryExtensions.IsAzureMonitorConfigured())
-            {
-                p.AddAzureMonitorLogExporter();
-            }
 
             if (TelemetryExtensions.IsOtlpCollectorConfigured())
             {

--- a/src/Costellobot/Program.cs
+++ b/src/Costellobot/Program.cs
@@ -92,7 +92,11 @@ app.UseStatusCodePagesWithReExecute("/error", "?id={0}");
 if (!app.Environment.IsDevelopment())
 {
     app.UseHsts();
-    app.UseHttpsRedirection();
+
+    if (!string.Equals(app.Configuration["ForwardedHeaders_Enabled"], bool.TrueString, StringComparison.OrdinalIgnoreCase))
+    {
+        app.UseHttpsRedirection();
+    }
 }
 
 app.UseResponseCompression();


### PR DESCRIPTION
When deployed with `ForwardedHeaders_Enabled=true` do not enable HTTPS redirection to avoid warnings being logged by platform-level HTTP requests (such as health checks).
