### PR TITLE
Fix diff 404s for private repos

### DIFF
--- a/exclusion.dic
+++ b/exclusion.dic
@@ -2,5 +2,6 @@ Costellobot
 DotNet
 GitHub
 NuGet
+Octokit
 serializer
 Webhook

--- a/src/Costellobot/Handlers/DeploymentStatusHandler.cs
+++ b/src/Costellobot/Handlers/DeploymentStatusHandler.cs
@@ -275,7 +275,7 @@ public sealed partial class DeploymentStatusHandler(
                 reference,
                 new IssueId(repository, pullRequest.Number));
 
-            var diff = await GetDiffAsync(pullRequest.DiffUrl);
+            var diff = await GetDiffAsync(pullRequest.Url);
 
             return (reference, diff);
         }

--- a/src/Costellobot/Handlers/PullRequestHandler.cs
+++ b/src/Costellobot/Handlers/PullRequestHandler.cs
@@ -252,7 +252,7 @@ public sealed partial class PullRequestHandler(
             repository.Name,
             message.PullRequest.Head.Sha);
 
-        var diff = await GetDiffAsync(message.PullRequest.DiffUrl);
+        var diff = await GetDiffAsync(message.PullRequest.Url);
 
         return await commitAnalyzer.IsTrustedDependencyUpdateAsync(
             repository,

--- a/src/Costellobot/Octokit/IGitHubClientExtensions.cs
+++ b/src/Costellobot/Octokit/IGitHubClientExtensions.cs
@@ -8,10 +8,11 @@ public static class IGitHubClientExtensions
     public static IWorkflowRunsClient WorkflowRuns(this IGitHubClient client)
         => new WorkflowRunsClient(new ApiConnection(client.Connection));
 
-    public static async Task<string> GetDiffAsync(this IGitHubClient client, string url)
+    public static async Task<string> GetDiffAsync(this IGitHubClient client, string pullRequestUrl)
     {
+        // See https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request
         var parameters = new Dictionary<string, string>(0);
-        var response = await client.Connection.Get<string>(new(url, UriKind.Absolute), parameters);
+        var response = await client.Connection.Get<string>(new(pullRequestUrl, UriKind.Absolute), parameters, "application/vnd.github.v3.diff");
         return response.Body;
     }
 

--- a/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
@@ -862,7 +862,8 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
 
         CreateDefaultBuilder()
             .Requests()
-            .ForPath($"/repos/{pullRequest.Repository.Owner.Login}/{pullRequest.Repository.Name}/pulls/{pullRequest.Number}.diff")
+            .ForPath($"/repos/{pullRequest.Repository.Owner.Login}/{pullRequest.Repository.Name}/pulls/{pullRequest.Number}")
+            .ForRequestHeader("Accept", "application/vnd.github.v3.diff")
             .Responds()
             .WithContent(string.Empty)
             .RegisterWith(Fixture.Interceptor);

--- a/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
@@ -617,7 +617,8 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
 
         CreateDefaultBuilder()
             .Requests()
-            .ForPath($"/repos/{driver.Repository.Owner.Login}/{driver.Repository.Name}/pulls/{driver.PullRequest.Number}.diff")
+            .ForPath($"/repos/{driver.Repository.Owner.Login}/{driver.Repository.Name}/pulls/{driver.PullRequest.Number}")
+            .ForRequestHeader("Accept", "application/vnd.github.v3.diff")
             .Responds()
             .WithContent(string.Empty)
             .RegisterWith(Fixture.Interceptor);


### PR DESCRIPTION
- Get pull request diffs using custom `Accepts` HTTP request header for the pull request resource from the API so that a 404 doesn't occur if a repo is private.
- Add `Octokit` to the spelling dictionary.
