### PR TITLE
Extract NuGet package versions from Git diffs

### DIFF
--- a/src/Costellobot/GitDiffParser.cs
+++ b/src/Costellobot/GitDiffParser.cs
@@ -31,9 +31,12 @@ public static class GitDiffParser
         string diff,
         [NotNullWhen(true)] out IDictionary<string, (NuGetVersion From, NuGetVersion To)>? packages)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(diff);
-
         packages = null;
+
+        if (string.IsNullOrEmpty(diff))
+        {
+            return false;
+        }
 
         var edits = GetEdits(diff);
 

--- a/src/Costellobot/GitDiffParser.cs
+++ b/src/Costellobot/GitDiffParser.cs
@@ -1,0 +1,229 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Xml.Linq;
+using NuGet.Versioning;
+
+namespace MartinCostello.Costellobot;
+
+public static class GitDiffParser
+{
+    private const char Added = '+';
+    private const char Removed = '-';
+    private const string HunkPrefix = "@@ ";
+
+    private static readonly XName Include = nameof(Include);
+    private static readonly XName GlobalPackageReference = nameof(GlobalPackageReference);
+    private static readonly XName PackageReference = nameof(PackageReference);
+    private static readonly XName PackageVersion = nameof(PackageVersion);
+    private static readonly XName Version = nameof(Version);
+
+    private enum DiffLineType
+    {
+        None = 0,
+        Added,
+        Removed,
+    }
+
+    public static bool TryParseUpdatedPackages(
+        string diff,
+        [NotNullWhen(true)] out IDictionary<string, (NuGetVersion From, NuGetVersion To)>? packages)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(diff);
+
+        packages = null;
+
+        var edits = GetEdits(diff);
+
+        if (edits.Count < 1)
+        {
+            return false;
+        }
+
+        var packageUpdates = GetPackages(edits);
+
+        if (packageUpdates.Count < 1)
+        {
+            return false;
+        }
+
+        packages = packageUpdates;
+        return true;
+    }
+
+    private static Dictionary<string, (NuGetVersion From, NuGetVersion To)> GetPackages(
+        List<(DiffLineType Type, string Package, NuGetVersion Version)> edits)
+    {
+        var comparer = StringComparer.OrdinalIgnoreCase;
+        var added = new Dictionary<string, IList<NuGetVersion>>(comparer);
+        var removed = new Dictionary<string, IList<NuGetVersion>>(comparer);
+
+        foreach (var edit in edits)
+        {
+            Dictionary<string, IList<NuGetVersion>> target;
+
+            if (edit.Type == DiffLineType.Added)
+            {
+                target = added;
+            }
+            else
+            {
+                Debug.Assert(edit.Type is DiffLineType.Removed, "Expected a DiffLineType of Removed.");
+                target = removed;
+            }
+
+            if (!target.TryGetValue(edit.Package, out var versions))
+            {
+                target[edit.Package] = versions = [];
+            }
+
+            versions.Add(edit.Version);
+        }
+
+        var packages = new Dictionary<string, (NuGetVersion From, NuGetVersion To)>(comparer);
+
+        foreach ((var package, var previous) in removed)
+        {
+            if (previous.Count < 1 ||
+                !added.TryGetValue(package, out var updated) ||
+                updated.Count < 1)
+            {
+                continue;
+            }
+
+            var minimum = previous.Min()!;
+            var maximum = updated.Max()!;
+
+            if (minimum < maximum)
+            {
+                packages[package] = (minimum, maximum);
+            }
+        }
+
+        return packages;
+    }
+
+    private static List<(DiffLineType Type, string Package, NuGetVersion Version)> GetEdits(string diff)
+    {
+        using var reader = new StringReader(diff);
+        string? line;
+
+        bool inHunk = false;
+
+        var edits = new List<(DiffLineType Type, string Package, NuGetVersion Version)>();
+
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (line.StartsWith(HunkPrefix, StringComparison.Ordinal))
+            {
+                inHunk = true;
+                continue;
+            }
+            else if (inHunk)
+            {
+                char prefix = line[0];
+
+                if (prefix is Added or Removed)
+                {
+                    if (TryParseLine(line, out var type, out var package))
+                    {
+                        edits.Add((type, package.Value.Package, package.Value.Version));
+                    }
+
+                    continue;
+                }
+                else if (prefix is ' ')
+                {
+                    continue;
+                }
+
+                inHunk = false;
+            }
+        }
+
+        return edits;
+    }
+
+    private static bool TryParseLine(
+        string line,
+        out DiffLineType lineType,
+        [NotNullWhen(true)] out (string Package, NuGetVersion Version)? package)
+    {
+        lineType = DiffLineType.None;
+        package = null;
+
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return false;
+        }
+
+        lineType = line[0] switch
+        {
+            Added => DiffLineType.Added,
+            Removed => DiffLineType.Removed,
+            _ => DiffLineType.None,
+        };
+
+        if (lineType == DiffLineType.None)
+        {
+            return false;
+        }
+
+        var fragmentText = line[1..];
+
+        if (!fragmentText.Contains('<', StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        XElement fragment;
+
+        try
+        {
+            fragment = XElement.Parse(fragmentText);
+
+            if (fragment.Name == PackageReference ||
+                fragment.Name == PackageVersion ||
+                fragment.Name == GlobalPackageReference)
+            {
+                if (TryParsePackage(fragment, out var name, out var version))
+                {
+                    package = (name, version);
+                    return true;
+                }
+            }
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+
+        return false;
+
+        static bool TryParsePackage(
+            XElement element,
+            [NotNullWhen(true)] out string? name,
+            [NotNullWhen(true)] out NuGetVersion? version)
+        {
+            name = null;
+            version = null;
+
+            if (element.Attribute(Include) is not { } include ||
+                include.Value is not { Length: > 0 } packageId)
+            {
+                return false;
+            }
+
+            if (element.Attribute(Version) is not { } attribute ||
+                attribute.Value is not { Length: > 0 } versionString)
+            {
+                return false;
+            }
+
+            name = packageId;
+            return NuGetVersion.TryParse(versionString, out version);
+        }
+    }
+}

--- a/src/Costellobot/GitDiffParser.cs
+++ b/src/Costellobot/GitDiffParser.cs
@@ -131,15 +131,11 @@ public static class GitDiffParser
                     {
                         edits.Add((type, package.Value.Package, package.Value.Version));
                     }
-
-                    continue;
                 }
-                else if (prefix is ' ')
+                else if (prefix is not ' ')
                 {
-                    continue;
+                    inHunk = false;
                 }
-
-                inHunk = false;
             }
         }
 
@@ -184,15 +180,13 @@ public static class GitDiffParser
         {
             fragment = XElement.Parse(fragmentText);
 
-            if (fragment.Name == PackageReference ||
-                fragment.Name == PackageVersion ||
-                fragment.Name == GlobalPackageReference)
+            if ((fragment.Name == PackageReference ||
+                 fragment.Name == PackageVersion ||
+                 fragment.Name == GlobalPackageReference) &&
+                 TryParsePackage(fragment, out var name, out var version))
             {
-                if (TryParsePackage(fragment, out var name, out var version))
-                {
-                    package = (name, version);
-                    return true;
-                }
+                package = (name, version);
+                return true;
             }
         }
         catch (Exception)

--- a/src/Costellobot/GitDiffParser.cs
+++ b/src/Costellobot/GitDiffParser.cs
@@ -107,6 +107,7 @@ public static class GitDiffParser
 
     private static List<(DiffLineType Type, string Package, NuGetVersion Version)> GetEdits(string diff)
     {
+        // See https://stackoverflow.com/a/2530012/1064169
         using var reader = new StringReader(diff);
         string? line;
 

--- a/src/Costellobot/Octokit/IGitHubClientExtensions.cs
+++ b/src/Costellobot/Octokit/IGitHubClientExtensions.cs
@@ -8,6 +8,13 @@ public static class IGitHubClientExtensions
     public static IWorkflowRunsClient WorkflowRuns(this IGitHubClient client)
         => new WorkflowRunsClient(new ApiConnection(client.Connection));
 
+    public static async Task<string> GetDiffAsync(this IGitHubClient client, string url)
+    {
+        var parameters = new Dictionary<string, string>(0);
+        var response = await client.Connection.Get<string>(new(url, UriKind.Absolute), parameters);
+        return response.Body;
+    }
+
     public static async Task RepositoryDispatchAsync(this IGitHubClient client, string owner, string name, object body)
     {
         // See https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event

--- a/tests/Costellobot.Tests/Builders/PullRequestBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/PullRequestBuilder.cs
@@ -59,6 +59,7 @@ public sealed class PullRequestBuilder(RepositoryBuilder repository, UserBuilder
                 @ref = RefHead,
                 sha = ShaHead,
             },
+            diff_url = $"https://api.github.com/repos/{Repository.Owner.Login}/{Repository.Name}/pulls/{Number}.diff",
             html_url = $"https://github.com/{Repository.Owner.Login}/{Repository.Name}/pull/{Number}",
             labels = Labels.Build(),
             mergeable = IsMergeable,

--- a/tests/Costellobot.Tests/Costellobot.Tests.csproj
+++ b/tests/Costellobot.Tests/Costellobot.Tests.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Bundles\*.json" CopyToOutputDirectory="PreserveNewest" />
+    <EmbeddedResource Include="GitDiffParserTests.*.diff" />
     <None Update="costellobot-tests.pem" CopyToOutputDirectory="PreserveNewest" />
     <None Update="localhost-dev.pfx" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/tests/Costellobot.Tests/GitCommitAnalyzerTests.cs
+++ b/tests/Costellobot.Tests/GitCommitAnalyzerTests.cs
@@ -150,6 +150,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
         var repo = owner.CreateRepository();
         var repository = new RepositoryId(repo.Owner.Login, repo.Name);
 
+        var diff = string.Empty;
         var sha = "0304f7fb4e17d674ea52392d70e775761ccf5aed";
         var commitMessage = TrustedCommitMessage(dependency);
 
@@ -158,7 +159,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             repository,
             reference,
             sha,
-            commitMessage);
+            commitMessage,
+            diff);
 
         // Assert
         actual.ShouldBe(expected);
@@ -211,6 +213,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
         using var scope = Fixture.Services.CreateScope();
         var target = CreateTarget(scope.ServiceProvider, options, [registry]);
 
+        var diff = string.Empty;
         var sha = "0304f7fb4e17d674ea52392d70e775761ccf5aed";
         var commitMessage = TrustedCommitMessage(dependency, version);
 
@@ -219,7 +222,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             repository,
             reference,
             sha,
-            commitMessage);
+            commitMessage,
+            diff);
 
         // Assert
         actual.ShouldBe(expected);
@@ -246,6 +250,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
         using var scope = Fixture.Services.CreateScope();
         var target = CreateTarget(scope.ServiceProvider, options, [Substitute.For<IPackageRegistry>()]);
 
+        var diff = string.Empty;
         var sha = "0304f7fb4e17d674ea52392d70e775761ccf5aed";
         var commitMessage = @"""
                             Bump Foo to 1.0.1
@@ -266,7 +271,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             new("someone", "something"),
             "blah-blah",
             sha,
-            commitMessage);
+            commitMessage,
+            diff);
 
         // Assert
         actual.ShouldBeFalse();
@@ -284,6 +290,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
         using var scope = Fixture.Services.CreateScope();
         var target = CreateTarget(scope.ServiceProvider, options, [Substitute.For<IPackageRegistry>()]);
 
+        var diff = string.Empty;
         var sha = "0304f7fb4e17d674ea52392d70e775761ccf5aed";
         var commitMessage = TrustedCommitMessage();
 
@@ -292,7 +299,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             new("someone", "something"),
             "dependabot/nuget/NodaTimeVersion-3.1.0",
             sha,
-            commitMessage);
+            commitMessage,
+            diff);
 
         // Assert
         actual.ShouldBeFalse();
@@ -316,6 +324,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
         using var scope = Fixture.Services.CreateScope();
         var target = CreateTarget(scope.ServiceProvider, options, [Substitute.For<IPackageRegistry>()]);
 
+        var diff = string.Empty;
         var sha = "0304f7fb4e17d674ea52392d70e775761ccf5aed";
         var commitMessage = TrustedCommitMessage();
 
@@ -324,7 +333,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             new("someone", "something"),
             "dependabot/nuget/NodaTimeVersion-3.1.0",
             sha,
-            commitMessage);
+            commitMessage,
+            diff);
 
         // Assert
         actual.ShouldBeFalse();
@@ -363,6 +373,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
         using var scope = Fixture.Services.CreateScope();
         var target = CreateTarget(scope.ServiceProvider, options, [registry]);
 
+        var diff = string.Empty;
         var sha = "0304f7fb4e17d674ea52392d70e775761ccf5aed";
         var commitMessage = TrustedCommitMessage("actions/checkout", "3");
 
@@ -371,7 +382,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             repository,
             "dependabot/github_actions/actions/checkout-3",
             sha,
-            commitMessage);
+            commitMessage,
+            diff);
 
         // Assert
         actual.ShouldBeFalse();
@@ -412,6 +424,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
         using var scope = Fixture.Services.CreateScope();
         var target = CreateTarget(scope.ServiceProvider, options, [registry]);
 
+        var diff = string.Empty;
         var sha = "987879d752236a5a574000f40da7630be061faca";
         var commitMessage = """
                             Bump OpenTelemetryInstrumentationVersion
@@ -443,7 +456,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             repository,
             "dependabot/nuget/OpenTelemetryInstrumentationVersion-1.0.0-rc9.12",
             sha,
-            commitMessage);
+            commitMessage,
+            diff);
 
         // Assert
         actual.ShouldBeTrue();
@@ -478,6 +492,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
         using var scope = Fixture.Services.CreateScope();
         var target = CreateTarget(scope.ServiceProvider, options, [registry]);
 
+        var diff = string.Empty;
         var sha = "62bf0f9046a782d0233aed41e9fe466aa6751f95";
         var commitMessage = """
                             Bump the xunit group with 1 update
@@ -501,7 +516,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             repository,
             "dependabot/nuget/xunit-beb0c94413",
             sha,
-            commitMessage);
+            commitMessage,
+            diff);
 
         // Assert
         actual.ShouldBeTrue();
@@ -539,6 +555,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
         using var scope = Fixture.Services.CreateScope();
         var target = CreateTarget(scope.ServiceProvider, options, [registry]);
 
+        var diff = string.Empty;
         var sha = "dd1180fe710bc24ef13403f2b9dec6e069cb607c";
         var commitMessage = """
                             Bump the xunit group with 2 updates (#315)
@@ -573,7 +590,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             repository,
             "dependabot/nuget/xunit-9380cae661",
             sha,
-            commitMessage);
+            commitMessage,
+            diff);
 
         // Assert
         actual.ShouldBeTrue();
@@ -611,6 +629,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
         using var scope = Fixture.Services.CreateScope();
         var target = CreateTarget(scope.ServiceProvider, options, [registry]);
 
+        var diff = string.Empty;
         var sha = "661369a466e4ac01d5db6057d499074733d8086f";
         var commitMessage = """
                             Bump the xunit group with 2 updates
@@ -641,7 +660,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             repository,
             "dependabot/nuget/xunit-8e312df114",
             sha,
-            commitMessage);
+            commitMessage,
+            diff);
 
         // Assert
         actual.ShouldBeTrue();
@@ -680,6 +700,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
         using var scope = Fixture.Services.CreateScope();
         var target = CreateTarget(scope.ServiceProvider, options, [registry]);
 
+        var diff = string.Empty;
         var sha = "552aae859c24f0ed63bcc1f82ef96dd83040762f";
         var commitMessage = """
                             Bump Microsoft.TypeScript.MSBuild from 4.9.4 to 4.9.5
@@ -698,7 +719,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             repository,
             "dependabot/nuget/Microsoft.TypeScript.MSBuild-4.9.5",
             sha,
-            commitMessage);
+            commitMessage,
+            diff);
 
         // Assert
         actual.ShouldBeTrue();
@@ -742,6 +764,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
         using var scope = Fixture.Services.CreateScope();
         var target = CreateTarget(scope.ServiceProvider, options, [registry]);
 
+        var diff = string.Empty;
         var sha = "4f01e284f9bfac38bcf14f7595b1258fc5b1b542";
         var commitMessage = """
                             Bump .NET NuGet packages
@@ -772,7 +795,89 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             repository,
             "update-dotnet-sdk-7.0.203",
             sha,
-            commitMessage);
+            commitMessage,
+            diff);
+
+        // Assert
+        actual.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Commit_Is_Analyzed_Correctly_With_Trusted_Publisher_For_Grouped_Package_Update_With_Only_Yaml_Frontmatter()
+    {
+        // Arrange
+        var owner = CreateUser();
+        var repo = owner.CreateRepository();
+        var repository = new RepositoryId(repo.Owner.Login, repo.Name);
+
+        var registry = Substitute.For<IPackageRegistry>();
+
+        registry.Ecosystem.Returns(DependencyEcosystem.NuGet);
+
+        registry.GetPackageOwnersAsync(repository, "AWSSDK.SecurityToken", "3.7.300.118")
+                .Returns(Task.FromResult<IReadOnlyList<string>>(["awsdotnet"]));
+
+        registry.GetPackageOwnersAsync(repository, "AWSSDK.SimpleSystemsManagement", "3.7.305.8")
+                .Returns(Task.FromResult<IReadOnlyList<string>>(["awsdotnet"]));
+
+        var options = new WebhookOptions()
+        {
+            TrustedEntities = new()
+            {
+                Publishers = new Dictionary<DependencyEcosystem, IList<string>>()
+                {
+                    [DependencyEcosystem.NuGet] = ["awsdotnet"],
+                },
+            },
+        };
+
+        using var scope = Fixture.Services.CreateScope();
+        var target = CreateTarget(scope.ServiceProvider, options, [registry]);
+
+        var sha = "bd2804732332a86c336d1c9308b9dba36f0c2e03";
+        var commitMessage = """
+                            Bump the awssdk group with 2 updates
+                            ---
+                            updated-dependencies:
+                            - dependency-name: AWSSDK.SecurityToken
+                              dependency-type: direct:production
+                              update-type: version-update:semver-patch
+                              dependency-group: awssdk
+                            - dependency-name: AWSSDK.SimpleSystemsManagement
+                              dependency-type: direct:production
+                              update-type: version-update:semver-patch
+                              dependency-group: awssdk
+                            ...
+
+                            Signed-off-by: dependabot[bot] <support@github.com>
+                            """;
+
+        var diff =
+            """
+            diff --git a/Directory.Packages.props b/Directory.Packages.props
+            index 5efad590..bd28047 100644
+            --- a/Directory.Packages.props
+            +++ b/Directory.Packages.props
+            @@ -7,8 +7,8 @@
+               <ItemGroup>
+                 <PackageVersion Include="Amazon.AspNetCore.DataProtection.SSM" Version="3.2.1" />
+                 <PackageVersion Include="Aspire.Hosting.AppHost" Version="8.1.0" />
+            -    <PackageVersion Include="AWSSDK.SecurityToken" Version="3.7.300.117" />
+            -    <PackageVersion Include="AWSSDK.SimpleSystemsManagement" Version="3.7.305.7" />
+            +    <PackageVersion Include="AWSSDK.SecurityToken" Version="3.7.300.118" />
+            +    <PackageVersion Include="AWSSDK.SimpleSystemsManagement" Version="3.7.305.8" />
+                 <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+                 <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
+                 <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
+            """;
+
+        // Act
+        var actual = await target.IsTrustedDependencyUpdateAsync(
+            repository,
+            "dependabot/nuget/awssdk-b8164d6bd2",
+            sha,
+            commitMessage,
+            diff);
 
         // Assert
         actual.ShouldBeTrue();

--- a/tests/Costellobot.Tests/GitDiffParserTests.MultipleFiles.diff
+++ b/tests/Costellobot.Tests/GitDiffParserTests.MultipleFiles.diff
@@ -1,0 +1,208 @@
+diff --git a/.vscode/launch.json b/.vscode/launch.json
+index 154f9ac8..617e9d71 100644
+--- a/.vscode/launch.json
++++ b/.vscode/launch.json
+@@ -6,7 +6,7 @@
+       "type": "coreclr",
+       "request": "launch",
+       "preLaunchTask": "build",
+-      "program": "${workspaceFolder}/src/TodoApp/bin/Debug/net8.0/TodoApp.dll",
++      "program": "${workspaceFolder}/src/TodoApp/bin/Debug/net9.0/TodoApp.dll",
+       "args": [],
+       "cwd": "${workspaceFolder}/src/TodoApp",
+       "stopAtEntry": false,
+diff --git a/.vsconfig b/.vsconfig
+index e47eff05..694c29fc 100644
+--- a/.vsconfig
++++ b/.vsconfig
+@@ -3,7 +3,7 @@
+   "components": [
+     "Microsoft.VisualStudio.Component.CoreEditor",
+     "Microsoft.VisualStudio.Workload.CoreEditor",
+-    "Microsoft.NetCore.Component.Runtime.8.0",
++    "Microsoft.NetCore.Component.Runtime.9.0",
+     "Microsoft.NetCore.Component.SDK",
+     "Microsoft.VisualStudio.Component.Roslyn.Compiler",
+     "Microsoft.VisualStudio.Component.Roslyn.LanguageServices",
+diff --git a/Directory.Build.props b/Directory.Build.props
+index 2dc78d8b..868a8118 100644
+--- a/Directory.Build.props
++++ b/Directory.Build.props
+@@ -8,7 +8,7 @@
+     <EnableNETAnalyzers>true</EnableNETAnalyzers>
+     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+     <ImplicitUsings>enable</ImplicitUsings>
+-    <LangVersion>latest</LangVersion>
++    <LangVersion>preview</LangVersion>
+     <NeutralLanguage>en-US</NeutralLanguage>
+     <Nullable>enable</Nullable>
+     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+diff --git a/README.md b/README.md
+index dd237688..7886a241 100644
+--- a/README.md
++++ b/README.md
+@@ -77,7 +77,7 @@ with [User Secrets] instead.
+ 
+ Compiling the application yourself requires Git and the
+ [.NET SDK](https://www.microsoft.com/net/download/core "Download the .NET SDK")
+-to be installed (version `8.0.100` or later).
++to be installed (version `9.0.100` or later).
+ 
+ To build and test the application locally from a terminal/command-line, run the
+ following set of commands:
+diff --git a/TodoApp.ruleset b/TodoApp.ruleset
+index 26de3827..f87cb2fb 100644
+--- a/TodoApp.ruleset
++++ b/TodoApp.ruleset
+@@ -10,6 +10,7 @@
+     <Rule Id="CA1056" Action="None" />
+     <Rule Id="CA1062" Action="None" />
+     <Rule Id="CA1303" Action="None" />
++    <Rule Id="CA1515" Action="None" />
+     <Rule Id="CA1707" Action="None" />
+     <Rule Id="CA1711" Action="None" />
+     <Rule Id="CA1720" Action="None" />
+diff --git a/build.ps1 b/build.ps1
+index 3ed0048b..7f678744 100755
+--- a/build.ps1
++++ b/build.ps1
+@@ -12,10 +12,6 @@ param(
+ $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = "true"
+ $env:NUGET_XMLDOC_MODE = "skip"
+ 
+-if ($null -eq $env:MSBUILDTERMINALLOGGER) {
+-    $env:MSBUILDTERMINALLOGGER = "auto"
+-}
+-
+ $Configuration = "Release"
+ $ErrorActionPreference = "Stop"
+ $ProgressPreference = "SilentlyContinue"
+diff --git a/global.json b/global.json
+index 4b4a4454..0ddd1707 100644
+--- a/global.json
++++ b/global.json
+@@ -1,6 +1,6 @@
+ {
+   "sdk": {
+-    "version": "8.0.401",
++    "version": "9.0.100-preview.7.24407.12",
+     "allowPrerelease": false,
+     "rollForward": "latestMajor"
+   }
+diff --git a/src/TodoApp/Program.cs b/src/TodoApp/Program.cs
+index 355b7b72..829502cf 100644
+--- a/src/TodoApp/Program.cs
++++ b/src/TodoApp/Program.cs
+@@ -17,11 +17,14 @@
+ builder.Services.AddRazorPages();
+ 
+ // Configure OpenAPI documentation for the Todo API
+-builder.Services.AddEndpointsApiExplorer();
+-builder.Services.AddOpenApiDocument(options =>
++builder.Services.AddOpenApi(options =>
+ {
+-    options.Title = "Todo API";
+-    options.Version = "v1";
++    options.AddDocumentTransformer((document, _, _) =>
++    {
++        document.Info.Title = "Todo API";
++        document.Info.Version = "v1";
++        return Task.CompletedTask;
++    });
+ });
+ 
+ if (string.Equals(builder.Configuration["CODESPACES"], "true", StringComparison.OrdinalIgnoreCase))
+@@ -57,7 +60,7 @@
+ app.UseAuthorization();
+ 
+ // Add endpoint for OpenAPI
+-app.UseOpenApi();
++app.MapOpenApi();
+ 
+ // Add the HTTP endpoints
+ app.MapAuthenticationRoutes();
+diff --git a/src/TodoApp/TodoApp.csproj b/src/TodoApp/TodoApp.csproj
+index d4f34365..54a63c47 100644
+--- a/src/TodoApp/TodoApp.csproj
++++ b/src/TodoApp/TodoApp.csproj
+@@ -4,16 +4,16 @@
+     <IsPackable>false</IsPackable>
+     <NoWarn>$(NoWarn);CA1050</NoWarn>
+     <RootNamespace>TodoApp</RootNamespace>
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net9.0</TargetFramework>
+     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
+     <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>
+     <UserSecretsId>TodoApp</UserSecretsId>
+   </PropertyGroup>
+   <ItemGroup>
+     <PackageReference Include="AspNet.Security.OAuth.GitHub" Version="8.1.0" />
+-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
++    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-preview.7.24406.2" />
++    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0-preview.7.24405.3" />
+     <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.5.3" PrivateAssets="all" />
+-    <PackageReference Include="NSwag.AspNetCore" Version="14.1.0" />
+   </ItemGroup>
+   <ItemGroup>
+     <Content Update="package.json;package-lock.json;tsconfig.json" CopyToPublishDirectory="Never" />
+diff --git a/src/TodoApp/wwwroot/swagger-ui/index.html b/src/TodoApp/wwwroot/swagger-ui/index.html
+index eac16920..65b67a7c 100644
+--- a/src/TodoApp/wwwroot/swagger-ui/index.html
++++ b/src/TodoApp/wwwroot/swagger-ui/index.html
+@@ -32,7 +32,7 @@
+     <script>
+         window.onload = function () {
+             window.ui = SwaggerUIBundle({
+-                url: "/swagger/v1/swagger.json",
++                url: "/openapi/v1.json",
+                 dom_id: '#swagger-ui',
+                 deepLinking: true,
+                 presets: [
+diff --git a/startvscode.cmd b/startvscode.cmd
+index abec237b..45ea8f6d 100644
+--- a/startvscode.cmd
++++ b/startvscode.cmd
+@@ -11,7 +11,7 @@ SET DOTNET_ROOT(x86)=%~dp0.dotnetcli\x86
+ SET PATH=%DOTNET_ROOT%;%PATH%
+ 
+ :: Sets the Target Framework for Visual Studio Code.
+-SET TARGET=net8.0
++SET TARGET=net9.0
+ 
+ SET FOLDER=%~1
+ 
+diff --git a/tests/TodoApp.Tests/HttpServerFixture.cs b/tests/TodoApp.Tests/HttpServerFixture.cs
+index 1f9966ef..7abb6f41 100644
+--- a/tests/TodoApp.Tests/HttpServerFixture.cs
++++ b/tests/TodoApp.Tests/HttpServerFixture.cs
+@@ -44,7 +44,7 @@ protected override void ConfigureWebHost(IWebHostBuilder builder)
+         // Configure a self-signed TLS certificate for HTTPS
+         builder.ConfigureKestrel(
+             serverOptions => serverOptions.ConfigureHttpsDefaults(
+-                httpsOptions => httpsOptions.ServerCertificate = new X509Certificate2("localhost-dev.pfx", "Pa55w0rd!")));
++                httpsOptions => httpsOptions.ServerCertificate = X509CertificateLoader.LoadPkcs12FromFile("localhost-dev.pfx", "Pa55w0rd!")));
+ 
+         // Configure the server address for the server to
+         // listen on for HTTPS requests on a dynamic port.
+diff --git a/tests/TodoApp.Tests/TodoApp.Tests.csproj b/tests/TodoApp.Tests/TodoApp.Tests.csproj
+index 28faf134..05ea1420 100644
+--- a/tests/TodoApp.Tests/TodoApp.Tests.csproj
++++ b/tests/TodoApp.Tests/TodoApp.Tests.csproj
+@@ -3,7 +3,7 @@
+     <IsPackable>false</IsPackable>
+     <NoWarn>$(NoWarn);CA1861</NoWarn>
+     <RootNamespace>TodoApp</RootNamespace>
+-    <TargetFramework>net8.0</TargetFramework>
++    <TargetFramework>net9.0</TargetFramework>
+   </PropertyGroup>
+   <ItemGroup>
+     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+@@ -11,7 +11,7 @@
+     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
+     <PackageReference Include="JustEat.HttpClientInterception" Version="4.3.0" />
+     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
+-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
++    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-preview.7.24406.2" />
+     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+     <PackageReference Include="Microsoft.Playwright" Version="1.46.0" />
+     <PackageReference Include="ReportGenerator" Version="5.3.8" />

--- a/tests/Costellobot.Tests/GitDiffParserTests.NoUpdates.diff
+++ b/tests/Costellobot.Tests/GitDiffParserTests.NoUpdates.diff
@@ -1,0 +1,967 @@
+diff --git a/.github/workflows/benchmark.yml b/.github/workflows/benchmark.yml
+new file mode 100644
+index 000000000..2fd462c33
+--- /dev/null
++++ b/.github/workflows/benchmark.yml
+@@ -0,0 +1,70 @@
++name: benchmark
++
++env:
++  DOTNET_CLI_TELEMETRY_OPTOUT: true
++  DOTNET_NOLOGO: true
++  DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
++  NUGET_XMLDOC_MODE: skip
++  TERM: xterm
++
++on:
++  push:
++    branches: [ main ]
++    paths-ignore:
++      - '**/*.gitattributes'
++      - '**/*.gitignore'
++      - '**/*.md'
++  workflow_dispatch:
++
++permissions:
++  contents: read
++
++jobs:
++  benchmark:
++    name: benchmark
++    runs-on: ubuntu-latest
++
++    concurrency:
++      group: ${{ github.workflow }}
++      cancel-in-progress: false
++
++    steps:
++
++    - name: Checkout code
++      uses: actions/checkout@v4
++
++    - name: Setup .NET SDK
++      uses: actions/setup-dotnet@v4
++
++    - name: Setup Node
++      uses: actions/setup-node@v4
++      with:
++        node-version: '20'
++
++    - name: Run benchmarks
++      shell: pwsh
++      run: ./benchmark.ps1
++
++    - name: Publish results
++      uses: benchmark-action/github-action-benchmark@v1
++      with:
++        auto-push: true
++        alert-comment-cc-users: '@${{ github.repository_owner }}'
++        benchmark-data-dir-path: 'website'
++        comment-on-alert: true
++        fail-on-alert: true
++        gh-pages-branch: main
++        gh-repository: 'github.com/${{ github.repository_owner }}/benchmarks'
++        github-token: ${{ secrets.BENCHMARKS_TOKEN }}
++        name: API
++        output-file-path: BenchmarkDotNet.Artifacts/results/MartinCostello.Website.Benchmarks.WebsiteBenchmarks-report-full-compressed.json
++        tool: 'benchmarkdotnet'
++
++    - name: Output summary
++      shell: pwsh
++      run: |
++        $repoName = ${env:GITHUB_REPOSITORY}.Split("/")[-1]
++        $summary = Get-Content -Path (Join-Path ${env:GITHUB_WORKSPACE} "BenchmarkDotNet.Artifacts" "results" "MartinCostello.Website.Benchmarks.WebsiteBenchmarks-report-github.md") -Raw
++        $summary += "`n`n"
++        $summary += "View benchmark results history [here](https://benchmarks.martincostello.com/${repoName})."
++        $summary >> ${env:GITHUB_STEP_SUMMARY}
+diff --git a/.gitignore b/.gitignore
+index 8a0f6c99a..970127d63 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -9,6 +9,7 @@ _reports
+ _UpgradeReport_Files/
+ artifacts/
+ Backup*/
++BenchmarkDotNet.Artifacts/
+ bin
+ Bin
+ BuildOutput
+diff --git a/Directory.Packages.props b/Directory.Packages.props
+index d42c772d9..1a76f4bb9 100644
+--- a/Directory.Packages.props
++++ b/Directory.Packages.props
+@@ -5,6 +5,7 @@
+   </ItemGroup>
+   <ItemGroup>
+     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
++    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
+     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
+     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
+diff --git a/Website.sln b/Website.sln
+index 6d2e45b35..7d62b3f90 100644
+--- a/Website.sln
++++ b/Website.sln
+@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution
+ 		.gitattributes = .gitattributes
+ 		.gitignore = .gitignore
+ 		.vsconfig = .vsconfig
++		benchmark.ps1 = benchmark.ps1
+ 		build.ps1 = build.ps1
+ 		Directory.Build.props = Directory.Build.props
+ 		Directory.Build.targets = Directory.Build.targets
+@@ -38,8 +39,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{FBD3
+ EndProject
+ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{5B31CD2E-3F11-4609-88E8-117EF1389235}"
+ 	ProjectSection(SolutionItems) = preProject
++		.github\workflows\benchmark.yml = .github\workflows\benchmark.yml
+ 		.github\workflows\build.yml = .github\workflows\build.yml
+ 		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
++		.github\workflows\container-scan.yml = .github\workflows\container-scan.yml
+ 		.github\workflows\dependency-review.yml = .github\workflows\dependency-review.yml
+ 		.github\workflows\deploy.yml = .github\workflows\deploy.yml
+ 		.github\workflows\lighthouse.yml = .github\workflows\lighthouse.yml
+@@ -57,6 +60,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".vscode", ".vscode", "{DF79
+ 		.vscode\tasks.json = .vscode\tasks.json
+ 	EndProjectSection
+ EndProject
++Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "perf", "perf", "{A1F57AE9-C5B7-4503-8095-2C9376BAF873}"
++EndProject
++Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Website.Benchmarks", "perf\Website.Benchmarks\Website.Benchmarks.csproj", "{3548588A-27A1-47A7-BFB2-8D67D18EB81A}"
++EndProject
+ Global
+ 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+ 		Debug|Any CPU = Debug|Any CPU
+@@ -79,6 +86,10 @@ Global
+ 		{26DB8EDD-BC86-428F-86A9-1C55711ABD0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+ 		{26DB8EDD-BC86-428F-86A9-1C55711ABD0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+ 		{26DB8EDD-BC86-428F-86A9-1C55711ABD0F}.Release|Any CPU.Build.0 = Release|Any CPU
++		{3548588A-27A1-47A7-BFB2-8D67D18EB81A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
++		{3548588A-27A1-47A7-BFB2-8D67D18EB81A}.Debug|Any CPU.Build.0 = Debug|Any CPU
++		{3548588A-27A1-47A7-BFB2-8D67D18EB81A}.Release|Any CPU.ActiveCfg = Release|Any CPU
++		{3548588A-27A1-47A7-BFB2-8D67D18EB81A}.Release|Any CPU.Build.0 = Release|Any CPU
+ 	EndGlobalSection
+ 	GlobalSection(SolutionProperties) = preSolution
+ 		HideSolutionNode = FALSE
+@@ -91,6 +102,7 @@ Global
+ 		{E1197F63-A671-4484-B5BE-36C3561F4CBF} = {668E07A5-C40F-4694-9D3C-EBC1180656CF}
+ 		{26DB8EDD-BC86-428F-86A9-1C55711ABD0F} = {668E07A5-C40F-4694-9D3C-EBC1180656CF}
+ 		{DF799E65-EEEC-47DA-90E1-47A2965F132F} = {DD7EA67A-4FE1-4D4F-825E-51FF842107AB}
++		{3548588A-27A1-47A7-BFB2-8D67D18EB81A} = {A1F57AE9-C5B7-4503-8095-2C9376BAF873}
+ 	EndGlobalSection
+ 	GlobalSection(ExtensibilityGlobals) = postSolution
+ 		SolutionGuid = {15DDCA85-B2C3-4172-8203-DB0967289CA4}
+diff --git a/benchmark.ps1 b/benchmark.ps1
+new file mode 100644
+index 000000000..a65623c42
+--- /dev/null
++++ b/benchmark.ps1
+@@ -0,0 +1,88 @@
++#! /usr/bin/env pwsh
++
++#Requires -PSEdition Core
++#Requires -Version 7
++
++param(
++    [Parameter(Mandatory = $false)][string] $Filter = "",
++    [Parameter(Mandatory = $false)][string] $Job = ""
++)
++
++$ErrorActionPreference = "Stop"
++$ProgressPreference = "SilentlyContinue"
++
++if ($null -eq ${env:MSBUILDTERMINALLOGGER}) {
++    ${env:MSBUILDTERMINALLOGGER} = "auto"
++}
++
++$solutionPath = $PSScriptRoot
++$sdkFile = Join-Path $solutionPath "global.json"
++
++$dotnetVersion = (Get-Content $sdkFile | Out-String | ConvertFrom-Json).sdk.version
++
++$installDotNetSdk = $false
++
++if (($null -eq (Get-Command "dotnet" -ErrorAction SilentlyContinue)) -and ($null -eq (Get-Command "dotnet.exe" -ErrorAction SilentlyContinue))) {
++    Write-Host "The .NET SDK is not installed."
++    $installDotNetSdk = $true
++}
++else {
++    Try {
++        $installedDotNetVersion = (dotnet --version 2>&1 | Out-String).Trim()
++    }
++    Catch {
++        $installedDotNetVersion = "?"
++    }
++
++    if ($installedDotNetVersion -ne $dotnetVersion) {
++        Write-Host "The required version of the .NET SDK is not installed. Expected $dotnetVersion."
++        $installDotNetSdk = $true
++    }
++}
++
++if ($installDotNetSdk -eq $true) {
++    ${env:DOTNET_INSTALL_DIR} = Join-Path $PSScriptRoot ".dotnet"
++    $sdkPath = Join-Path ${env:DOTNET_INSTALL_DIR} "sdk" $dotnetVersion
++
++    if (!(Test-Path $sdkPath)) {
++        if (!(Test-Path ${env:DOTNET_INSTALL_DIR})) {
++            mkdir ${env:DOTNET_INSTALL_DIR} | Out-Null
++        }
++        $installScript = Join-Path ${env:DOTNET_INSTALL_DIR} "install.ps1"
++        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
++        Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile $installScript -UseBasicParsing
++        & $installScript -JsonFile $sdkFile -InstallDir ${env:DOTNET_INSTALL_DIR} -NoPath
++    }
++
++    ${env:PATH} = "${env:DOTNET_INSTALL_DIR};${env:PATH}"
++    $dotnet = Join-Path ${env:DOTNET_INSTALL_DIR} "dotnet"
++}
++else {
++    $dotnet = "dotnet"
++}
++
++$benchmarks = (Join-Path $solutionPath "perf" "Website.Benchmarks" "Website.Benchmarks.csproj")
++
++Write-Host "Running benchmarks..." -ForegroundColor Green
++
++$additionalArgs = @(
++    "--artifacts",
++    (Join-Path $solutionPath "BenchmarkDotNet.Artifacts")
++)
++
++if (-Not [string]::IsNullOrEmpty($Filter)) {
++    $additionalArgs += "--filter"
++    $additionalArgs += $Filter
++}
++
++if (-Not [string]::IsNullOrEmpty($Job)) {
++    $additionalArgs += "--job"
++    $additionalArgs += $Job
++}
++
++if (-Not [string]::IsNullOrEmpty(${env:GITHUB_SHA})) {
++    $additionalArgs += "--exporters"
++    $additionalArgs += "json"
++}
++
++& $dotnet run --project $benchmarks --configuration "Release" -- $additionalArgs
+diff --git a/perf/Website.Benchmarks/Program.cs b/perf/Website.Benchmarks/Program.cs
+new file mode 100644
+index 000000000..3a4e382ff
+--- /dev/null
++++ b/perf/Website.Benchmarks/Program.cs
+@@ -0,0 +1,25 @@
++// Copyright (c) Martin Costello, 2016. All rights reserved.
++// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
++
++using BenchmarkDotNet.Running;
++using MartinCostello.Website.Benchmarks;
++
++if (args.SequenceEqual(["--test"]))
++{
++    await using var benchmark = new WebsiteBenchmarks();
++    await benchmark.StartServer();
++
++    try
++    {
++        _ = await benchmark.Root();
++        _ = await benchmark.Version();
++    }
++    finally
++    {
++        await benchmark.StopServer();
++    }
++}
++else
++{
++    BenchmarkRunner.Run<WebsiteBenchmarks>(args: args);
++}
+diff --git a/perf/Website.Benchmarks/Properties/launchSettings.json b/perf/Website.Benchmarks/Properties/launchSettings.json
+new file mode 100644
+index 000000000..db615cf0d
+--- /dev/null
++++ b/perf/Website.Benchmarks/Properties/launchSettings.json
+@@ -0,0 +1,8 @@
++{
++  "profiles": {
++    "Website.Benchmarks": {
++      "commandName": "Project",
++      "commandLineArgs": ""
++    }
++  }
++}
+diff --git a/perf/Website.Benchmarks/Website.Benchmarks.csproj b/perf/Website.Benchmarks/Website.Benchmarks.csproj
+new file mode 100644
+index 000000000..21ba63b65
+--- /dev/null
++++ b/perf/Website.Benchmarks/Website.Benchmarks.csproj
+@@ -0,0 +1,17 @@
++<Project Sdk="Microsoft.NET.Sdk">
++  <PropertyGroup>
++    <Description>Benchmarks for the website.</Description>
++    <NoWarn>$(NoWarn);SA1600</NoWarn>
++    <OutputType>Exe</OutputType>
++    <RootNamespace>MartinCostello.Website.Benchmarks</RootNamespace>
++    <Summary>$(Description)</Summary>
++    <TargetFramework>net8.0</TargetFramework>
++  </PropertyGroup>
++  <ItemGroup>
++    <ProjectReference Include="..\..\src\Website\Website.csproj" />
++  </ItemGroup>
++  <ItemGroup>
++    <FrameworkReference Include="Microsoft.AspNetCore.App" />
++    <PackageReference Include="BenchmarkDotNet" />
++  </ItemGroup>
++</Project>
+diff --git a/perf/Website.Benchmarks/WebsiteBenchmarks.cs b/perf/Website.Benchmarks/WebsiteBenchmarks.cs
+new file mode 100644
+index 000000000..8a73bd541
+--- /dev/null
++++ b/perf/Website.Benchmarks/WebsiteBenchmarks.cs
+@@ -0,0 +1,75 @@
++﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
++// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
++
++using BenchmarkDotNet.Attributes;
++using BenchmarkDotNet.Diagnosers;
++
++namespace MartinCostello.Website.Benchmarks;
++
++[EventPipeProfiler(EventPipeProfile.CpuSampling)]
++[MemoryDiagnoser]
++public class WebsiteBenchmarks : IAsyncDisposable
++{
++    private WebsiteServer? _app = new();
++    private HttpClient? _client;
++    private bool _disposed;
++
++    [GlobalSetup]
++    public async Task StartServer()
++    {
++        if (_app is { } app)
++        {
++            await app.StartAsync();
++            _client = app.CreateHttpClient();
++        }
++    }
++
++    [GlobalCleanup]
++    public async Task StopServer()
++    {
++        if (_app is { } app)
++        {
++            await app.StopAsync();
++            _app = null;
++        }
++    }
++
++    [Benchmark]
++    public async Task<byte[]> Root()
++        => await _client!.GetByteArrayAsync("/");
++
++    [Benchmark]
++    public async Task<byte[]> About()
++        => await _client!.GetByteArrayAsync("/home/about");
++
++    [Benchmark]
++    public async Task<byte[]> Projects()
++        => await _client!.GetByteArrayAsync("/projects");
++
++    [Benchmark]
++    public async Task<byte[]> Tools()
++        => await _client!.GetByteArrayAsync("/tools");
++
++    [Benchmark]
++    public async Task<byte[]> Version()
++        => await _client!.GetByteArrayAsync("/version");
++
++    public async ValueTask DisposeAsync()
++    {
++        GC.SuppressFinalize(this);
++
++        if (!_disposed)
++        {
++            _client?.Dispose();
++            _client = null;
++
++            if (_app is not null)
++            {
++                await _app.DisposeAsync();
++                _app = null;
++            }
++        }
++
++        _disposed = true;
++    }
++}
+diff --git a/perf/Website.Benchmarks/WebsiteServer.cs b/perf/Website.Benchmarks/WebsiteServer.cs
+new file mode 100644
+index 000000000..5538c773a
+--- /dev/null
++++ b/perf/Website.Benchmarks/WebsiteServer.cs
+@@ -0,0 +1,103 @@
++﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
++// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
++
++using Microsoft.AspNetCore.Builder;
++using Microsoft.AspNetCore.Hosting;
++using Microsoft.AspNetCore.Hosting.Server;
++using Microsoft.AspNetCore.Hosting.Server.Features;
++using Microsoft.Extensions.DependencyInjection;
++using Microsoft.Extensions.Logging;
++
++namespace MartinCostello.Website.Benchmarks;
++
++internal sealed class WebsiteServer : IAsyncDisposable
++{
++    private WebApplication? _app;
++    private Uri? _baseAddress;
++    private bool _disposed;
++
++    public WebsiteServer()
++    {
++        var builder = WebApplication.CreateBuilder([$"--contentRoot={GetContentRoot()}"]);
++
++        builder.Logging.ClearProviders();
++        builder.WebHost.UseUrls("https://127.0.0.1:0");
++
++        builder.AddWebsite();
++
++        _app = builder.Build();
++        _app.UseWebsite();
++    }
++
++    public HttpClient CreateHttpClient()
++    {
++#pragma warning disable CA2000
++        var handler = new HttpClientHandler()
++        {
++            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
++        };
++#pragma warning restore CA2000
++
++#pragma warning disable CA5400
++        return new(handler, disposeHandler: true) { BaseAddress = _baseAddress };
++#pragma warning restore CA5400
++    }
++
++    public async Task StartAsync()
++    {
++        if (_app is { } app)
++        {
++            await app.StartAsync();
++
++            var server = app.Services.GetRequiredService<IServer>();
++            var addresses = server.Features.Get<IServerAddressesFeature>();
++
++            _baseAddress = addresses!.Addresses
++                .Select((p) => new Uri(p))
++                .Last();
++        }
++    }
++
++    public async Task StopAsync()
++    {
++        if (_app is { } app)
++        {
++            await app.StopAsync();
++            _app = null;
++        }
++    }
++
++    public async ValueTask DisposeAsync()
++    {
++        GC.SuppressFinalize(this);
++
++        if (!_disposed && _app is not null)
++        {
++            await _app.DisposeAsync();
++        }
++
++        _disposed = true;
++    }
++
++    private static string GetContentRoot()
++    {
++        string contentRoot = string.Empty;
++        var directoryInfo = new DirectoryInfo(Path.GetDirectoryName(typeof(WebsiteBenchmarks).Assembly.Location)!);
++
++        do
++        {
++            string? solutionPath = Directory.EnumerateFiles(directoryInfo.FullName, "Website.sln").FirstOrDefault();
++
++            if (solutionPath is not null)
++            {
++                contentRoot = Path.GetFullPath(Path.Combine(directoryInfo.FullName, "src", "Website"));
++                break;
++            }
++
++            directoryInfo = directoryInfo.Parent;
++        }
++        while (directoryInfo is not null);
++
++        return contentRoot;
++    }
++}
+diff --git a/src/Website/Program.cs b/src/Website/Program.cs
+index 460159666..a771f656a 100644
+--- a/src/Website/Program.cs
++++ b/src/Website/Program.cs
+@@ -1,211 +1,14 @@
+ ﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
+ // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+ 
+-using System.IO.Compression;
+-using System.Reflection;
+-using System.Runtime.CompilerServices;
+-using System.Runtime.InteropServices;
+-using System.Text.Json.Nodes;
+ using MartinCostello.Website;
+-using MartinCostello.Website.Middleware;
+-using MartinCostello.Website.Models;
+-using MartinCostello.Website.Options;
+-using MartinCostello.Website.Slices;
+-using Microsoft.AspNetCore.CookiePolicy;
+-using Microsoft.AspNetCore.ResponseCompression;
+-using Microsoft.AspNetCore.Rewrite;
+-using Microsoft.AspNetCore.StaticFiles;
+ 
+ var builder = WebApplication.CreateBuilder(args);
+ 
+-builder.Services.AddOptions();
+-
+-builder.Services.Configure<SiteOptions>(builder.Configuration.GetSection("Site"));
+-builder.Services.ConfigureHttpJsonOptions((options) =>
+-{
+-    options.SerializerOptions.PropertyNameCaseInsensitive = false;
+-    options.SerializerOptions.WriteIndented = true;
+-    options.SerializerOptions.TypeInfoResolverChain.Add(ApplicationJsonSerializerContext.Default);
+-});
+-
+-builder.Services.Configure<StaticFileOptions>((options) =>
+-{
+-    var provider = new FileExtensionContentTypeProvider();
+-    provider.Mappings[".webmanifest"] = "application/manifest+json";
+-
+-    options.ContentTypeProvider = provider;
+-    options.DefaultContentType = "application/json";
+-    options.ServeUnknownFileTypes = true;
+-
+-    options.OnPrepareResponse = (context) =>
+-    {
+-        var maxAge = TimeSpan.FromDays(7);
+-
+-        if (context.File.Exists && builder.Environment.IsProduction())
+-        {
+-            string? extension = Path.GetExtension(context.File.PhysicalPath);
+-
+-            // These files are served with a content hash in the URL so can be cached for longer
+-            bool isScriptOrStyle =
+-                string.Equals(extension, ".css", StringComparison.OrdinalIgnoreCase) ||
+-                string.Equals(extension, ".js", StringComparison.OrdinalIgnoreCase);
+-
+-            if (isScriptOrStyle)
+-            {
+-                maxAge = TimeSpan.FromDays(365);
+-            }
+-        }
+-
+-        var headers = context.Context.Response.GetTypedHeaders();
+-        headers.CacheControl = new() { MaxAge = maxAge };
+-    };
+-});
+-
+-builder.Services.AddAntiforgery((options) =>
+-{
+-    options.Cookie.HttpOnly = true;
+-    options.Cookie.Name = "_anti-forgery";
+-    options.Cookie.SecurePolicy = builder.Environment.IsDevelopment() ? CookieSecurePolicy.SameAsRequest : CookieSecurePolicy.Always;
+-    options.FormFieldName = "_anti-forgery";
+-    options.HeaderName = "x-anti-forgery";
+-});
+-
+-builder.Services.AddHttpContextAccessor();
+-
+-builder.Services.AddRouting((options) =>
+-{
+-    options.AppendTrailingSlash = true;
+-    options.LowercaseUrls = true;
+-});
+-
+-if (!builder.Environment.IsDevelopment())
+-{
+-    builder.Services.AddHsts((options) =>
+-    {
+-        options.MaxAge = TimeSpan.FromDays(365);
+-        options.IncludeSubDomains = false;
+-        options.Preload = false;
+-    });
+-}
+-
+-builder.Services.AddResponseCaching();
+-
+-builder.Services.AddTelemetry(builder.Environment);
+-
+-builder.Services.Configure<GzipCompressionProviderOptions>((p) => p.Level = CompressionLevel.Fastest);
+-builder.Services.Configure<BrotliCompressionProviderOptions>((p) => p.Level = CompressionLevel.Fastest);
+-
+-builder.Services.AddResponseCompression((options) =>
+-{
+-    options.EnableForHttps = true;
+-    options.Providers.Add<BrotliCompressionProvider>();
+-    options.Providers.Add<GzipCompressionProvider>();
+-});
+-
+-builder.Logging.AddTelemetry();
+-
+-builder.WebHost.CaptureStartupErrors(true);
+-builder.WebHost.ConfigureKestrel((p) => p.AddServerHeader = false);
++builder.AddWebsite();
+ 
+ var app = builder.Build();
+ 
+-app.UseMiddleware<CustomHttpHeadersMiddleware>();
+-
+-bool isDevelopment = app.Environment.IsDevelopment();
+-
+-if (!isDevelopment)
+-{
+-    app.UseExceptionHandler("/error");
+-}
+-
+-app.UseStatusCodePagesWithReExecute("/error", "?id={0}");
+-
+-if (!app.Environment.IsDevelopment())
+-{
+-    app.UseHsts();
+-
+-    if (!string.Equals(app.Configuration["ForwardedHeaders_Enabled"], bool.TrueString, StringComparison.OrdinalIgnoreCase))
+-    {
+-        app.UseHttpsRedirection();
+-    }
+-}
+-
+-app.UseResponseCompression();
+-
+-app.UseRewriter(new RewriteOptions().AddRedirectToNonWww());
+-
+-app.UseStaticFiles();
+-
+-app.MapRedirects();
+-
+-app.MapGet("/version", static () =>
+-{
+-    return new JsonObject()
+-    {
+-        ["applicationVersion"] = GitMetadata.Version,
+-        ["frameworkDescription"] = RuntimeInformation.FrameworkDescription,
+-        ["operatingSystem"] = new JsonObject()
+-        {
+-            ["description"] = RuntimeInformation.OSDescription,
+-            ["architecture"] = RuntimeInformation.OSArchitecture.ToString(),
+-            ["version"] = Environment.OSVersion.VersionString,
+-            ["is64Bit"] = Environment.Is64BitOperatingSystem,
+-        },
+-        ["process"] = new JsonObject()
+-        {
+-            ["architecture"] = RuntimeInformation.ProcessArchitecture.ToString(),
+-            ["is64BitProcess"] = Environment.Is64BitProcess,
+-            ["isNativeAoT"] = !RuntimeFeature.IsDynamicCodeSupported,
+-            ["isPrivilegedProcess"] = Environment.IsPrivilegedProcess,
+-        },
+-        ["dotnetVersions"] = new JsonObject()
+-        {
+-            ["runtime"] = GetVersion<object>(),
+-            ["aspNetCore"] = GetVersion<HttpContext>(),
+-        },
+-    };
+-
+-    static string GetVersion<T>()
+-        => typeof(T).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
+-});
+-
+-// HACK Workaround for https://github.com/dotnet/sdk/issues/40511
+-app.MapGet(".well-known/{fileName}", (string fileName, IWebHostEnvironment environment) =>
+-{
+-    var file = environment.WebRootFileProvider.GetFileInfo(Path.Combine("well-known", fileName));
+-
+-    if (file.Exists && file.PhysicalPath is { Length: > 0 })
+-    {
+-        return Results.File(file.PhysicalPath, contentType: "application/json");
+-    }
+-
+-    return Results.NotFound();
+-});
+-
+-app.UseCookiePolicy(new()
+-{
+-    HttpOnly = HttpOnlyPolicy.Always,
+-    Secure = app.Environment.IsDevelopment() ? CookieSecurePolicy.SameAsRequest : CookieSecurePolicy.Always,
+-});
+-
+-string[] methods = [HttpMethod.Get.Method, HttpMethod.Head.Method];
+-
+-app.MapMethods("/", methods, () => Results.Extensions.RazorSlice<Home>());
+-app.MapMethods("/home/about", methods, () => Results.Extensions.RazorSlice<About>());
+-app.MapMethods("/projects", methods, () => Results.Extensions.RazorSlice<Projects>());
+-app.MapMethods("/tools", methods, () => Results.Extensions.RazorSlice<Tools>());
+-
+-app.MapMethods("/error", methods, (int? id) =>
+-{
+-    int statusCode = StatusCodes.Status500InternalServerError;
+-
+-    if (id is { } status &&
+-        status >= 400 && status < 599)
+-    {
+-        statusCode = status;
+-    }
+-
+-    return Results.Extensions.RazorSlice<Error>(statusCode);
+-});
++app.UseWebsite();
+ 
+ app.Run();
+diff --git a/src/Website/WebsiteBuilder.cs b/src/Website/WebsiteBuilder.cs
+new file mode 100644
+index 000000000..c5f49e685
+--- /dev/null
++++ b/src/Website/WebsiteBuilder.cs
+@@ -0,0 +1,235 @@
++﻿// Copyright (c) Martin Costello, 2016. All rights reserved.
++// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
++
++using System.IO.Compression;
++using System.Reflection;
++using System.Runtime.CompilerServices;
++using System.Runtime.InteropServices;
++using System.Text.Json.Nodes;
++using MartinCostello.Website.Middleware;
++using MartinCostello.Website.Options;
++using MartinCostello.Website.Slices;
++using Microsoft.AspNetCore.CookiePolicy;
++using Microsoft.AspNetCore.ResponseCompression;
++using Microsoft.AspNetCore.Rewrite;
++using Microsoft.AspNetCore.StaticFiles;
++
++namespace MartinCostello.Website;
++
++/// <summary>
++/// Extension methods for configuring the website application.
++/// </summary>
++public static class WebsiteBuilder
++{
++    /// <summary>
++    /// Adds website services to the specified <see cref="WebApplicationBuilder"/>.
++    /// </summary>
++    /// <param name="builder">The <see cref="WebApplicationBuilder"/> to configure.</param>
++    /// <returns>
++    /// The value passed by <paramref name="builder"/> for chaining.
++    /// </returns>
++    public static WebApplicationBuilder AddWebsite(this WebApplicationBuilder builder)
++    {
++        builder.Services.AddOptions();
++
++        builder.Services.Configure<SiteOptions>(builder.Configuration.GetSection("Site"));
++        builder.Services.ConfigureHttpJsonOptions((options) =>
++        {
++            options.SerializerOptions.PropertyNameCaseInsensitive = false;
++            options.SerializerOptions.WriteIndented = true;
++            options.SerializerOptions.TypeInfoResolverChain.Add(ApplicationJsonSerializerContext.Default);
++        });
++
++        builder.Services.Configure<StaticFileOptions>((options) =>
++        {
++            var provider = new FileExtensionContentTypeProvider();
++            provider.Mappings[".webmanifest"] = "application/manifest+json";
++
++            options.ContentTypeProvider = provider;
++            options.DefaultContentType = "application/json";
++            options.ServeUnknownFileTypes = true;
++
++            options.OnPrepareResponse = (context) =>
++            {
++                var maxAge = TimeSpan.FromDays(7);
++
++                if (context.File.Exists && builder.Environment.IsProduction())
++                {
++                    string? extension = Path.GetExtension(context.File.PhysicalPath);
++
++                    // These files are served with a content hash in the URL so can be cached for longer
++                    bool isScriptOrStyle =
++                        string.Equals(extension, ".css", StringComparison.OrdinalIgnoreCase) ||
++                        string.Equals(extension, ".js", StringComparison.OrdinalIgnoreCase);
++
++                    if (isScriptOrStyle)
++                    {
++                        maxAge = TimeSpan.FromDays(365);
++                    }
++                }
++
++                var headers = context.Context.Response.GetTypedHeaders();
++                headers.CacheControl = new() { MaxAge = maxAge };
++            };
++        });
++
++        builder.Services.AddAntiforgery((options) =>
++        {
++            options.Cookie.HttpOnly = true;
++            options.Cookie.Name = "_anti-forgery";
++            options.Cookie.SecurePolicy = builder.Environment.IsDevelopment() ? CookieSecurePolicy.SameAsRequest : CookieSecurePolicy.Always;
++            options.FormFieldName = "_anti-forgery";
++            options.HeaderName = "x-anti-forgery";
++        });
++
++        builder.Services.AddHttpContextAccessor();
++
++        builder.Services.AddRouting((options) =>
++        {
++            options.AppendTrailingSlash = true;
++            options.LowercaseUrls = true;
++        });
++
++        if (!builder.Environment.IsDevelopment())
++        {
++            builder.Services.AddHsts((options) =>
++            {
++                options.MaxAge = TimeSpan.FromDays(365);
++                options.IncludeSubDomains = false;
++                options.Preload = false;
++            });
++        }
++
++        builder.Services.AddResponseCaching();
++
++        builder.Services.AddTelemetry(builder.Environment);
++
++        builder.Services.Configure<GzipCompressionProviderOptions>((p) => p.Level = CompressionLevel.Fastest);
++        builder.Services.Configure<BrotliCompressionProviderOptions>((p) => p.Level = CompressionLevel.Fastest);
++
++        builder.Services.AddResponseCompression((options) =>
++        {
++            options.EnableForHttps = true;
++            options.Providers.Add<BrotliCompressionProvider>();
++            options.Providers.Add<GzipCompressionProvider>();
++        });
++
++        builder.Logging.AddTelemetry();
++
++        builder.WebHost.CaptureStartupErrors(true);
++        builder.WebHost.ConfigureKestrel((p) => p.AddServerHeader = false);
++
++        return builder;
++    }
++
++    /// <summary>
++    /// Configures the specified <see cref="WebApplication"/> to use the website.
++    /// </summary>
++    /// <param name="app">The <see cref="WebApplication"/> to configure.</param>
++    /// <returns>
++    /// The value passed by <paramref name="app"/> for chaining.
++    /// </returns>
++    public static WebApplication UseWebsite(this WebApplication app)
++    {
++        app.UseMiddleware<CustomHttpHeadersMiddleware>();
++
++        bool isDevelopment = app.Environment.IsDevelopment();
++
++        if (!isDevelopment)
++        {
++            app.UseExceptionHandler("/error");
++        }
++
++        app.UseStatusCodePagesWithReExecute("/error", "?id={0}");
++
++        if (!app.Environment.IsDevelopment())
++        {
++            app.UseHsts();
++
++            if (!string.Equals(app.Configuration["ForwardedHeaders_Enabled"], bool.TrueString, StringComparison.OrdinalIgnoreCase))
++            {
++                app.UseHttpsRedirection();
++            }
++        }
++
++        app.UseResponseCompression();
++
++        app.UseRewriter(new RewriteOptions().AddRedirectToNonWww());
++
++        app.UseStaticFiles();
++
++        app.MapRedirects();
++
++        app.MapGet("/version", static () =>
++        {
++            return new JsonObject()
++            {
++                ["applicationVersion"] = GitMetadata.Version,
++                ["frameworkDescription"] = RuntimeInformation.FrameworkDescription,
++                ["operatingSystem"] = new JsonObject()
++                {
++                    ["description"] = RuntimeInformation.OSDescription,
++                    ["architecture"] = RuntimeInformation.OSArchitecture.ToString(),
++                    ["version"] = Environment.OSVersion.VersionString,
++                    ["is64Bit"] = Environment.Is64BitOperatingSystem,
++                },
++                ["process"] = new JsonObject()
++                {
++                    ["architecture"] = RuntimeInformation.ProcessArchitecture.ToString(),
++                    ["is64BitProcess"] = Environment.Is64BitProcess,
++                    ["isNativeAoT"] = !RuntimeFeature.IsDynamicCodeSupported,
++                    ["isPrivilegedProcess"] = Environment.IsPrivilegedProcess,
++                },
++                ["dotnetVersions"] = new JsonObject()
++                {
++                    ["runtime"] = GetVersion<object>(),
++                    ["aspNetCore"] = GetVersion<HttpContext>(),
++                },
++            };
++
++            static string GetVersion<T>()
++                => typeof(T).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
++        });
++
++        // HACK Workaround for https://github.com/dotnet/sdk/issues/40511
++        app.MapGet(".well-known/{fileName}", (string fileName, IWebHostEnvironment environment) =>
++        {
++            var file = environment.WebRootFileProvider.GetFileInfo(Path.Combine("well-known", fileName));
++
++            if (file.Exists && file.PhysicalPath is { Length: > 0 })
++            {
++                return Results.File(file.PhysicalPath, contentType: "application/json");
++            }
++
++            return Results.NotFound();
++        });
++
++        app.UseCookiePolicy(new()
++        {
++            HttpOnly = HttpOnlyPolicy.Always,
++            Secure = app.Environment.IsDevelopment() ? CookieSecurePolicy.SameAsRequest : CookieSecurePolicy.Always,
++        });
++
++        string[] methods = [HttpMethod.Get.Method, HttpMethod.Head.Method];
++
++        app.MapMethods("/", methods, () => Results.Extensions.RazorSlice<Home>());
++        app.MapMethods("/home/about", methods, () => Results.Extensions.RazorSlice<About>());
++        app.MapMethods("/projects", methods, () => Results.Extensions.RazorSlice<Projects>());
++        app.MapMethods("/tools", methods, () => Results.Extensions.RazorSlice<Tools>());
++
++        app.MapMethods("/error", methods, (int? id) =>
++        {
++            int statusCode = StatusCodes.Status500InternalServerError;
++
++            if (id is { } status &&
++                status >= 400 && status < 599)
++            {
++                statusCode = status;
++            }
++
++            return Results.Extensions.RazorSlice<Error>(statusCode);
++        });
++
++        return app;
++    }
++}
+diff --git a/src/Website/wwwroot/favicon.ico b/src/Website/wwwroot/favicon.ico
+index 08a8cbe16..188b96b73 100644
+Binary files a/src/Website/wwwroot/favicon.ico and b/src/Website/wwwroot/favicon.ico differ

--- a/tests/Costellobot.Tests/GitDiffParserTests.OneFile.diff
+++ b/tests/Costellobot.Tests/GitDiffParserTests.OneFile.diff
@@ -1,0 +1,15 @@
+diff --git a/Directory.Packages.props b/Directory.Packages.props
+index 5efad590..1641603a 100644
+--- a/Directory.Packages.props
++++ b/Directory.Packages.props
+@@ -7,8 +7,8 @@
+   <ItemGroup>
+     <PackageVersion Include="Amazon.AspNetCore.DataProtection.SSM" Version="3.2.1" />
+     <PackageVersion Include="Aspire.Hosting.AppHost" Version="8.1.0" />
+-    <PackageVersion Include="AWSSDK.SecurityToken" Version="3.7.400.10" />
+-    <PackageVersion Include="AWSSDK.SimpleSystemsManagement" Version="3.7.401.8" />
++    <PackageVersion Include="AWSSDK.SecurityToken" Version="3.7.400.11" />
++    <PackageVersion Include="AWSSDK.SimpleSystemsManagement" Version="3.7.401.9" />
+     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
+     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />

--- a/tests/Costellobot.Tests/GitDiffParserTests.cs
+++ b/tests/Costellobot.Tests/GitDiffParserTests.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Costellobot;
+
+public static class GitDiffParserTests
+{
+    [Fact]
+    public static void TryParseUpdatedPackages_Parses_Diff_Correctly_For_One_File()
+    {
+        // Arrange
+        string diff = GetDiff("OneFile");
+
+        // Act
+        bool actual = GitDiffParser.TryParseUpdatedPackages(diff, out var packages);
+
+        // Assert
+        actual.ShouldBeTrue();
+        packages.ShouldNotBeNull();
+        packages.ShouldContainKeyAndValue("AWSSDK.SecurityToken", (new("3.7.400.10"), new("3.7.400.11")));
+        packages.ShouldContainKeyAndValue("AWSSDK.SimpleSystemsManagement", (new("3.7.401.8"), new("3.7.401.9")));
+        packages.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public static void TryParseUpdatedPackages_Parses_Diff_Correctly_For_Multiple_Files()
+    {
+        // Arrange
+        string diff = GetDiff("MultipleFiles");
+
+        // Act
+        bool actual = GitDiffParser.TryParseUpdatedPackages(diff, out var packages);
+
+        // Assert
+        actual.ShouldBeTrue();
+        packages.ShouldNotBeNull();
+        packages.ShouldContainKeyAndValue("Microsoft.AspNetCore.Mvc.Testing", (new("8.0.8"), new("9.0.0-preview.7.24406.2")));
+        packages.ShouldContainKeyAndValue("Microsoft.EntityFrameworkCore.Sqlite", (new("8.0.8"), new("9.0.0-preview.7.24405.3")));
+        packages.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public static void TryParseUpdatedPackages_Parses_Diff_Correctly_For_No_Package_Updates()
+    {
+        // Arrange
+        string diff = GetDiff("NoUpdates");
+
+        // Act
+        bool actual = GitDiffParser.TryParseUpdatedPackages(diff, out var packages);
+
+        // Assert
+        actual.ShouldBeFalse();
+        packages.ShouldBeNull();
+    }
+
+    private static string GetDiff(string name)
+    {
+        var type = typeof(GitDiffParserTests);
+        var assembly = type.Assembly;
+        var resource = assembly.GetManifestResourceStream($"{type.Namespace}.GitDiffParserTests.{name}.diff")!;
+        using var reader = new StreamReader(resource);
+        return reader.ReadToEnd();
+    }
+}

--- a/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
@@ -859,5 +859,12 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
             .Responds()
             .WithJsonContent(pullRequest)
             .RegisterWith(Fixture.Interceptor);
+
+        CreateDefaultBuilder()
+            .Requests()
+            .ForPath($"/repos/{pullRequest.Repository.Owner.Login}/{pullRequest.Repository.Name}/pulls/{pullRequest.Number}.diff")
+            .Responds()
+            .WithContent(string.Empty)
+            .RegisterWith(Fixture.Interceptor);
     }
 }

--- a/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
@@ -25,7 +25,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
             .WithCommitMessage(TrustedCommitMessage());
 
         RegisterGetAccessToken();
-        RegisterCommit(driver);
+        RegisterCommitAndDiff(driver);
 
         var pullRequestApproved = RegisterReview(driver);
 
@@ -49,7 +49,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
             .WithCommitMessage(TrustedCommitMessage("Newtonsoft.Json", "13.0.1"));
 
         RegisterGetAccessToken();
-        RegisterCommit(driver);
+        RegisterCommitAndDiff(driver);
 
         var pullRequestApproved = RegisterReview(driver);
 
@@ -87,7 +87,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
         driver.Repository.AllowSquashMerge = allowSquashMerge;
 
         RegisterGetAccessToken();
-        RegisterCommit(driver);
+        RegisterCommitAndDiff(driver);
         RegisterReview(driver);
 
         var automergeEnabled = RegisterEnableAutomerge(driver, (p, tcs) => p.WithInterceptionCallback(async (request) =>
@@ -143,7 +143,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
 
         RegisterGetAccessToken();
         RegisterCollaborator(driver, driver.Sender.Login, isCollaborator: true);
-        RegisterCommit(driver);
+        RegisterCommitAndDiff(driver);
         RegisterReview(driver);
 
         var pullRequestApproved = RegisterReview(driver);
@@ -180,7 +180,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
 
         RegisterGetAccessToken();
         RegisterCollaborator(driver, driver.Sender.Login, isCollaborator: true);
-        RegisterCommit(driver);
+        RegisterCommitAndDiff(driver);
         RegisterReview(driver);
 
         var pullRequestMerged = RegisterPutPullRequestMerge(driver, mergeable: true);
@@ -237,7 +237,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
             .WithCommitMessage(TrustedCommitMessage());
 
         RegisterGetAccessToken();
-        RegisterCommit(driver);
+        RegisterCommitAndDiff(driver);
         RegisterReview(driver);
 
         var automergeEnabled = RegisterEnableAutomerge(driver, (p, tcs) =>
@@ -266,7 +266,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
             .WithCommitMessage(UntrustedCommitMessage());
 
         RegisterGetAccessToken();
-        RegisterCommit(driver);
+        RegisterCommitAndDiff(driver);
 
         var pullRequestApproved = RegisterReview(driver);
 
@@ -289,7 +289,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
             .WithCommitMessage(TrustedCommitMessage());
 
         RegisterGetAccessToken();
-        RegisterCommit(driver);
+        RegisterCommitAndDiff(driver);
 
         var pullRequestApproved = RegisterReview(driver);
 
@@ -312,7 +312,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
             .WithCommitMessage("Fix a typo");
 
         RegisterGetAccessToken();
-        RegisterCommit(driver);
+        RegisterCommitAndDiff(driver);
 
         var pullRequestApproved = RegisterReview(driver);
 
@@ -350,7 +350,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
             .WithCommitMessage(TrustedCommitMessage());
 
         RegisterGetAccessToken();
-        RegisterCommit(driver);
+        RegisterCommitAndDiff(driver);
 
         var pullRequestApproved = RegisterReview(driver);
 
@@ -375,7 +375,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
         driver.PullRequest.IsDraft = true;
 
         RegisterGetAccessToken();
-        RegisterCommit(driver);
+        RegisterCommitAndDiff(driver);
 
         var pullRequestApproved = RegisterReview(driver);
 
@@ -401,7 +401,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
         driver.Repository.Owner.Login = "ignored-org";
 
         RegisterGetAccessToken();
-        RegisterCommit(driver);
+        RegisterCommitAndDiff(driver);
 
         var pullRequestApproved = RegisterReview(driver);
 
@@ -432,7 +432,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
 
         RegisterGetAccessToken();
         RegisterCollaborator(driver, driver.Sender.Login, isCollaborator: false);
-        RegisterCommit(driver);
+        RegisterCommitAndDiff(driver);
         RegisterReview(driver);
 
         var pullRequestApproved = RegisterReview(driver);
@@ -464,7 +464,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
 
         RegisterGetAccessToken();
         RegisterCollaborator(driver, driver.Sender.Login, isCollaborator: true);
-        RegisterCommit(driver);
+        RegisterCommitAndDiff(driver);
         RegisterReview(driver);
 
         var pullRequestApproved = RegisterReview(driver);
@@ -497,7 +497,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
 
         RegisterGetAccessToken();
         RegisterCollaborator(driver, driver.Sender.Login, isCollaborator: true);
-        RegisterCommit(driver);
+        RegisterCommitAndDiff(driver);
         RegisterReview(driver);
 
         var pullRequestApproved = RegisterReview(driver);
@@ -529,7 +529,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
 
         RegisterGetAccessToken();
         RegisterCollaborator(driver, driver.Sender.Login, isCollaborator: true);
-        RegisterCommit(driver);
+        RegisterCommitAndDiff(driver);
         RegisterReview(driver);
 
         var pullRequestMerged = RegisterPutPullRequestMerge(driver, mergeable: false);
@@ -606,13 +606,20 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
             .RegisterWith(Fixture.Interceptor);
     }
 
-    private void RegisterCommit(PullRequestDriver driver)
+    private void RegisterCommitAndDiff(PullRequestDriver driver)
     {
         CreateDefaultBuilder()
             .Requests()
             .ForPath($"/repos/{driver.Repository.Owner.Login}/{driver.Repository.Name}/commits/{driver.Commit.Sha}")
             .Responds()
             .WithJsonContent(driver.Commit)
+            .RegisterWith(Fixture.Interceptor);
+
+        CreateDefaultBuilder()
+            .Requests()
+            .ForPath($"/repos/{driver.Repository.Owner.Login}/{driver.Repository.Name}/pulls/{driver.PullRequest.Number}.diff")
+            .Responds()
+            .WithContent(string.Empty)
             .RegisterWith(Fixture.Interceptor);
     }
 


### PR DESCRIPTION
If a Dependabot pull request updates multiple packages and the versions that were updated are unknown, parse the Git diff to extract which NuGet packages were updated and the versions they were updated from and to. This information can then be used to try and determine whether a pull request should be automatically approved.
