### PR TITLE
Reduce logging volume

### DIFF
--- a/src/Costellobot/appsettings.Development.json
+++ b/src/Costellobot/appsettings.Development.json
@@ -12,6 +12,7 @@
     "LogLevel": {
       "Default": "Information",
       "Azure": "Information",
+      "MartinCostello.Costellobot.GitHubWebhookDispatcher": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
   },

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -46,6 +46,7 @@
     "LogLevel": {
       "Default": "Information",
       "Azure": "Warning",
+      "MartinCostello.Costellobot.GitHubWebhookDispatcher": "Warning",
       "Microsoft": "Warning",
       "Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager": "Error",
       "Microsoft.AspNetCore.DataProtection.Repositories.EphemeralXmlRepository": "Error",

--- a/tests/Costellobot.Tests/Infrastructure/AppFixture.cs
+++ b/tests/Costellobot.Tests/Infrastructure/AppFixture.cs
@@ -127,6 +127,7 @@ public class AppFixture : WebApplicationFactory<Program>, ITestOutputHelperAcces
                 KeyValuePair.Create<string, string?>("GitHub:PrivateKey", testKey),
                 KeyValuePair.Create<string, string?>("GitHub:WebhookSecret", "github-webhook-secret"),
                 KeyValuePair.Create<string, string?>("HostOptions:ShutdownTimeout", "00:00:01"),
+                KeyValuePair.Create<string, string?>("Logging:LogLevel:MartinCostello.Costellobot.GitHubWebhookDispatcher", "Information"),
                 KeyValuePair.Create<string, string?>("Site:AdminUsers:0", "john-smith"),
                 KeyValuePair.Create<string, string?>("Webhook:DeployEnvironments:0", "production"),
                 KeyValuePair.Create<string, string?>("Webhook:IgnoreRepositories:0", "ignored-org/ignored-repo"),


### PR DESCRIPTION
Reduce the volume of logs by turning `GitHubWebhookDispatcher` down to `Warning` in production.
