### PR TITLE
Use default interface method

### DIFF
--- a/src/Costellobot/Registries/IPackageRegistry.cs
+++ b/src/Costellobot/Registries/IPackageRegistry.cs
@@ -7,7 +7,7 @@ public interface IPackageRegistry
 {
     DependencyEcosystem Ecosystem { get; }
 
-    Task<bool> AreOwnersTrustedAsync(IReadOnlyList<string> owners);
+    Task<bool> AreOwnersTrustedAsync(IReadOnlyList<string> owners) => Task.FromResult(false);
 
     Task<IReadOnlyList<string>> GetPackageOwnersAsync(
         string owner,

--- a/src/Costellobot/Registries/PackageRegistry.cs
+++ b/src/Costellobot/Registries/PackageRegistry.cs
@@ -9,9 +9,6 @@ public abstract class PackageRegistry(HttpClient client) : IPackageRegistry
 
     protected HttpClient Client { get; } = client;
 
-    public virtual Task<bool> AreOwnersTrustedAsync(IReadOnlyList<string> owners)
-        => Task.FromResult(false);
-
     public abstract Task<IReadOnlyList<string>> GetPackageOwnersAsync(
         string owner,
         string repository,


### PR DESCRIPTION
Move the default implementation for `AreOwnersTrustedAsync()` to the interface rather than being in the `PackageRegistry` base class.
