### PR TITLE
Fix mixed package trust approval

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,7 @@
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
     <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="9.0.0-rc.2.24474.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-rc.2.24474.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0-rc.2.24473.5" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0-preview.9.24507.7" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0-preview.9.24507.7" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.2.0" />

--- a/src/Costellobot.AppHost/Costellobot.AppHost.csproj
+++ b/src/Costellobot.AppHost/Costellobot.AppHost.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Aspire.Hosting.Azure.KeyVault" />
     <PackageReference Include="Aspire.Hosting.Azure.ServiceBus" />
     <PackageReference Include="Aspire.Hosting.Azure.Storage" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fix pull requests not being approved when the method of trust in a batch of updated dependencies. Otherwise, a package trusted by owner amongst packages trusted by name would cause the trust check to fail.

Also fixes not being able to open the Aspire app host's User Secrets in Visual Studio.
