### PR TITLE
Configure spellcheck and markdown linter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,10 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+# Visual Studio Spell Checker
+spelling_exclusion_path = .\exclusion.dic
+spelling_languages = en-us
+
 [*.{config,cshtml,csproj,json,props,ruleset,targets,yml}]
 indent_size = 2
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# Contributing
+
 To contribute changes (source code, scripts, configuration) to this repository please follow the steps below.
 These steps are a guideline for contributing and do not necessarily need to be followed for all changes.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041 -->
 ### Expected behaviour
 
 <!-- Explain what you expected to happen. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,48 +2,48 @@
 name: Bug report
 about: Create a bug report to help us improve this project
 labels: bug
-
 ---
 
-**Describe the bug**
+<!-- markdownlint-disable MD041 -->
+### Describe the bug
 
 <!--
 A clear and concise description of what the bug is.
 -->
 
-**Steps To reproduce**
+### Steps To reproduce
 
 <!--
 A concise, repeatable, example of how to reproduce the issue.
 -->
 
-**Expected behaviour**
+### Expected behaviour
 
 <!--
 A clear and concise description of what you expected to happen.
 -->
 
-**Actual behaviour**
+### Actual behaviour
 
 <!--
 A clear and concise description of what actually happened. If an exception occurred, please include a stack trace if available.
 -->
 
-**Screenshots**
+### Screenshots
 
 <!--
 If applicable, add screenshots to help explain your problem.
 -->
 
-**System information:**
+### System information
 
 <!--
- - OS: [e.g. Windows 10]
+ - OS: [e.g. Windows 11]
  - Application Version [e.g. Git commit SHA]
  - .NET version (e.g. output from `dotnet --info`)
 -->
 
-**Additional context**
+### Additional context
 
 <!--
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,8 @@ about: Suggest an idea for a feature for this project
 labels: feature-request
 ---
 
-### Is your feature request related to a problem? Please describe.
+<!-- markdownlint-disable MD041 -->
+### Is your feature request related to a problem?
 
 <!--
 A clear and concise description of what the problem is. For example: _It would be useful if [...]_

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,3 +37,10 @@ jobs:
       uses: docker://rhysd/actionlint@sha256:89d3f90f82781dee3c8724651129634b08cf2241bbd67fcd02a1c5198119fc5e # v1.7.2
       with:
         args: -color
+
+    - name: Lint markdown
+      uses: DavidAnson/markdownlint-cli2-action@db43aef879112c3119a410d69f66701e0d530809 # v17.0.0
+      with:
+        config: '.markdownlint.json'
+        globs: |
+          **/*.md

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD013": false,
+  "MD040": false
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
+    "davidanson.vscode-markdownlint",
     "dbaeumer.vscode-eslint",
     "EditorConfig.EditorConfig",
     "github.vscode-github-actions",

--- a/Costellobot.sln
+++ b/Costellobot.sln
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
+		exclusion.dic = exclusion.dic
 		global.json = global.json
 		LICENSE = LICENSE
 		NuGet.config = NuGet.config

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Any feedback or issues can be added to the issues for this project in
 
 The repository is hosted in
 [GitHub](https://github.com/martincostello/costellobot "This project on GitHub.com"):
-https://github.com/martincostello/costellobot.git
+<https://github.com/martincostello/costellobot.git>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ itself: [#5](https://github.com/martincostello/costellobot/pull/5)
 ## Building and Testing
 
 Compiling the application yourself requires Git and the
-[.NET SDK](https://dotnet.microsoft.com/en-us/download "Download the .NET SDK")
+[.NET SDK](https://dotnet.microsoft.com/download "Download the .NET SDK")
 to be installed.
 
 To build and test the application locally from a terminal/command-line, run the

--- a/exclusion.dic
+++ b/exclusion.dic
@@ -1,0 +1,2 @@
+Costellobot
+NuGet

--- a/src/Costellobot/Registries/NuGetPackageRegistry.cs
+++ b/src/Costellobot/Registries/NuGetPackageRegistry.cs
@@ -27,7 +27,7 @@ public sealed partial class NuGetPackageRegistry(
             return [];
         }
 
-        // https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#versioning
+        // https://docs.microsoft.com/nuget/api/search-query-service-resource#versioning
         var baseAddress = await GetBaseAddressAsync("SearchQueryService/3.5.0");
 
         if (baseAddress is null)
@@ -35,7 +35,7 @@ public sealed partial class NuGetPackageRegistry(
             return [];
         }
 
-        // https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#search-for-packages
+        // https://docs.microsoft.com/nuget/api/search-query-service-resource#search-for-packages
         var query = new Dictionary<string, string?>()
         {
             ["prerelease"] = "true",
@@ -78,7 +78,7 @@ public sealed partial class NuGetPackageRegistry(
             return [];
         }
 
-        // https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource#search-result
+        // https://docs.microsoft.com/nuget/api/search-query-service-resource#search-result
         return package.Owners.ValueKind switch
         {
             JsonValueKind.Array => GetPackageOwners(package.Owners),


### PR DESCRIPTION
- Add settings to configure the Visual Studio spell checker.
- Remove `en-us` from documentation URLs.
- Add a markdown linter.
