### PR TITLE
Add repository badges

### DIFF
--- a/src/Costellobot/BadgeService.cs
+++ b/src/Costellobot/BadgeService.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Options;
+using Octokit;
+
+namespace MartinCostello.Costellobot;
+
+public sealed partial class BadgeService(
+    IGitHubClientForInstallation client,
+    IOptionsMonitor<GitHubOptions> options,
+    ILogger<BadgeService> logger)
+{
+    private static readonly string[] AlertTypes = ["code-scanning", "dependabot", "secret-scanning"];
+
+    private readonly byte[] _key = Encoding.UTF8.GetBytes(options.CurrentValue.BadgesKey);
+
+    public async Task<string?> GetBadgeAsync(string type, string owner, string repo, string? signature)
+    {
+        if (!VerifySignature(type, owner, repo, signature))
+        {
+            return null;
+        }
+
+        try
+        {
+            return type.ToUpperInvariant() switch
+            {
+                "RELEASE" => await LatestReleaseBadgeAsync(owner, repo),
+                "SECURITY" => await SecurityAlertsAsync(owner, repo),
+                _ => null,
+            };
+        }
+        catch (Exception ex)
+        {
+            Log.FailedToGenerateBadge(logger, ex, type, owner, repo);
+            return null;
+        }
+    }
+
+    private bool VerifySignature(string type, string owner, string repo, string? signature)
+    {
+        const int Length = 256 / 8;
+        Span<byte> expected = stackalloc byte[Length];
+
+        if (string.IsNullOrEmpty(signature) || !Convert.TryFromBase64String(signature, expected, out var written) || written != Length)
+        {
+            return false;
+        }
+
+        var data = GetBytes($"badge-{type}-{owner}-{repo}");
+        var actual = HMACSHA256.HashData(_key, data);
+
+        return CryptographicOperations.FixedTimeEquals(expected, actual);
+
+        static ReadOnlySpan<byte> GetBytes(string value)
+            => Encoding.UTF8.GetBytes(value);
+    }
+
+    private async Task<string?> LatestReleaseBadgeAsync(string owner, string name)
+    {
+        Release? release = null;
+
+        try
+        {
+            release = await client.Repository.Release.GetLatest(owner, name);
+        }
+        catch (NotFoundException)
+        {
+            // No releases, or all releases are pre-releases
+        }
+
+        if (release is null)
+        {
+            var releases = await client.Repository.Release.GetAll(owner, name, new() { PageSize = 1 });
+
+            if (releases.Count < 1)
+            {
+                return null;
+            }
+
+            release = releases[0];
+        }
+
+        string releaseName = release.Name;
+
+        if (releaseName[0] is not 'v' && !char.IsAsciiDigit(releaseName[0]))
+        {
+            releaseName = releaseName.Split(' ').Last();
+        }
+
+        releaseName = Uri.EscapeDataString(releaseName).Replace("-", "--", StringComparison.Ordinal);
+
+        return $"https://img.shields.io/badge/release-{releaseName}-blue?logo=github";
+    }
+
+    private async Task<string?> SecurityAlertsAsync(string owner, string name)
+    {
+        int count = 0;
+
+        foreach (var type in AlertTypes)
+        {
+            count += await GetAlertsAsync(client, owner, name, type);
+        }
+
+        string color = count is 0 ? "brightgreen" : "red";
+
+        return $"https://img.shields.io/badge/security-{count}-{color}?logo=github";
+
+        static async Task<int> GetAlertsAsync(IGitHubClient client, string owner, string name, string type)
+        {
+            var parameters = new Dictionary<string, string>(1)
+            {
+                ["state"] = "open",
+            };
+
+            try
+            {
+                if (await client.Connection.Get<object[]>(new($"/repos/{owner}/{name}/{type}/alerts", UriKind.Relative), parameters) is { Body.Length: > 0 } alerts)
+                {
+                    return alerts.Body.Length;
+                }
+            }
+            catch (Exception ex) when (ex is ForbiddenException or NotFoundException)
+            {
+                // Not enabled or no access
+            }
+
+            return 0;
+        }
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    private static partial class Log
+    {
+        [LoggerMessage(
+           EventId = 1,
+           Level = LogLevel.Warning,
+           Message = "Failed to generate badge of type {BadgeType} for {Owner}/{Repository}.")]
+        public static partial void FailedToGenerateBadge(
+            ILogger logger,
+            Exception exception,
+            string badgeType,
+            string owner,
+            string repository);
+    }
+}

--- a/src/Costellobot/GitHubExtensions.cs
+++ b/src/Costellobot/GitHubExtensions.cs
@@ -78,6 +78,7 @@ public static class GitHubExtensions
         services.AddPackageRegistry<NpmPackageRegistry>("Npm");
         services.AddPackageRegistry<NuGetPackageRegistry>("NuGet");
 
+        services.AddSingleton<BadgeService>();
         services.AddSingleton<PublicHolidayProvider>();
 
         services.AddSingleton<IHandlerFactory, HandlerFactory>();

--- a/src/Costellobot/GitHubOptions.cs
+++ b/src/Costellobot/GitHubOptions.cs
@@ -9,6 +9,8 @@ public sealed class GitHubOptions
 
     public string AppId { get; set; } = string.Empty;
 
+    public string BadgesKey { get; set; } = string.Empty;
+
     public string ClientId { get; set; } = string.Empty;
 
     public string ClientSecret { get; set; } = string.Empty;

--- a/src/Costellobot/Program.cs
+++ b/src/Costellobot/Program.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Text.Json.Nodes;
 using MartinCostello.Costellobot;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.ResponseCompression;
 using Octokit.Webhooks.AspNetCore;
 
@@ -108,6 +109,16 @@ app.UseAuthorization();
 
 app.MapAuthenticationRoutes();
 app.MapGitHubWebhooks("/github-webhook", app.Configuration["GitHub:WebhookSecret"] ?? string.Empty);
+
+app.MapGet("/badge/{type}/{owner}/{repo}", async (string type, string owner, string repo, [FromQuery(Name = "s")] string? signature, BadgeService service) =>
+{
+    if (await service.GetBadgeAsync(type, owner, repo, signature) is { } url)
+    {
+        return Results.Redirect(url);
+    }
+
+    return Results.NotFound();
+}).AllowAnonymous();
 
 app.MapGet("/version", () => new JsonObject()
 {

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -6,6 +6,7 @@
   "GitHub": {
     "AccessToken": "",
     "AppId": "",
+    "BadgesKey": "",
     "ClientId": "",
     "ClientSecret": "",
     "EnterpriseDomain": "",

--- a/tests/Costellobot.Tests/BadgeTests.cs
+++ b/tests/Costellobot.Tests/BadgeTests.cs
@@ -1,0 +1,193 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using JustEat.HttpClientInterception;
+using MartinCostello.Costellobot.Infrastructure;
+
+namespace MartinCostello.Costellobot;
+
+[Collection(AppCollection.Name)]
+public sealed class BadgeTests(AppFixture fixture, ITestOutputHelper outputHelper) : IntegrationTests<AppFixture>(fixture, outputHelper)
+{
+    [Theory]
+    [InlineData("security")]
+    [InlineData("release")]
+    public async Task Cannot_Get_Badge_Without_Signature(string type)
+    {
+        // Arrange
+        using var client = Fixture.CreateHttpClientForApp();
+
+        // Act
+        using var response = await client.GetAsync($"/badge/{type}/github-user/github-repo");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("invalid-signature")]
+    [InlineData("++++++++++++++++++++++++++++")]
+    [InlineData("============================")]
+    [InlineData("////////////////////////////")]
+    [InlineData("gAKMaYt06qT+tWTWAEJo54nc15Q=")]
+    [InlineData("lm2VKg2sppYxul0S2SxWb0txKu7jBfm6+qqYi5tvP2I=")]
+    [InlineData("fSANxeXb07Skc0tV/ZHUv8lGo/iKi+OpGdLPb6BbmfLPQP2bEHZL7fAhT0BTivCi")]
+    [InlineData("wlP/xeSHaugTF0Y1Lf8HKCub9nYbtXBZ85Ghn92ttE96YDUvwxAtmSuB64XKrDAW+EjcBTO35c0TJx0jWWDT6Q==")]
+    public async Task Cannot_Get_Badge_Without_Valid_Signature(string signature)
+    {
+        // Arrange
+        using var client = Fixture.CreateHttpClientForApp();
+
+        // Act
+        using var response = await client.GetAsync($"/badge/security/github-user/github-repo?s={signature}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Forbidden)]
+    [InlineData(HttpStatusCode.NotFound)]
+    public async Task Can_Get_Security_Badge_When_No_Access(HttpStatusCode statusCode)
+    {
+        // Arrange
+        string owner = "github-user";
+        string repo = "github-repo";
+        string signature = CreateSignature("security", owner, repo);
+
+        RegisterGetAccessToken();
+
+        Fixture.Interceptor.RegisterGet($"https://api.github.com/repos/{owner}/{repo}/code-scanning/alerts?state=open", "{}", statusCode);
+        Fixture.Interceptor.RegisterGet($"https://api.github.com/repos/{owner}/{repo}/dependabot/alerts?state=open", "{}", statusCode);
+        Fixture.Interceptor.RegisterGet($"https://api.github.com/repos/{owner}/{repo}/secret-scanning/alerts?state=open", "{}", statusCode);
+
+        using var client = Fixture.CreateHttpClientForApp();
+
+        // Act
+        using var response = await client.GetAsync($"/badge/security/{owner}/{repo}?s={Uri.EscapeDataString(signature)}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location.ShouldBe(new("https://img.shields.io/badge/security-0-brightgreen?logo=github"));
+    }
+
+    [Fact]
+    public async Task Can_Get_Security_Badge_When_No_Alerts()
+    {
+        // Arrange
+        string owner = "github-user";
+        string repo = "github-repo";
+        string signature = CreateSignature("security", owner, repo);
+
+        RegisterGetAccessToken();
+
+        Fixture.Interceptor.RegisterGetJson($"https://api.github.com/repos/{owner}/{repo}/code-scanning/alerts?state=open", Array.Empty<object>());
+        Fixture.Interceptor.RegisterGetJson($"https://api.github.com/repos/{owner}/{repo}/dependabot/alerts?state=open", Array.Empty<object>());
+        Fixture.Interceptor.RegisterGetJson($"https://api.github.com/repos/{owner}/{repo}/secret-scanning/alerts?state=open", Array.Empty<object>());
+
+        using var client = Fixture.CreateHttpClientForApp();
+
+        // Act
+        using var response = await client.GetAsync($"/badge/security/{owner}/{repo}?s={Uri.EscapeDataString(signature)}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location.ShouldBe(new("https://img.shields.io/badge/security-0-brightgreen?logo=github"));
+    }
+
+    [Fact]
+    public async Task Can_Get_Security_Badge_When_Some_Alerts()
+    {
+        // Arrange
+        string owner = "github-user";
+        string repo = "github-repo";
+        string signature = CreateSignature("security", owner, repo);
+
+        RegisterGetAccessToken();
+
+        Fixture.Interceptor.RegisterGetJson($"https://api.github.com/repos/{owner}/{repo}/code-scanning/alerts?state=open", Alerts(1));
+        Fixture.Interceptor.RegisterGetJson($"https://api.github.com/repos/{owner}/{repo}/dependabot/alerts?state=open", Alerts(3));
+        Fixture.Interceptor.RegisterGetJson($"https://api.github.com/repos/{owner}/{repo}/secret-scanning/alerts?state=open", Alerts(5));
+
+        using var client = Fixture.CreateHttpClientForApp();
+
+        // Act
+        using var response = await client.GetAsync($"/badge/security/{owner}/{repo}?s={Uri.EscapeDataString(signature)}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location.ShouldBe(new("https://img.shields.io/badge/security-9-red?logo=github"));
+
+        static object[] Alerts(int count)
+        {
+            return Enumerable.Range(0, count)
+                .Select((i) => new { })
+                .ToArray();
+        }
+    }
+
+    [Fact]
+    public async Task Cannot_Get_Release_Badge_When_No_Releases()
+    {
+        // Arrange
+        string owner = "github-user";
+        string repo = "github-repo";
+        string signature = CreateSignature("release", owner, repo);
+
+        RegisterGetAccessToken();
+
+        Fixture.Interceptor.RegisterGet($"https://api.github.com/repos/{owner}/{repo}/releases/latest", "{}", HttpStatusCode.NotFound);
+        Fixture.Interceptor.RegisterGet($"https://api.github.com/repos/{owner}/{repo}/releases?per_page=1", "[]");
+
+        using var client = Fixture.CreateHttpClientForApp();
+
+        // Act
+        using var response = await client.GetAsync($"/badge/release/{owner}/{repo}?s={Uri.EscapeDataString(signature)}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Theory]
+    [InlineData("1.2.3", "1.2.3")]
+    [InlineData("v1.2.3", "v1.2.3")]
+    [InlineData("v1.2.3-preview.1", "v1.2.3--preview.1")]
+    [InlineData("My Product 1.2.3", "1.2.3")]
+    public async Task Can_Get_Release_Badge_When_Latest_Release_Found(string name, string expected)
+    {
+        // Arrange
+        string owner = "github-user";
+        string repo = "github-repo";
+        string signature = CreateSignature("release", owner, repo);
+
+        RegisterGetAccessToken();
+
+        /*lang=json,strict*/
+        string json = $$"""{ "name": "{{name}}" }""";
+
+        Fixture.Interceptor.RegisterGet($"https://api.github.com/repos/{owner}/{repo}/releases/latest", json);
+
+        using var client = Fixture.CreateHttpClientForApp();
+
+        // Act
+        using var response = await client.GetAsync($"/badge/release/{owner}/{repo}?s={Uri.EscapeDataString(signature)}");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location.ShouldBe(new($"https://img.shields.io/badge/release-{expected}-blue?logo=github"));
+    }
+
+    private static string CreateSignature(string type, string owner, string repo)
+    {
+        var key = Encoding.UTF8.GetBytes("badges-key");
+        var data = Encoding.UTF8.GetBytes($"badge-{type}-{owner}-{repo}");
+
+        var hmac = HMACSHA256.HashData(key, data);
+        return Convert.ToBase64String(hmac);
+    }
+}

--- a/tests/Costellobot.Tests/Infrastructure/AppFixture.cs
+++ b/tests/Costellobot.Tests/Infrastructure/AppFixture.cs
@@ -113,6 +113,7 @@ public class AppFixture : WebApplicationFactory<Program>, ITestOutputHelperAcces
                 KeyValuePair.Create<string, string?>("ConnectionStrings:AzureStorage", string.Empty),
                 KeyValuePair.Create<string, string?>("GitHub:AccessToken", "gho_github-access-token"),
                 KeyValuePair.Create<string, string?>("GitHub:AppId", "123"),
+                KeyValuePair.Create<string, string?>("GitHub:BadgesKey", "badges-key"),
                 KeyValuePair.Create<string, string?>("GitHub:ClientId", "github-id"),
                 KeyValuePair.Create<string, string?>("GitHub:ClientSecret", "github-secret"),
                 KeyValuePair.Create<string, string?>("GitHub:EnterpriseDomain", string.Empty),


### PR DESCRIPTION
Add endpoint to generate badges backed by GitHub API queries for security alerts and the latest version of releases.
