### PR TITLE
Add Aspire health checks

### DIFF
--- a/src/Costellobot/HealthCheckEndpoints.cs
+++ b/src/Costellobot/HealthCheckEndpoints.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace MartinCostello.Costellobot;
+
+public static class HealthCheckEndpoints
+{
+    private const string LiveTag = "live";
+
+    public static IServiceCollection AddApplicationHealthChecks(this IServiceCollection services)
+    {
+        services.AddHealthChecks()
+                .AddCheck("self", () => HealthCheckResult.Healthy(), [LiveTag]);
+
+        return services;
+    }
+
+    public static IEndpointRouteBuilder MapHealthCheckRoutes(this IEndpointRouteBuilder builder)
+    {
+        builder.MapHealthCheck("/health/readiness");
+        builder.MapHealthCheck("/health/startup");
+        builder.MapHealthCheck("/health/liveness", (p) => p.Predicate = (r) => r.Tags.Contains(LiveTag));
+
+        return builder;
+    }
+
+    private static void MapHealthCheck(this IEndpointRouteBuilder builder, string pattern, Action<HealthCheckOptions>? configure = null)
+    {
+        var options = new HealthCheckOptions() { ResponseWriter = WriteResponse };
+
+        configure?.Invoke(options);
+
+        builder.MapHealthChecks(pattern, options)
+               .RequireHost(["localhost", "127.0.0.1"]);
+    }
+
+    private static Task WriteResponse(HttpContext context, HealthReport healthReport)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream, new() { Indented = true }))
+        {
+            writer.WriteStartObject();
+            {
+                writer.WriteString("status", healthReport.Status.ToString());
+                writer.WriteStartObject("results");
+
+                foreach ((var name, var entry) in healthReport.Entries)
+                {
+                    writer.WriteStartObject(name);
+                    {
+                        writer.WriteString("status", entry.Status.ToString());
+
+                        if (entry.Description is { Length: > 0 } description)
+                        {
+                            writer.WriteString("description", description);
+                        }
+
+                        writer.WriteStartObject("data");
+
+                        foreach ((var key, var item) in entry.Data)
+                        {
+                            writer.WritePropertyName(key);
+                            JsonSerializer.Serialize(writer, item, item?.GetType() ?? typeof(object));
+                        }
+
+                        writer.WriteEndObject();
+                    }
+
+                    writer.WriteEndObject();
+                }
+
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndObject();
+        }
+
+        context.Response.ContentType = "application/json; charset=utf-8";
+        return context.Response.WriteAsync(Encoding.UTF8.GetString(stream.ToArray()));
+    }
+}

--- a/src/Costellobot/Octokit/IGitHubClientForApp.cs
+++ b/src/Costellobot/Octokit/IGitHubClientForApp.cs
@@ -3,6 +3,4 @@
 
 namespace Octokit;
 
-public interface IGitHubClientForApp : IGitHubClient
-{
-}
+public interface IGitHubClientForApp : IGitHubClient;

--- a/src/Costellobot/Octokit/IGitHubClientForInstallation.cs
+++ b/src/Costellobot/Octokit/IGitHubClientForInstallation.cs
@@ -3,6 +3,4 @@
 
 namespace Octokit;
 
-public interface IGitHubClientForInstallation : IGitHubClient
-{
-}
+public interface IGitHubClientForInstallation : IGitHubClient;

--- a/src/Costellobot/Program.cs
+++ b/src/Costellobot/Program.cs
@@ -99,9 +99,9 @@ if (!app.Environment.IsDevelopment())
     {
         app.UseHttpsRedirection();
     }
-}
 
-app.UseResponseCompression();
+    app.UseResponseCompression();
+}
 
 app.UseStaticFiles();
 

--- a/src/Costellobot/Program.cs
+++ b/src/Costellobot/Program.cs
@@ -82,9 +82,6 @@ builder.WebHost.ConfigureKestrel((p) => p.AddServerHeader = false);
 
 var app = builder.Build();
 
-// Give the webhook queue a chance to drain before the application stops
-app.Lifetime.ApplicationStopping.Register(() => Thread.Sleep(TimeSpan.FromSeconds(10)));
-
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/error");

--- a/src/Costellobot/Program.cs
+++ b/src/Costellobot/Program.cs
@@ -21,6 +21,7 @@ if (builder.Configuration["ConnectionStrings:AzureBlobStorage"] is { Length: > 0
 }
 
 builder.Services.AddAntiforgery();
+builder.Services.AddApplicationHealthChecks();
 builder.Services.AddGitHub(builder.Configuration);
 builder.Services.AddHsts((options) => options.MaxAge = TimeSpan.FromDays(180));
 builder.Services.AddResponseCaching();
@@ -110,6 +111,7 @@ app.UseAuthorization();
 
 app.UseAntiforgery();
 
+app.MapHealthCheckRoutes();
 app.MapAuthenticationRoutes();
 app.MapApiRoutes(app.Configuration);
 app.MapAdminRoutes();

--- a/src/Costellobot/appsettings.Development.json
+++ b/src/Costellobot/appsettings.Development.json
@@ -1,4 +1,13 @@
 {
+  "Aspire": {
+    "Azure": {
+      "Messaging": {
+        "ServiceBus": {
+          "HealthCheckQueueName": "webhooks-dev"
+        }
+      }
+    }
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -37,6 +37,9 @@
     "Scopes": [],
     "WebhookSecret": ""
   },
+  "HostOptions": {
+    "ShutdownTimeout": "00:00:10"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -9,6 +9,7 @@
     "Azure": {
       "Messaging": {
         "ServiceBus": {
+          "HealthCheckQueueName": "",
           "ClientOptions": {
             "Identifier": "costellobot"
           }

--- a/tests/Costellobot.Tests/Infrastructure/AppFixture.cs
+++ b/tests/Costellobot.Tests/Infrastructure/AppFixture.cs
@@ -122,6 +122,7 @@ public class AppFixture : WebApplicationFactory<Program>, ITestOutputHelperAcces
                 KeyValuePair.Create<string, string?>("GitHub:InstallationId", InstallationId),
                 KeyValuePair.Create<string, string?>("GitHub:PrivateKey", testKey),
                 KeyValuePair.Create<string, string?>("GitHub:WebhookSecret", "github-webhook-secret"),
+                KeyValuePair.Create<string, string?>("HostOptions:ShutdownTimeout", "00:00:01"),
                 KeyValuePair.Create<string, string?>("Site:AdminUsers:0", "john-smith"),
                 KeyValuePair.Create<string, string?>("Webhook:DeployEnvironments:0", "production"),
                 KeyValuePair.Create<string, string?>("Webhook:IgnoreRepositories:0", "ignored-org/ignored-repo"),

--- a/tests/Costellobot.Tests/ResourceTests.cs
+++ b/tests/Costellobot.Tests/ResourceTests.cs
@@ -16,6 +16,9 @@ public sealed class ResourceTests(AppFixture fixture, ITestOutputHelper outputHe
     [InlineData("/error.html", MediaTypeNames.Text.Html)]
     [InlineData("/favicon.png", "image/png")]
     [InlineData("/forbidden.html", MediaTypeNames.Text.Html)]
+    [InlineData("/health/liveness", MediaTypeNames.Application.Json)]
+    [InlineData("/health/readiness", MediaTypeNames.Application.Json)]
+    [InlineData("/health/startup", MediaTypeNames.Application.Json)]
     [InlineData("/humans.txt", MediaTypeNames.Text.Plain)]
     [InlineData("/manifest.webmanifest", "application/manifest+json")]
     [InlineData("/not-found.html", MediaTypeNames.Text.Html)]
@@ -27,6 +30,7 @@ public sealed class ResourceTests(AppFixture fixture, ITestOutputHelper outputHe
     [InlineData("/static/js/main.js", "text/javascript")]
     [InlineData("/static/js/main.js.map", MediaTypeNames.Text.Plain)]
     [InlineData("/unauthorized.html", MediaTypeNames.Text.Html)]
+    [InlineData("/version", MediaTypeNames.Application.Json)]
     public async Task Can_Get_Resource_Unauthenticated(string requestUri, string contentType)
     {
         // Arrange


### PR DESCRIPTION
- Add health checks to integrate with the corresponding built-in functionality in .NET Aspire.
- Set the shutdown timeout with configuration rather than code.
- Lower the shutdown timeout for tests.
- Disable response compression in development to avoid warnings from BrowserLink.
