### PR TITLE
Update obsolete linter rule

### DIFF
--- a/src/Costellobot/package-lock.json
+++ b/src/Costellobot/package-lock.json
@@ -12,6 +12,7 @@
         "@babel/core": "^7.24.5",
         "@babel/preset-env": "^7.24.5",
         "@microsoft/signalr": "^8.0.0",
+        "@stylistic/eslint-plugin-js": "^2.1.0",
         "@typescript-eslint/eslint-plugin": "^7.9.0",
         "@typescript-eslint/parser": "^7.9.0",
         "css-loader": "^7.1.1",
@@ -2766,6 +2767,50 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@stylistic/eslint-plugin-js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.1.0.tgz",
+      "integrity": "sha512-gdXUjGNSsnY6nPyqxu6lmDTtVrwCOjun4x8PUn0x04d5ucLI74N3MT1Q0UhdcOR9No3bo5PGDyBgXK+KmD787A==",
+      "dependencies": {
+        "@types/eslint": "^8.56.10",
+        "acorn": "^8.11.3",
+        "eslint-visitor-keys": "^4.0.0",
+        "espree": "^10.0.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js/node_modules/eslint-visitor-keys": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin-js/node_modules/espree": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.0.1.tgz",
+      "integrity": "sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==",
+      "dependencies": {
+        "acorn": "^8.11.3",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -2812,9 +2857,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.44.3",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.3.tgz",
-      "integrity": "sha512-iM/WfkwAhwmPff3wZuPLYiHX18HI24jU8k1ZSH7P8FHwxTjZ2P6CoX2wnF43oprR+YXJM6UUxATkNvyv/JHd+g==",
+      "version": "8.56.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3300,9 +3345,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "bin": {
         "acorn": "bin/acorn"
       },

--- a/src/Costellobot/package.json
+++ b/src/Costellobot/package.json
@@ -22,6 +22,7 @@
     "@babel/core": "^7.24.5",
     "@babel/preset-env": "^7.24.5",
     "@microsoft/signalr": "^8.0.0",
+    "@stylistic/eslint-plugin-js": "^2.1.0",
     "@typescript-eslint/eslint-plugin": "^7.9.0",
     "@typescript-eslint/parser": "^7.9.0",
     "css-loader": "^7.1.1",
@@ -60,18 +61,19 @@
       "sourceType": "module"
     },
     "plugins": [
+      "@stylistic/js",
       "@typescript-eslint",
       "jest"
     ],
     "rules": {
+      "@stylistic/js/quotes": [
+        "error",
+        "single"
+      ],
       "@typescript-eslint/indent": "error",
       "@typescript-eslint/member-delimiter-style": "error",
       "@typescript-eslint/naming-convention": "error",
       "@typescript-eslint/prefer-namespace-keyword": "error",
-      "@typescript-eslint/quotes": [
-        "error",
-        "single"
-      ],
       "@typescript-eslint/semi": [
         "error",
         "always"

--- a/src/Costellobot/webpack.config.js
+++ b/src/Costellobot/webpack.config.js
@@ -1,8 +1,8 @@
 const path = require('path');
 const webpack = require('webpack');
-const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-const RemoveEmptyScriptsPlugin = require("webpack-remove-empty-scripts");
+const cssMinimizerPlugin = require('css-minimizer-webpack-plugin');
+const miniCssExtractPlugin = require('mini-css-extract-plugin');
+const removeEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
 
 module.exports = {
     devtool: 'source-map',
@@ -16,12 +16,12 @@ module.exports = {
             {
                 test: /.css$/,
                 use: [
-                  MiniCssExtractPlugin.loader,
-                  { loader: "css-loader", options: { sourceMap: true } },
+                    miniCssExtractPlugin.loader,
+                    { loader: 'css-loader', options: { sourceMap: true } },
                 ],
             },
             {
-                test: /\.ts$/,
+                test: /\.tsx?$/,
                 use: 'ts-loader',
                 exclude: /node_modules/,
             },
@@ -30,8 +30,8 @@ module.exports = {
     optimization: {
         minimize: true,
         minimizer: [
-            `...`,
-            new CssMinimizerPlugin(),
+            '...',
+            new cssMinimizerPlugin(),
         ],
     },
     output: {
@@ -39,13 +39,13 @@ module.exports = {
         path: path.resolve(__dirname, 'wwwroot', 'static'),
     },
     plugins: [
-        new MiniCssExtractPlugin({
+        new miniCssExtractPlugin({
             filename: '[name]/main.css'
         }),
-        new RemoveEmptyScriptsPlugin(),
+        new removeEmptyScriptsPlugin(),
         new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /en-gb/),
     ],
     resolve: {
-        extensions: ['.css', '.ts', '.js'],
+        extensions: ['.css', '.tsx', '.ts', '.js'],
     },
 };


### PR DESCRIPTION
- Remove obsolete ESLint rule.
- Fix lint violations in webpack configuration.
- Configure webpack for potential future use of react.
