### PR TITLE
Add GitHub OAuth to service mappings

### DIFF
--- a/src/Costellobot/TelemetryExtensions.cs
+++ b/src/Costellobot/TelemetryExtensions.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using AspNet.Security.OAuth.GitHub;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
-using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Instrumentation.Http;
 using OpenTelemetry.Metrics;


### PR DESCRIPTION
Include all of the endpoints for GitHub OAuth in the OpenTelemetry host mappings.
