### PR TITLE
Show delivery count

### DIFF
--- a/src/Costellobot/Pages/Home/Index.cshtml
+++ b/src/Costellobot/Pages/Home/Index.cshtml
@@ -25,6 +25,7 @@
   <div class="container-fluid">
     <h3>
       Webhook Deliveries
+      <span id="webhooks-count"></span>
       <span class="fa-solid fa-box-open" />
     </h3>
     <div class="row">

--- a/src/Costellobot/Pages/Webhooks/Debug.cshtml
+++ b/src/Costellobot/Pages/Webhooks/Debug.cshtml
@@ -16,6 +16,7 @@
                 (WebhookEventType.DeploymentProtectionRule, false),
                 (WebhookEventType.DeploymentStatus, false),
                 (WebhookEventType.Installation, false),
+                (WebhookEventType.IssueComment, false),
                 (WebhookEventType.PullRequest, true),
                 (WebhookEventType.Push, false),
                 (WebhookEventType.Status, false),

--- a/src/Costellobot/scripts/App.ts
+++ b/src/Costellobot/scripts/App.ts
@@ -12,6 +12,7 @@ export class App {
 
     private logsAutoscroll: HTMLInputElement;
     private logsContainer: HTMLInputElement;
+    private webhooksCountContainer: HTMLElement;
     private webhooksIndexContainer: HTMLElement;
     private webhooksContentContainer: HTMLElement;
 
@@ -50,6 +51,7 @@ export class App {
 
     private async initializeLogs(logsContainer: HTMLInputElement): Promise<void> {
         this.logsContainer = logsContainer;
+        this.webhooksCountContainer = document.getElementById('webhooks-count');
         this.webhooksIndexContainer = document.getElementById('webhooks-index');
         this.logsAutoscroll = <HTMLInputElement>document.getElementById('logs-auto-scroll');
         this.webhooksContentContainer = document.getElementById('webhooks-content');
@@ -203,6 +205,7 @@ export class App {
         }
 
         this.webhooksContentContainer.appendChild(contentItem);
+        this.webhooksCountContainer.innerText = `(${this.webhooksContentContainer.children.length.toLocaleString()})`;
     }
 
     private addLog(logEntry: LogEntry) {


### PR DESCRIPTION
- Show the count of webhook deliveries that have been received.
- Add the `issue_comment` event type to the debugging page.
