### PR TITLE
Support reloading the webhook secret

### DIFF
--- a/exclusion.dic
+++ b/exclusion.dic
@@ -1,2 +1,6 @@
 Costellobot
+DotNet
+GitHub
 NuGet
+serializer
+Webhook

--- a/src/Costellobot/ApiEndpoints.cs
+++ b/src/Costellobot/ApiEndpoints.cs
@@ -12,9 +12,9 @@ namespace MartinCostello.Costellobot;
 
 public static class ApiEndpoints
 {
-    public static IEndpointRouteBuilder MapApiRoutes(this IEndpointRouteBuilder builder, IConfiguration configuration)
+    public static IEndpointRouteBuilder MapApiRoutes(this IEndpointRouteBuilder builder)
     {
-        builder.MapGitHubWebhooks("/github-webhook", configuration["GitHub:WebhookSecret"] ?? string.Empty);
+        builder.MapGitHubWebhooks("/github-webhook");
 
         builder.MapGet("/badge/{type}/{owner}/{repo}", async (string type, string owner, string repo, [FromQuery(Name = "s")] string? signature, BadgeService service) =>
         {

--- a/src/Costellobot/CostellobotBuilder.cs
+++ b/src/Costellobot/CostellobotBuilder.cs
@@ -125,7 +125,7 @@ public static class CostellobotBuilder
 
         app.MapHealthCheckRoutes();
         app.MapAuthenticationRoutes();
-        app.MapApiRoutes(app.Configuration);
+        app.MapApiRoutes();
         app.MapAdminRoutes();
 
         return app;

--- a/src/Costellobot/GitHubExtensions.cs
+++ b/src/Costellobot/GitHubExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.IdentityModel.Tokens;
 using Octokit;
 using Octokit.Internal;
 using Octokit.Webhooks;
+using Octokit.Webhooks.AspNetCore;
 
 namespace MartinCostello.Costellobot;
 
@@ -30,6 +31,7 @@ public static class GitHubExtensions
         services.AddOptions();
 
         services.Configure<GitHubOptions>(configuration.GetSection("GitHub"));
+        services.Configure<GitHubWebhookOptions>((p) => p.Secret = configuration["GitHub:WebhookSecret"]);
         services.Configure<SiteOptions>(configuration.GetSection("Site"));
         services.Configure<WebhookOptions>(configuration.GetSection("Webhook"));
 


### PR DESCRIPTION
Leverage new functionality in Octokit.Webhooks.AspNetCore 2.3.0 (see #1736) to allow the webhook secret to be reloaded at runtime.
