### PR TITLE
Show event action in logs

### DIFF
--- a/src/Costellobot/GitHubEvent.cs
+++ b/src/Costellobot/GitHubEvent.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Text;
 using System.Text.Json;
 using Octokit.Webhooks;
 
@@ -10,4 +11,19 @@ public record GitHubEvent(
     WebhookHeaders Headers,
     WebhookEvent Event,
     IDictionary<string, string> RawHeaders,
-    JsonElement RawPayload);
+    JsonElement RawPayload)
+{
+    public override string ToString()
+    {
+        var builder = new StringBuilder()
+            .Append(Headers.Event);
+
+        if (Event.Action is { Length: > 0 })
+        {
+            builder.Append(':')
+                   .Append(Event.Action);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/Costellobot/GitHubWebhookDispatcher.cs
+++ b/src/Costellobot/GitHubWebhookDispatcher.cs
@@ -13,11 +13,11 @@ public sealed partial class GitHubWebhookDispatcher(
 {
     public async Task DispatchAsync(GitHubEvent message)
     {
-        Log.ProcessingWebhook(logger, message.Headers.Delivery, message.Headers.Event);
+        Log.ProcessingWebhook(logger, message.Headers.Delivery, message);
 
         if (!IsValidInstallation(message))
         {
-            Log.IncorrectInstallationWebhookIgnored(logger, message.Headers.Delivery, message.Headers.Event, message.Event.Installation?.Id);
+            Log.IncorrectInstallationWebhookIgnored(logger, message.Headers.Delivery, message, message.Event.Installation?.Id);
             return;
         }
 
@@ -26,11 +26,11 @@ public sealed partial class GitHubWebhookDispatcher(
             var handler = handlerFactory.Create(message.Headers.Event);
             await handler.HandleAsync(message.Event);
 
-            Log.ProcessedWebhook(logger, message.Headers.Delivery, message.Headers.Event);
+            Log.ProcessedWebhook(logger, message.Headers.Delivery, message);
         }
         catch (Exception ex)
         {
-            Log.WebhookProcessingFailed(logger, ex, message.Headers.Delivery, message.Headers.Event);
+            Log.WebhookProcessingFailed(logger, ex, message.Headers.Delivery, message);
             throw;
         }
     }
@@ -44,25 +44,25 @@ public sealed partial class GitHubWebhookDispatcher(
         [LoggerMessage(
            EventId = 1,
            Level = LogLevel.Debug,
-           Message = "Processing webhook with ID {HookId} for event {EventName}.")]
-        public static partial void ProcessingWebhook(ILogger logger, string? hookId, string? eventName);
+           Message = "Processing webhook with ID {HookId} for event {Event}.")]
+        public static partial void ProcessingWebhook(ILogger logger, string? hookId, GitHubEvent @event);
 
         [LoggerMessage(
            EventId = 2,
            Level = LogLevel.Information,
-           Message = "Processed webhook with ID {HookId} for event {EventName}.")]
-        public static partial void ProcessedWebhook(ILogger logger, string? hookId, string? eventName);
+           Message = "Processed webhook with ID {HookId} for event {Event}.")]
+        public static partial void ProcessedWebhook(ILogger logger, string? hookId, GitHubEvent @event);
 
         [LoggerMessage(
            EventId = 3,
            Level = LogLevel.Warning,
-           Message = "Ignored webhook with ID {HookId} for event {EventName} as the installation ID {InstallationId} is incorrect.")]
-        public static partial void IncorrectInstallationWebhookIgnored(ILogger logger, string? hookId, string? eventName, long? installationId);
+           Message = "Ignored webhook with ID {HookId} for event {Event} as the installation ID {InstallationId} is incorrect.")]
+        public static partial void IncorrectInstallationWebhookIgnored(ILogger logger, string? hookId, GitHubEvent @event, long? installationId);
 
         [LoggerMessage(
            EventId = 4,
            Level = LogLevel.Error,
-           Message = "Failed to process webhook with ID {HookId} for event {EventName}.")]
-        public static partial void WebhookProcessingFailed(ILogger logger, Exception exception, string? hookId, string? eventName);
+           Message = "Failed to process webhook with ID {HookId} for event {Event}.")]
+        public static partial void WebhookProcessingFailed(ILogger logger, Exception exception, string? hookId, GitHubEvent @event);
     }
 }

--- a/src/Costellobot/styles/main.css
+++ b/src/Costellobot/styles/main.css
@@ -134,7 +134,7 @@ textarea.form-payload {
 
     main.container {
         max-width: unset;
-        width: 75%;
+        width: 80%;
     }
 
     .log-console,
@@ -142,5 +142,9 @@ textarea.form-payload {
     .log-console[readonly] {
         max-height: 23rem;
         min-height: 23rem;
+    }
+
+    main.container:has(div.log-console) {
+        width: 90%;
     }
 }


### PR DESCRIPTION
- Show the action associated with a webhook event in the logs, if available.
- Use 80% of the width on desktop for content; use 90% when there are logs.
