### PR TITLE
Use lint-actions-powershell

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,6 +31,9 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        filter: 'tree:0'
+        show-progress: false
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,8 @@ jobs:
     - name: Get npm cache directory
       id: npm-cache-dir
       shell: pwsh
-      run: echo "dir=$(npm config get cache)" >> ${env:GITHUB_OUTPUT}
+      run: |
+        "dir=$(npm config get cache)" >> ${env:GITHUB_OUTPUT}
 
     - name: Setup npm cache
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
@@ -250,7 +251,7 @@ jobs:
           if (($null -ne $response) -And ($response.StatusCode -eq 200)) {
             $json = $response.Content | ConvertFrom-Json
             $app = $json.application
-            $version = $app -eq $null ? "" : $app.version
+            $version = $null -eq $app ? "" : $app.version
             if ((-Not [string]::IsNullOrWhiteSpace($version)) -And $version.Contains(${env:GITHUB_SHA})) {
               $success = $true
               break

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,9 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        filter: 'tree:0'
+        show-progress: false
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
@@ -269,6 +272,9 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        filter: 'tree:0'
+        show-progress: false
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,6 +32,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        filter: 'tree:0'
+        show-progress: false
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -28,6 +28,9 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          filter: 'tree:0'
+          show-progress: false
 
       - name: Configure Trivy
         id: configure

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,6 +18,9 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          filter: 'tree:0'
+          show-progress: false
 
       - name: Review dependencies
         uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -27,6 +27,9 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        filter: 'tree:0'
+        show-progress: false
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,8 @@ permissions:
 
 env:
   FORCE_COLOR: 3
+  POWERSHELL_YAML_VERSION: '0.4.12'
+  PSSCRIPTANALYZER_VERSION: '1.23.0'
   TERM: xterm
 
 jobs:
@@ -29,6 +31,9 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        filter: 'tree:0'
+        show-progress: false
 
     - name: Add actionlint problem matcher
       run: echo "::add-matcher::.github/actionlint-matcher.json"
@@ -45,6 +50,13 @@ jobs:
         globs: |
           **/*.md
 
-    - name: Lint PowerShell
+    - name: Lint PowerShell in workflows
+      uses: martincostello/lint-actions-powershell@5942e3350ee5bd8f8933cec4e1185d13f0ea688f # v1.0.0
+      with:
+        powershell-yaml-version: ${{ env.POWERSHELL_YAML_VERSION }}
+        psscriptanalyzer-version: ${{ env.PSSCRIPTANALYZER_VERSION }}
+        treat-warnings-as-errors: true
+
+    - name: Lint PowerShell scripts
       shell: pwsh
       run: Invoke-ScriptAnalyzer -Path . -Recurse -IncludeDefaultRules -ReportSummary -Severity @('Error','Warning') -EnableExit

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          filter: 'tree:0'
           persist-credentials: false
+          show-progress: false
 
       - name: Run analysis
         uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0

--- a/.github/workflows/update-bank-holidays.yml
+++ b/.github/workflows/update-bank-holidays.yml
@@ -40,7 +40,7 @@ jobs:
         $GitStatus = (git status --porcelain)
 
         if ([string]::IsNullOrEmpty($GitStatus)) {
-          Write-Host "No changes to commit."
+          Write-Output "No changes to commit."
           exit 0
         }
 
@@ -52,7 +52,7 @@ jobs:
         git rev-parse --verify --quiet "remotes/origin/${BranchName}" | Out-Null
 
         if ($LASTEXITCODE -eq 0) {
-          Write-Host "Branch ${BranchName} already exists."
+          Write-Output "Branch ${BranchName} already exists."
           exit 0
         }
 

--- a/.github/workflows/update-bank-holidays.yml
+++ b/.github/workflows/update-bank-holidays.yml
@@ -18,6 +18,8 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
+        filter: 'tree:0'
+        show-progress: false
         token: ${{ secrets.COSTELLOBOT_TOKEN }}
 
     - name: Update UK bank holidays


### PR DESCRIPTION
- Use martincostello/lint-actions-powershell to lint PowerShell code embedded in GitHub Actions workflow files.
- Add filter and hide progress when checking out code.
