### PR TITLE
Support JSON error responses

### DIFF
--- a/src/Costellobot/AdminEndpoints.cs
+++ b/src/Costellobot/AdminEndpoints.cs
@@ -33,6 +33,11 @@ public static class AdminEndpoints
                 statusCode = StatusCodes.Status500InternalServerError;
             }
 
+            if (context.Request.IsJson())
+            {
+                return Results.Problem(statusCode: statusCode);
+            }
+
             var model = new ErrorModel(statusCode)
             {
                 RequestId = Activity.Current?.Id ?? context.TraceIdentifier,

--- a/src/Costellobot/HttpRequestExtensions.cs
+++ b/src/Costellobot/HttpRequestExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Primitives;
+
+namespace MartinCostello.Costellobot;
+
+public static class HttpRequestExtensions
+{
+    public static bool IsJson(this HttpRequest request)
+    {
+        var headers = request.GetTypedHeaders();
+
+        return IsJson(headers.ContentType?.MediaType ?? StringSegment.Empty) || headers.Accept.Any((p) => IsJson(p.MediaType));
+
+        static bool IsJson(StringSegment? segment)
+            => segment?.Equals("application/json", StringComparison.OrdinalIgnoreCase) is true;
+    }
+}


### PR DESCRIPTION
Return a `ProblemDetails` if an error occurs and the client has sent or accepts `application/json`.
