### PR TITLE
Avoid warning for installation webhook events

### DIFF
--- a/src/Costellobot/AuthenticationEndpoints.cs
+++ b/src/Costellobot/AuthenticationEndpoints.cs
@@ -145,10 +145,10 @@ public static class AuthenticationEndpoints
 
     public static IEndpointRouteBuilder MapAuthenticationRoutes(this IEndpointRouteBuilder builder)
     {
-        builder.MapGet(DeniedPath, () => Results.Redirect(SignInPath + "?denied=true"));
-        builder.MapGet(ForbiddenPath, () => Results.Redirect(ErrorPath + "?id=403"));
+        builder.MapGet(DeniedPath, () => Results.LocalRedirect(SignInPath + "?denied=true"));
+        builder.MapGet(ForbiddenPath, () => Results.LocalRedirect(ErrorPath + "?id=403"));
 
-        builder.MapGet(SignOutPath, () => Results.Redirect(RootPath));
+        builder.MapGet(SignOutPath, () => Results.LocalRedirect(RootPath));
 
         builder.MapGet(SignInPath, (HttpContext context, IAntiforgery antiforgery) =>
         {
@@ -167,7 +167,7 @@ public static class AuthenticationEndpoints
             if (!await antiforgery.IsRequestValidAsync(context))
             {
                 antiforgery.SetCookieTokenAndHeader(context);
-                return Results.Redirect(RootPath);
+                return Results.LocalRedirect(RootPath);
             }
 
             return Results.Challenge(
@@ -179,7 +179,7 @@ public static class AuthenticationEndpoints
         {
             if (!await antiforgery.IsRequestValidAsync(context))
             {
-                return Results.Redirect(RootPath);
+                return Results.LocalRedirect(RootPath);
             }
 
             return Results.SignOut(

--- a/src/Costellobot/GitHubWebhookDispatcher.cs
+++ b/src/Costellobot/GitHubWebhookDispatcher.cs
@@ -36,7 +36,16 @@ public sealed partial class GitHubWebhookDispatcher(
     }
 
     private bool IsValidInstallation(GitHubEvent message)
-        => message.Event.Installation?.Id == options.CurrentValue.InstallationId;
+    {
+        long? installationId = message.Event switch
+        {
+            Octokit.Webhooks.Events.InstallationEvent installation => installation.Installation.Id,
+            Octokit.Webhooks.Events.InstallationRepositoriesEvent repos => repos.Installation.Id,
+            _ => message.Event.Installation?.Id,
+        };
+
+        return installationId == options.CurrentValue.InstallationId;
+    }
 
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     private static partial class Log

--- a/src/Costellobot/Slices/Debug.cshtml
+++ b/src/Costellobot/Slices/Debug.cshtml
@@ -15,6 +15,7 @@
                 (WebhookEventType.DeploymentProtectionRule, false),
                 (WebhookEventType.DeploymentStatus, false),
                 (WebhookEventType.Installation, false),
+                (WebhookEventType.InstallationRepositories, false),
                 (WebhookEventType.IssueComment, false),
                 (WebhookEventType.PullRequest, true),
                 (WebhookEventType.Push, false),

--- a/tests/Costellobot.Tests/Handlers/HandlerFactoryTests.cs
+++ b/tests/Costellobot.Tests/Handlers/HandlerFactoryTests.cs
@@ -17,6 +17,8 @@ public static class HandlerFactoryTests
     [InlineData("check_suite", typeof(CheckSuiteHandler))]
     [InlineData("deployment_protection_rule", typeof(DeploymentProtectionRuleHandler))]
     [InlineData("deployment_status", typeof(DeploymentStatusHandler))]
+    [InlineData("installation", typeof(NullHandler))]
+    [InlineData("installation_repositories", typeof(NullHandler))]
     [InlineData("issues", typeof(NullHandler))]
     [InlineData("issue_comment", typeof(IssueCommentHandler))]
     [InlineData("ping", typeof(NullHandler))]

--- a/tests/Costellobot.Tests/ResourceTests.cs
+++ b/tests/Costellobot.Tests/ResourceTests.cs
@@ -108,6 +108,36 @@ public sealed class ResourceTests(AppFixture fixture, ITestOutputHelper outputHe
         response.Headers.Location.OriginalString.ShouldBe("/");
     }
 
+    [Fact]
+    public async Task Sign_In_Redirects_To_Return_Url_If_Authenticated()
+    {
+        // Arrange
+        using var client = await CreateAuthenticatedClientAsync();
+
+        // Act
+        using var response = await client.GetAsync("/sign-in?ReturnUrl=%2Fdebug");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location.ShouldNotBeNull();
+        response.Headers.Location.OriginalString.ShouldBe("/debug");
+    }
+
+    [Fact]
+    public async Task Sign_In_Does_Not_Open_Redirect()
+    {
+        // Arrange
+        using var client = await CreateAuthenticatedClientAsync();
+
+        // Act
+        using var response = await client.GetAsync("/sign-in?ReturnUrl=http%3A%2F%2Fcostellobot.local%2Fdebug");
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
+        response.Headers.Location.ShouldNotBeNull();
+        response.Headers.Location.OriginalString.ShouldBe("/");
+    }
+
     [Theory]
     [InlineData("/sign-in")]
     [InlineData("/sign-out")]


### PR DESCRIPTION
- Avoid warnings for `installation` and `installation_repositories` due to the installation ID being incorrectly checked for.
- Use `ReturnUrl` when signing in if it is a local URL.
- Explicitly use `Results.LocalRedirect()` for redirects that should only ever be local and is a bug if not.
- Add the `installation_repositories` event to the debug page.
