### PR TITLE
Trust babel packages

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -91,6 +91,8 @@
     "TrustedEntities": {
       "Dependencies": [
         "^@actions\/.*$",
+        "^@babel\/core$",
+        "^@babel\/preset-env$",
         "^@microsoft\/signalr$",
         "^@typescript-eslint\/eslint-plugin$",
         "^@typescript-eslint\/parser$",


### PR DESCRIPTION
Trust the `@babel/core` and `@babel/preset-env` packages.
