### PR TITLE
Skip workload manifest update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
 
     - name: Install .NET Workloads
       shell: pwsh
-      run: dotnet workload restore
+      run: dotnet workload restore --skip-manifest-update
 
     - name: Build, Test and Publish
       id: build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Build .NET code
       if: matrix.language == 'csharp'
       run: |
-        dotnet workload restore --skip-manifest-update
+        dotnet workload restore
         dotnet build --configuration Release
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Build .NET code
       if: matrix.language == 'csharp'
       run: |
-        dotnet workload restore
+        dotnet workload restore --skip-manifest-update
         dotnet build --configuration Release
 
     - name: Perform CodeQL Analysis


### PR DESCRIPTION
Skip updating .NET workload manifests to see if it speeds up CI builds on Windows.
