### PR TITLE
Messaging fixes

### DIFF
--- a/src/Costellobot/GitHubEventProcessor.cs
+++ b/src/Costellobot/GitHubEventProcessor.cs
@@ -35,6 +35,9 @@ public sealed partial class GitHubEventProcessor(
         (var rawHeaders, var rawPayload) = await BroadcastLogAsync(headers, body);
 
         var webhookHeaders = WebhookHeaders.Parse(headers);
+
+        using var scope = logger.BeginScope(webhookHeaders);
+
         var webhookEvent = DeserializeWebhookEvent(webhookHeaders, body);
 
         Log.ReceivedWebhook(logger, webhookHeaders.Delivery);

--- a/src/Costellobot/GitHubMessageProcessor.cs
+++ b/src/Costellobot/GitHubMessageProcessor.cs
@@ -19,6 +19,9 @@ public sealed partial class GitHubMessageProcessor(
         (var rawHeaders, var rawPayload) = ParseRaw(headers, body);
 
         var webhookHeaders = WebhookHeaders.Parse(headers);
+
+        using var scope = logger.BeginScope(webhookHeaders);
+
         var webhookEvent = DeserializeWebhookEvent(webhookHeaders, body);
 
         Log.ReceivedWebhook(logger, webhookHeaders.Delivery);

--- a/src/Costellobot/GitHubMessageSerializer.cs
+++ b/src/Costellobot/GitHubMessageSerializer.cs
@@ -20,11 +20,9 @@ public sealed partial class GitHubMessageSerializer
 
     public static (IDictionary<string, StringValues> Headers, string Body) Deserialize(ServiceBusReceivedMessage message)
     {
-        var contentEncoding = GetEncoding(message);
-
         GitHubMessage payload;
 
-        if (contentEncoding is Brotli)
+        if (GetEncoding(message) is Brotli)
         {
             using var compressed = message.Body.ToStream();
             using var utf8Json = Decompress(compressed);

--- a/src/Costellobot/ILoggerExtensions.cs
+++ b/src/Costellobot/ILoggerExtensions.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Octokit.Webhooks;
+
+namespace MartinCostello.Costellobot;
+
+public static class ILoggerExtensions
+{
+    public static IDisposable? BeginScope(this ILogger logger, WebhookHeaders headers)
+    {
+        var items = new Dictionary<string, object?>(2)
+        {
+            ["GitHubDelivery"] = headers.Delivery,
+            ["GitHubEvent"] = headers.Event,
+        };
+
+        return logger.BeginScope(items);
+    }
+}

--- a/tests/Costellobot.Tests/GitHubMessageSerializerTests.cs
+++ b/tests/Costellobot.Tests/GitHubMessageSerializerTests.cs
@@ -58,13 +58,14 @@ public static class GitHubMessageSerializerTests
         // Assert
         serialized.ShouldNotBeNull();
         serialized.Body.ShouldNotBeNull();
+        serialized.Body.ToArray().Length.ShouldBeLessThanOrEqualTo(256 * 1024);
         serialized.ContentType.ShouldBe("application/json");
         serialized.MessageId.ShouldBe(deliveryId);
         serialized.Subject.ShouldBe("github-webhook");
         serialized.ApplicationProperties.ShouldContainKey("publisher");
-        serialized.GetRawAmqpMessage().Properties.ContentEncoding.ShouldBeNull();
 
         var amqp = serialized.GetRawAmqpMessage();
+        amqp.Properties.ContentEncoding.ShouldBeNull();
 
         var message = ServiceBusReceivedMessage.FromAmqpMessage(amqp, BinaryData.FromBytes([]));
 

--- a/tests/Costellobot.Tests/GitHubMessageSerializerTests.cs
+++ b/tests/Costellobot.Tests/GitHubMessageSerializerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using Azure.Core.Amqp;
 using Azure.Messaging.ServiceBus;
 
 namespace MartinCostello.Costellobot;
@@ -63,8 +62,72 @@ public static class GitHubMessageSerializerTests
         serialized.MessageId.ShouldBe(deliveryId);
         serialized.Subject.ShouldBe("github-webhook");
         serialized.ApplicationProperties.ShouldContainKey("publisher");
+        serialized.GetRawAmqpMessage().Properties.ContentEncoding.ShouldBeNull();
 
-        var amqp = new AmqpAnnotatedMessage(AmqpMessageBody.FromData([serialized.Body]));
+        var amqp = serialized.GetRawAmqpMessage();
+
+        var message = ServiceBusReceivedMessage.FromAmqpMessage(amqp, BinaryData.FromBytes([]));
+
+        (var actualHeaders, var actualBody) = GitHubMessageSerializer.Deserialize(message);
+
+        // Assert
+        actualHeaders.ShouldNotBeNull();
+        actualBody.ShouldNotBeNull();
+        actualBody.ShouldBe(body);
+        actualHeaders.Keys.ToArray().ShouldBeEquivalentTo(headers.Keys.ToArray());
+        actualHeaders.Keys.ShouldAllBe((key) => actualHeaders[key].ToArray().SequenceEqual(new[] { headers[key] }));
+    }
+
+    [Theory]
+    [InlineData(128 * 1024, null)]
+    [InlineData(256 * 1024, "br")]
+    [InlineData(512 * 1024, "br")]
+    [InlineData(1024 * 1024, "br")]
+    [InlineData(2048 * 1024, "br")]
+    public static void GitHub_Payload_Can_Be_Roundtripped_For_Large_Paylods(
+        int length,
+        string? expectedContentEncoding)
+    {
+        // Arrange
+        var deliveryId = "1d6e86da-0a1f-46c7-99c8-f0d488cd0cd1";
+        var headers = new Dictionary<string, string>()
+        {
+            ["Accept"] = "*/*",
+            ["Content-Type"] = "application/json",
+            ["User-Agent"] = "GitHub-Hookshot/f22e2d9",
+            ["X-GitHub-Delivery"] = deliveryId,
+            ["X-GitHub-Event"] = "ping",
+            ["X-GitHub-Hook-ID"] = "456789",
+            ["X-GitHub-Hook-Installation-Target-ID"] = "123456",
+            ["X-GitHub-Hook-Installation-Target-Type"] = "integration",
+            ["X-Hub-Signature"] = "sha1=db2e04e6528d52be37e76cc047b50213d5d99de5",
+            ["X-Hub-Signature-256"] = "sha256=687f2fd74fc04b0ed1d34477cd4915ced4803b91a22422445c36853f11c5d99b",
+        };
+
+        // lang=json,strict
+        string body =
+            $$"""
+              {
+                 "content": "{{new string('a', length)}}"
+              }
+              """;
+
+        // Act
+        var serialized = GitHubMessageSerializer.Serialize(deliveryId, headers, body);
+
+        // Assert
+        serialized.ShouldNotBeNull();
+        serialized.Body.ShouldNotBeNull();
+        serialized.Body.ToArray().Length.ShouldBeLessThanOrEqualTo(256 * 1024);
+
+        serialized.ContentType.ShouldBe("application/json");
+        serialized.MessageId.ShouldBe(deliveryId);
+        serialized.Subject.ShouldBe("github-webhook");
+        serialized.ApplicationProperties.ShouldContainKey("publisher");
+
+        var amqp = serialized.GetRawAmqpMessage();
+        amqp.Properties.ContentEncoding.ShouldBe(expectedContentEncoding);
+
         var message = ServiceBusReceivedMessage.FromAmqpMessage(amqp, BinaryData.FromBytes([]));
 
         (var actualHeaders, var actualBody) = GitHubMessageSerializer.Deserialize(message);


### PR DESCRIPTION
- Compress payloads that are larger than 256KB.
- Explicitly disable indentation of serialized message payloads.
- Include the GitHub event and delivery ID in the logging scope when processing payloads.
