### PR TITLE
Trim release versions

### DIFF
--- a/src/Costellobot/BadgeService.cs
+++ b/src/Costellobot/BadgeService.cs
@@ -97,6 +97,7 @@ public sealed partial class BadgeService(
             releaseName = releaseName.Split(' ').Last();
         }
 
+        releaseName = releaseName.TrimStart('v');
         releaseName = Uri.EscapeDataString(releaseName).Replace("-", "--", StringComparison.Ordinal);
 
         return $"https://img.shields.io/badge/release-{releaseName}-blue?logo=github";

--- a/tests/Costellobot.Tests/BadgeTests.cs
+++ b/tests/Costellobot.Tests/BadgeTests.cs
@@ -155,8 +155,8 @@ public sealed class BadgeTests(AppFixture fixture, ITestOutputHelper outputHelpe
 
     [Theory]
     [InlineData("1.2.3", "1.2.3")]
-    [InlineData("v1.2.3", "v1.2.3")]
-    [InlineData("v1.2.3-preview.1", "v1.2.3--preview.1")]
+    [InlineData("v1.2.3", "1.2.3")]
+    [InlineData("v1.2.3-preview.1", "1.2.3--preview.1")]
     [InlineData("My Product 1.2.3", "1.2.3")]
     public async Task Can_Get_Release_Badge_When_Latest_Release_Found(string name, string expected)
     {


### PR DESCRIPTION
Trim leading `v` from GitHub releases for badge consistency.
