### PR TITLE
Use dependabot config to ignore packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,5 +58,6 @@
     <PackageVersion Include="System.Text.Json" Version="9.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
     <PackageVersion Include="xunit.v3" Version="1.0.1" />
+    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 </Project>

--- a/src/Costellobot/Costellobot.csproj
+++ b/src/Costellobot/Costellobot.csproj
@@ -52,6 +52,7 @@
     <PackageReference Include="RazorSlices" />
     <PackageReference Include="Sentry.AspNetCore" />
     <PackageReference Include="System.Drawing.Common" />
+    <PackageReference Include="YamlDotNet" />
   </ItemGroup>
   <ItemGroup>
     <ContainerPort Include="8080" Type="tcp" />

--- a/src/Costellobot/DependencyEcosystem.cs
+++ b/src/Costellobot/DependencyEcosystem.cs
@@ -10,5 +10,5 @@ public enum DependencyEcosystem
     GitHubActions,
     Npm,
     NuGet,
-    Submodules,
+    GitSubmodule,
 }

--- a/src/Costellobot/GitCommitAnalyzer.cs
+++ b/src/Costellobot/GitCommitAnalyzer.cs
@@ -19,6 +19,11 @@ public sealed partial class GitCommitAnalyzer(
     ILogger<GitCommitAnalyzer> logger)
 {
     private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+    private static readonly IDeserializer YamlDeserializer = new DeserializerBuilder()
+        .IgnoreUnmatchedProperties()
+        .WithNamingConvention(HyphenatedNamingConvention.Instance)
+        .Build();
+
     private readonly ImmutableList<IPackageRegistry> _registries = registries.ToImmutableList();
 
     public static bool TryParseVersionNumber(
@@ -358,12 +363,7 @@ public sealed partial class GitCommitAnalyzer(
             using var stream = new MemoryStream(configuration);
             using var reader = new StreamReader(stream);
 
-            var deserializer = new DeserializerBuilder()
-                .IgnoreUnmatchedProperties()
-                .WithNamingConvention(HyphenatedNamingConvention.Instance)
-                .Build();
-
-            var config = deserializer.Deserialize<DependabotConfig>(reader);
+            var config = YamlDeserializer.Deserialize<DependabotConfig>(reader);
 
             if (config?.Version is 2 && config.Updates is not null)
             {

--- a/src/Costellobot/Handlers/CheckSuiteHandler.cs
+++ b/src/Costellobot/Handlers/CheckSuiteHandler.cs
@@ -17,6 +17,7 @@ public sealed partial class CheckSuiteHandler(
     IOptionsMonitor<WebhookOptions> options,
     ILogger<CheckSuiteHandler> logger) : IHandler
 {
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
     private readonly IOptionsMonitor<WebhookOptions> _options = options;
 
     public async Task HandleAsync(WebhookEvent message)
@@ -140,7 +141,7 @@ public sealed partial class CheckSuiteHandler(
         var options = _options.CurrentValue;
 
         var retryEligibleRuns = failedRuns
-            .Where((p) => options.RerunFailedChecks.Any((pattern) => Regex.IsMatch(p.Name, pattern)))
+            .Where((p) => options.RerunFailedChecks.Any((pattern) => Regex.IsMatch(p.Name, pattern, RegexOptions.None, RegexTimeout)))
             .GroupBy((p) => p.Name)
             .ToList();
 

--- a/src/Costellobot/Registries/GitSubmodulePackageRegistry.cs
+++ b/src/Costellobot/Registries/GitSubmodulePackageRegistry.cs
@@ -9,7 +9,7 @@ public sealed class GitSubmodulePackageRegistry(
     IGitHubClientForInstallation client,
     Octokit.GraphQL.IConnection connection) : GitHubPackageRegistry(client, connection)
 {
-    public override DependencyEcosystem Ecosystem => DependencyEcosystem.Submodules;
+    public override DependencyEcosystem Ecosystem => DependencyEcosystem.GitSubmodule;
 
     public override async Task<IReadOnlyList<string>> GetPackageOwnersAsync(
         RepositoryId repository,

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -118,6 +118,9 @@
           "martincostello",
           "microsoft"
         ],
+        "GitSubmodule": [
+          "https://github.com/martincostello"
+        ],
         "Npm": [
           "microsoft1es",
           "octokitbot",
@@ -139,9 +142,6 @@
           "NodaTime",
           "Polly",
           "xunit"
-        ],
-        "Submodules": [
-          "https://github.com/martincostello"
         ]
       },
       "Users": [

--- a/tests/Costellobot.Tests/Handlers/HandlerFactoryTests.cs
+++ b/tests/Costellobot.Tests/Handlers/HandlerFactoryTests.cs
@@ -33,6 +33,7 @@ public static class HandlerFactoryTests
         var gitHubClient = Substitute.For<IGitHubClientForInstallation>();
 
         var commitAnalyzer = new GitCommitAnalyzer(
+            gitHubClient,
             [],
             webhookOptions,
             NullLoggerFactory.Instance.CreateLogger<GitCommitAnalyzer>());


### PR DESCRIPTION
Do not automatically approve pull requests that update dependencies that are ignored in the dependabot configuration file of the target repository.
