### PR TITLE
Publish fewer messages to ServiceBus

### DIFF
--- a/src/Costellobot/GitHubEventHandler.cs
+++ b/src/Costellobot/GitHubEventHandler.cs
@@ -20,10 +20,17 @@ public sealed partial class GitHubEventHandler(
 
         try
         {
-            var message = GitHubMessageSerializer.Serialize(payload.Headers.Delivery, payload.RawHeaders, payload.RawPayload.ToString());
+            if (WellKnownGitHubEvents.IsKnown(payload))
+            {
+                var message = GitHubMessageSerializer.Serialize(payload.Headers.Delivery, payload.RawHeaders, payload.RawPayload.ToString());
 
-            var sender = client.CreateSender(config.QueueName);
-            await sender.SendMessageAsync(message, cts.Token);
+                var sender = client.CreateSender(config.QueueName);
+                await sender.SendMessageAsync(message, cts.Token);
+            }
+            else
+            {
+                Log.IgnoringEvent(logger, payload.Headers.Delivery, payload.Headers.Event, payload.Event.Action);
+            }
         }
         catch (Exception ex)
         {
@@ -42,5 +49,11 @@ public sealed partial class GitHubEventHandler(
            Level = LogLevel.Error,
            Message = "Failed to publish message for webhook with ID {HookId}.")]
         public static partial void PublishFailed(ILogger logger, Exception exception, string? hookId);
+
+        [LoggerMessage(
+           EventId = 2,
+           Level = LogLevel.Debug,
+           Message = "Ignoring GitHub webhook with ID {HookId} for event {Event}:{Action}.")]
+        public static partial void IgnoringEvent(ILogger logger, string? hookId, string? @event, string? action);
     }
 }

--- a/src/Costellobot/WellKnownGitHubEvents.cs
+++ b/src/Costellobot/WellKnownGitHubEvents.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Octokit.Webhooks;
+using Octokit.Webhooks.Events.CheckSuite;
+using Octokit.Webhooks.Events.DeploymentProtectionRule;
+using Octokit.Webhooks.Events.DeploymentStatus;
+using Octokit.Webhooks.Events.IssueComment;
+using Octokit.Webhooks.Events.PullRequest;
+
+namespace MartinCostello.Costellobot;
+
+/// <summary>
+/// Defines all of the known/consumed GitHub webhook events.
+/// </summary>
+public static class WellKnownGitHubEvents
+{
+    private static readonly HashSet<(string? Event, string? Action)> KnownEvents =
+    [
+        (WebhookEventType.CheckSuite, CheckSuiteAction.Completed),
+        (WebhookEventType.DeploymentProtectionRule, DeploymentProtectionRuleAction.Requested),
+        (WebhookEventType.DeploymentStatus, DeploymentStatusActionValue.Created),
+        (WebhookEventType.IssueComment, IssueCommentActionValue.Created),
+        (WebhookEventType.Ping, null),
+        (WebhookEventType.Push, null),
+        (WebhookEventType.PullRequest, PullRequestActionValue.Labeled),
+        (WebhookEventType.PullRequest, PullRequestActionValue.Opened),
+    ];
+
+    public static bool IsKnown(GitHubEvent message)
+        => KnownEvents.Contains((message.Headers.Event, message.Event.Action));
+}


### PR DESCRIPTION
Reduce the number of GitHub Webhook payloads actually published to Azure ServiceBus by ignoring events not in the list of known payloads.
