### PR TITLE
Switch to Azure Monitor exporter

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.4" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.3" />
     <PackageVersion Include="Azure.Identity" Version="1.11.3" />
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.1" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.2.0" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />

--- a/src/Costellobot/Costellobot.csproj
+++ b/src/Costellobot/Costellobot.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
     <PackageReference Include="Humanizer" />
     <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />

--- a/src/Costellobot/ILoggingBuilderExtensions.cs
+++ b/src/Costellobot/ILoggingBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using Azure.Monitor.OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
 
 namespace MartinCostello.Costellobot;
@@ -15,14 +16,19 @@ public static class ILoggingBuilderExtensions
 
     public static ILoggingBuilder AddTelemetry(this ILoggingBuilder builder)
     {
-        return builder.AddOpenTelemetry((p) =>
+        return builder.AddOpenTelemetry((options) =>
         {
-            p.IncludeFormattedMessage = true;
-            p.IncludeScopes = true;
+            options.IncludeFormattedMessage = true;
+            options.IncludeScopes = true;
+
+            if (TelemetryExtensions.IsAzureMonitorConfigured())
+            {
+                options.AddAzureMonitorLogExporter();
+            }
 
             if (TelemetryExtensions.IsOtlpCollectorConfigured())
             {
-                p.AddOtlpExporter();
+                options.AddOtlpExporter();
             }
         });
     }


### PR DESCRIPTION
Switch to Azure.Monitor.OpenTelemetry.Exporter from Azure.Monitor.OpenTelemetry.AspNetCore as the latter is not AoT friendly.
