### PR TITLE
Configure Sentry CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,7 @@ jobs:
       shell: pwsh
       env:
         ContainerRegistry: ${{ env.PUBLISH_CONTAINER == 'true' && env.CONTAINER_REGISTRY || '' }}
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_TOKEN }}
       run: |
         dotnet publish ./src/Costellobot --arch x64 --os linux -p:PublishProfile=DefaultContainer
 

--- a/src/Costellobot/Costellobot.csproj
+++ b/src/Costellobot/Costellobot.csproj
@@ -12,6 +12,13 @@
     <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>
     <UserSecretsId>Costellobot</UserSecretsId>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(GITHUB_ACTIONS)' != '' AND '$(SENTRY_AUTH_TOKEN)' != '' AND '$(ContainerRegistry)' != '' ">
+    <SentryOrg>martin-costello</SentryOrg>
+    <SentryProject>costellobot</SentryProject>
+    <SentryCreateRelease>true</SentryCreateRelease>
+    <SentrySetCommits>true</SentrySetCommits>
+    <SentryUploadSymbols>true</SentryUploadSymbols>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Aspire.Azure.Messaging.ServiceBus" />
     <PackageReference Include="Aspire.Azure.Security.KeyVault" />


### PR DESCRIPTION
[Configure the Sentry CLI](https://docs.sentry.io/platforms/dotnet/configuration/msbuild/) in CI when publishing the container to generate releases and upload symbols.
