### PR TITLE
Disable format detection

### DIFF
--- a/src/Costellobot/Slices/_Layout.cshtml
+++ b/src/Costellobot/Slices/_Layout.cshtml
@@ -39,6 +39,7 @@
     <meta name="author" content="@(author)" />
     <meta name="copyright" content="&copy; @(author) @(DateTimeOffset.UtcNow.Date.Year)" />
     <meta name="description" content="@(description)" />
+    <meta name="format-detection" content="telephone=no" />
     <meta name="language" content="en" />
     <meta name="keywords" content="github" />
     <meta name="referrer" content="no-referrer-when-downgrade" />


### PR DESCRIPTION
Prevent iOS from detecting telephone numbers in JSON payloads.
<!--

Summarise the changes this Pull Request makes.

Please include a reference to a GitHub issue if appropriate.

-->
