### PR TITLE
Fix trusted packages not being approved

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,6 +35,7 @@
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.5.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.10.1" />
     <PackageVersion Include="Octokit" Version="13.0.1" />
     <PackageVersion Include="Octokit.GraphQL" Version="0.4.0-beta" />
     <PackageVersion Include="Octokit.Webhooks.AspNetCore" Version="2.2.2" />

--- a/src/Costellobot/Costellobot.csproj
+++ b/src/Costellobot/Costellobot.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="Octokit" />
     <PackageReference Include="Octokit.GraphQL" />
     <PackageReference Include="Octokit.Webhooks.AspNetCore" />

--- a/src/Costellobot/GitCommitAnalyzer.cs
+++ b/src/Costellobot/GitCommitAnalyzer.cs
@@ -27,12 +27,12 @@ public sealed partial class GitCommitAnalyzer(
         string escapedName = Regex.Escape(dependencyName).Replace("/", @"\/", StringComparison.Ordinal);
         string[] patterns =
         [
-            $@"(Bumps|Updates) {escapedName} from (?<from>\d[^ ]*) to (?<to>\d[^ ]*)\.", // Normal version updates
-            $@"(Bumps|Updates) `{escapedName}` from (?<from>\d[^ ]*) to (?<to>\d[^ ]*)\.?$", // Normal version updates with escaped name
-            $@"(Bumps|Updates) \[{escapedName}\]\(.*\) from (?<from>\d[^ ]*) to (?<to>\d[^ ]*)\.?$", // Normal version updates with link to repo
-            $@"(Bumps|Updates) `?{escapedName}`? from \`(?<from>[\da-f][^ ]*)\` to \`(?<to>[\da-f][^ ]*)\`\.?$", // Git submodule updates
-            $@"(Bumps|Updates) \[{escapedName}\]\(.*\) from \`(?<from>[\da-f][^ ]*)\` to \`(?<to>[\da-f][^ ]*)\`\.?", // Git submodule updates with link to repo
-            $@"\[{escapedName}\]\(.*\)\.\s+\- \[Commits\]\(.*\/(?<from>\d[^ ]*)\.\.\.(?<to>\d[^ ]*)\)", // Grouped version update that updates one package
+            $@"(Bumps|Updates) {escapedName} from (?<from>\d[^ ]*) to (?<to>\d[^ \n]*)\.", // Normal version updates
+            $@"(Bumps|Updates) `{escapedName}` from (?<from>\d[^ ]*) to (?<to>\d[^ \n]*)\.?$", // Normal version updates with escaped name
+            $@"(Bumps|Updates) \[{escapedName}\]\(.*\) from (?<from>\d[^ ]*) to (?<to>\d[^ \n]*)\.?$", // Normal version updates with link to repo
+            $@"(Bumps|Updates) `?{escapedName}`? from \`(?<from>[\da-f][^ ]*)\` to \`(?<to>[\da-f][^ \n]*)\`\.?$", // Git submodule updates
+            $@"(Bumps|Updates) \[{escapedName}\]\(.*\) from \`(?<from>[\da-f][^ ]*)\` to \`(?<to>[\da-f][^ \n]*)\`\.?", // Git submodule updates with link to repo
+            $@"\[{escapedName}\]\(.*\)\.\s+\- \[Commits\]\(.*\/(?<from>\d[^ ]*)\.\.\.(?<to>\d[^ \n]*)\)", // Grouped version update that updates one package
         ];
 
         foreach (var pattern in patterns)

--- a/src/Costellobot/GitHubExtensions.cs
+++ b/src/Costellobot/GitHubExtensions.cs
@@ -84,7 +84,7 @@ public static class GitHubExtensions
         services.AddSingleton<BadgeService>();
         services.AddSingleton<PublicHolidayProvider>();
 
-        services.AddSingleton<IHandlerFactory, HandlerFactory>();
+        services.AddScoped<IHandlerFactory, HandlerFactory>();
         services.AddTransient<CheckSuiteHandler>();
         services.AddTransient<DeploymentProtectionRuleHandler>();
         services.AddTransient<DeploymentStatusHandler>();

--- a/tests/Costellobot.Tests/Registries/NuGetPackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/NuGetPackageRegistryTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Caching.Memory;
 
 namespace MartinCostello.Costellobot.Registries;
 
-public static class NuGetPackageRegistryTests
+public class NuGetPackageRegistryTests(ITestOutputHelper outputHelper)
 {
     [Theory]
     [InlineData("AWSSDK.S3", "3.7.9.32", new[] { "awsdotnet" })]
@@ -17,7 +17,8 @@ public static class NuGetPackageRegistryTests
     [InlineData("Octokit.GraphQL", "0.1.9-beta", new[] { "GitHub", "grokys", "jcansdale", "nickfloyd", "StanleyGoldman" })]
     [InlineData("Octokit.Webhooks.AspNetCore", "1.4.0", new[] { "GitHub", "kfcampbell" })]
     [InlineData("foo", "1.0.0", new string[0])]
-    public static async Task Can_Get_Package_Owners(string id, string version, string[] expected)
+    [InlineData("System.Text.Json", "malformed", new string[0])]
+    public async Task Can_Get_Package_Owners(string id, string version, string[] expected)
     {
         // Arrange
         var repository = new RepositoryId("some-org", "some-repo");
@@ -31,7 +32,7 @@ public static class NuGetPackageRegistryTests
 
         using var cache = new MemoryCache(new MemoryCacheOptions());
 
-        var target = new NuGetPackageRegistry(client, cache);
+        var target = new NuGetPackageRegistry(client, cache, outputHelper.ToLogger<NuGetPackageRegistry>());
 
         // Act
         var actual = await target.GetPackageOwnersAsync(


### PR DESCRIPTION
- Fix regular expressions so that version numbers in commit messages are parsed correctly when there are no release notes present.
- Log warning if an invalid NuGet package version is encountered.
- Fix `HandlerFactory` scope.
