### PR TITLE
Trust OpenTelemetry NuGet packages

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -140,6 +140,7 @@
           "martin_costello",
           "Microsoft",
           "NodaTime",
+          "OpenTelemetry",
           "Polly",
           "xunit"
         ]


### PR DESCRIPTION
Trust NuGet packages published by `OpenTelemetry`.
