### PR TITLE
Bump NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <GlobalPackageReference Include="ReferenceTrimmer" Version="3.3.6" />
+    <GlobalPackageReference Include="ReferenceTrimmer" Version="3.3.10" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
@@ -36,7 +36,7 @@
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.6.2" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="NuGet.Versioning" Version="6.11.0" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.11.1" />
     <PackageVersion Include="Octokit" Version="13.0.1" />
     <PackageVersion Include="Octokit.GraphQL" Version="0.4.0-beta" />
     <PackageVersion Include="Octokit.Webhooks.AspNetCore" Version="2.2.3" />
@@ -50,7 +50,7 @@
     <PackageVersion Include="Polly.Extensions" Version="8.4.2" />
     <PackageVersion Include="Polly.RateLimiting" Version="8.4.2" />
     <PackageVersion Include="RazorSlices" Version="0.8.1" />
-    <PackageVersion Include="ReportGenerator" Version="5.3.9" />
+    <PackageVersion Include="ReportGenerator" Version="5.3.10" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.8" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0-rc.1.24431.7" />


### PR DESCRIPTION
Update NuGet packages while dependabot doesn't support .NET 9.
