### PR TITLE
Integration test refactoring

### DIFF
--- a/tests/Costellobot.Tests/Builders/GitHubCommitBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/GitHubCommitBuilder.cs
@@ -15,7 +15,7 @@ public sealed class GitHubCommitBuilder(RepositoryBuilder repository) : Response
 
     public RepositoryBuilder Repository { get; set; } = repository;
 
-    public string Sha { get; set; } = RandomString();
+    public string Sha { get; set; } = RandomString().Replace("-", string.Empty, StringComparison.Ordinal);
 
     public override object Build()
     {

--- a/tests/Costellobot.Tests/Builders/IssueBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/IssueBuilder.cs
@@ -34,12 +34,12 @@ public sealed class IssueBuilder(RepositoryBuilder repository, UserBuilder? user
         {
             id = Id,
             author_association = AuthorAssociation,
-            html_url = $"https://github.com/{Repository.Owner.Login}/{Repository.Name}/issues/{Number}",
+            html_url = $"https://github.com/{Repository.FullName}/issues/{Number}",
             number = Number,
             pull_request = PullRequest?.Build(),
             state = State,
             title = Title,
-            url = $"https://api.github.com/repos/{Repository.Owner.Login}/{Repository.Name}/issues/{Number}",
+            url = $"https://api.github.com/repos/{Repository.FullName}/issues/{Number}",
             user = (User ?? Repository.Owner).Build(),
         };
     }

--- a/tests/Costellobot.Tests/Builders/PullRequestBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/PullRequestBuilder.cs
@@ -7,6 +7,10 @@ public sealed class PullRequestBuilder(RepositoryBuilder repository, UserBuilder
 {
     public string AuthorAssociation { get; set; } = "owner";
 
+    public string DiffUrl => $"{Url}.diff";
+
+    public string HtmlUrl => $"https://github.com/{Repository.FullName}/pull/{Number}";
+
     public bool IsDraft { get; set; }
 
     public bool? IsMergeable { get; set; }
@@ -30,6 +34,8 @@ public sealed class PullRequestBuilder(RepositoryBuilder repository, UserBuilder
     public string State { get; set; } = "open";
 
     public string Title { get; set; } = RandomString();
+
+    public string Url => $"https://api.github.com/repos/{Repository.FullName}/pulls/{Number}";
 
     public UserBuilder? User { get; set; } = user;
 
@@ -59,15 +65,15 @@ public sealed class PullRequestBuilder(RepositoryBuilder repository, UserBuilder
                 @ref = RefHead,
                 sha = ShaHead,
             },
-            diff_url = $"https://api.github.com/repos/{Repository.Owner.Login}/{Repository.Name}/pulls/{Number}.diff",
-            html_url = $"https://github.com/{Repository.Owner.Login}/{Repository.Name}/pull/{Number}",
+            diff_url = DiffUrl,
+            html_url = HtmlUrl,
             labels = Labels.Build(),
             mergeable = IsMergeable,
             node_id = NodeId,
             number = Number,
             state = State,
             title = Title,
-            url = $"https://api.github.com/repos/{Repository.Owner.Login}/{Repository.Name}/pulls/{Number}",
+            url = Url,
             user = (User ?? Repository.Owner).Build(),
         };
     }

--- a/tests/Costellobot.Tests/Builders/RepositoryBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/RepositoryBuilder.cs
@@ -11,6 +11,8 @@ public sealed class RepositoryBuilder(UserBuilder owner, string? name = null) : 
 
     public bool? AllowSquashMerge { get; set; } = true;
 
+    public string FullName => $"{Owner.Login}/{Name}";
+
     public bool IsFork { get; set; }
 
     public bool IsPrivate { get; set; }
@@ -41,14 +43,14 @@ public sealed class RepositoryBuilder(UserBuilder owner, string? name = null) : 
             allow_rebase_merge = AllowRebaseMerge,
             allow_squash_merge = AllowSquashMerge,
             fork = IsFork,
-            full_name = $"{Owner.Login}/{Name}",
-            html_url = $"https://github.com/{Owner.Login}/{Name}",
+            full_name = FullName,
+            html_url = $"https://github.com/{FullName}",
             id = Id,
             language = Language,
             name = Name,
             owner = Owner.Build(),
             @private = IsPrivate,
-            url = $"https://api.github.com/repos/{Owner.Login}/{Name}",
+            url = $"https://api.github.com/repos/{FullName}",
         };
     }
 }

--- a/tests/Costellobot.Tests/Bundles/nuget-search.json
+++ b/tests/Costellobot.Tests/Bundles/nuget-search.json
@@ -470,6 +470,19 @@
         "totalHits": 0,
         "data": []
       }
+    },
+    {
+      "comment": "NuGet search result for bar",
+      "uri": "https://azuresearch-usnc.nuget.org/query?prerelease=true&q=PackageId%3Abar&semVerLevel=2.0.0&take=1",
+      "contentFormat": "json",
+      "contentJson": {
+        "@context": {
+          "@vocab": "http://schema.nuget.org/schema#",
+          "@base": "https://api.nuget.org/v3/registration5-gz-semver2/"
+        },
+        "totalHits": 0,
+        "data": []
+      }
     }
   ]
 }

--- a/tests/Costellobot.Tests/Drivers/DeploymentProtectionRuleDriver.cs
+++ b/tests/Costellobot.Tests/Drivers/DeploymentProtectionRuleDriver.cs
@@ -39,7 +39,7 @@ public sealed class DeploymentProtectionRuleDriver
             action,
             environment = Environment,
             @event = Event,
-            deployment_callback_url = $"https://api.github.com/repos/{Repository.Owner.Login}/{Repository.Name}/actions/runs/{RunId}/deployment_protection_rule",
+            deployment_callback_url = $"https://api.github.com/repos/{Repository.FullName}/actions/runs/{RunId}/deployment_protection_rule",
             deployment = Deployment.Build(),
             pull_requests = PullRequests.Build(),
             repository = Repository.Build(),

--- a/tests/Costellobot.Tests/Drivers/PullRequestDriver.cs
+++ b/tests/Costellobot.Tests/Drivers/PullRequestDriver.cs
@@ -7,7 +7,7 @@ using static MartinCostello.Costellobot.Builders.GitHubFixtures;
 
 namespace MartinCostello.Costellobot.Drivers;
 
-public sealed class PullRequestDriver
+public class PullRequestDriver
 {
     public PullRequestDriver(string? login = null)
     {
@@ -42,7 +42,7 @@ public sealed class PullRequestDriver
         return this;
     }
 
-    public object CreateWebhook(string action)
+    public virtual object CreateWebhook(string action)
     {
         return new
         {

--- a/tests/Costellobot.Tests/Handlers/CheckSuiteHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/CheckSuiteHandlerTests.cs
@@ -450,7 +450,7 @@ public class CheckSuiteHandlerTests(AppFixture fixture, ITestOutputHelper output
 
     private void RegisterGetCheckRuns(CheckSuiteDriver driver)
     {
-        string path = $"/repos/{driver.Repository.Owner.Login}/{driver.Repository.Name}/check-suites/{driver.CheckSuite.Id}/check-runs";
+        string path = $"/repos/{driver.Repository.FullName}/check-suites/{driver.CheckSuite.Id}/check-runs";
 
         var allCheckRuns = driver.CheckRuns.ToArray();
 
@@ -480,7 +480,7 @@ public class CheckSuiteHandlerTests(AppFixture fixture, ITestOutputHelper output
     {
         CreateDefaultBuilder()
             .Requests()
-            .ForPath($"/repos/{driver.Repository.Owner.Login}/{driver.Repository.Name}/pulls/{driver.PullRequest.Number}")
+            .ForPath($"/repos/{driver.Repository.FullName}/pulls/{driver.PullRequest.Number}")
             .Responds()
             .WithJsonContent(driver.PullRequest)
             .RegisterWith(Fixture.Interceptor);
@@ -492,7 +492,7 @@ public class CheckSuiteHandlerTests(AppFixture fixture, ITestOutputHelper output
     {
         CreateDefaultBuilder()
             .Requests()
-            .ForPath($"/repos/{checkSuite.Repository.Owner.Login}/{checkSuite.Repository.Name}/actions/runs")
+            .ForPath($"/repos/{checkSuite.Repository.FullName}/actions/runs")
             .ForQuery($"check_suite_id={checkSuite.Id}")
             .Responds()
             .WithJsonContent(CreateWorkflowRuns(workflows))
@@ -517,7 +517,7 @@ public class CheckSuiteHandlerTests(AppFixture fixture, ITestOutputHelper output
         var builder = CreateDefaultBuilder()
             .Requests()
             .ForPost()
-            .ForPath($"/repos/{driver.Repository.Owner.Login}/{driver.Repository.Name}/check-suites/{driver.CheckSuite.Id}/rerequest")
+            .ForPath($"/repos/{driver.Repository.FullName}/check-suites/{driver.CheckSuite.Id}/rerequest")
             .Responds()
             .WithStatus(StatusCodes.Status201Created)
             .WithSystemTextJsonContent(new { });
@@ -545,7 +545,7 @@ public class CheckSuiteHandlerTests(AppFixture fixture, ITestOutputHelper output
         var builder = CreateDefaultBuilder()
             .Requests()
             .ForPost()
-            .ForPath($"/repos/{driver.WorkflowRun.Repository.Owner.Login}/{driver.WorkflowRun.Repository.Name}/actions/runs/{driver.WorkflowRun.Id}/rerun-failed-jobs")
+            .ForPath($"/repos/{driver.WorkflowRun.Repository.FullName}/actions/runs/{driver.WorkflowRun.Id}/rerun-failed-jobs")
             .Responds()
             .WithStatus(StatusCodes.Status201Created)
             .WithSystemTextJsonContent(new { });

--- a/tests/Costellobot.Tests/Handlers/DeploymentProtectionRuleHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/DeploymentProtectionRuleHandlerTests.cs
@@ -123,7 +123,7 @@ public sealed class DeploymentProtectionRuleHandlerTests : IntegrationTests<AppF
         var builder = CreateDefaultBuilder()
             .Requests()
             .ForPost()
-            .ForPath($"/repos/{driver.Repository.Owner.Login}/{driver.Repository.Name}/actions/runs/{driver.RunId}/deployment_protection_rule")
+            .ForPath($"/repos/{driver.Repository.FullName}/actions/runs/{driver.RunId}/deployment_protection_rule")
             .Responds()
             .WithStatus(HttpStatusCode.NoContent);
 

--- a/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
@@ -730,7 +730,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
         var builder = CreateDefaultBuilder()
             .Requests()
             .ForPost()
-            .ForPath($"/repos/{driver.Repository.Owner.Login}/{driver.Repository.Name}/actions/runs/{driver.WorkflowRun.Id}/pending_deployments")
+            .ForPath($"/repos/{driver.Repository.FullName}/actions/runs/{driver.WorkflowRun.Id}/pending_deployments")
             .Responds()
             .WithJsonContent(driver.PendingDeployment!);
 
@@ -746,7 +746,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     {
         CreateDefaultBuilder()
             .Requests()
-            .ForPath($"/repos/{@base.Repository.Owner.Login}/{@base.Repository.Name}/compare/{@base.Sha}...{head.Sha}")
+            .ForPath($"/repos/{@base.Repository.FullName}/compare/{@base.Sha}...{head.Sha}")
             .Responds()
             .WithJsonContent(comparison)
             .RegisterWith(Fixture.Interceptor);
@@ -756,7 +756,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     {
         CreateDefaultBuilder()
             .Requests()
-            .ForPath($"/repos/{driver.BaseCommit.Repository.Owner.Login}/{driver.BaseCommit.Repository.Name}/compare/{driver.BaseCommit.Sha}...{driver.HeadCommit.Sha}")
+            .ForPath($"/repos/{driver.BaseCommit.Repository.FullName}/compare/{driver.BaseCommit.Sha}...{driver.HeadCommit.Sha}")
             .Responds()
             .WithJsonContent(driver.Comparison())
             .RegisterWith(Fixture.Interceptor);
@@ -769,7 +769,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     {
         CreateDefaultBuilder()
             .Requests()
-            .ForPath($"/repos/{repository.Owner.Login}/{repository.Name}/deployments")
+            .ForPath($"/repos/{repository.FullName}/deployments")
             .ForQuery($"environment={environmentName}")
             .Responds()
             .WithJsonContent(deployments)
@@ -783,7 +783,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     {
         CreateDefaultBuilder()
             .Requests()
-            .ForPath($"/repos/{repository.Owner.Login}/{repository.Name}/deployments/{deployment.Id}/statuses")
+            .ForPath($"/repos/{repository.FullName}/deployments/{deployment.Id}/statuses")
             .Responds()
             .WithJsonContent(deploymentStatuses)
             .RegisterWith(Fixture.Interceptor);
@@ -819,7 +819,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
 
         CreateDefaultBuilder()
             .Requests()
-            .ForPath($"/repos/{driver.Repository.Owner.Login}/{driver.Repository.Name}/deployments")
+            .ForPath($"/repos/{driver.Repository.FullName}/deployments")
             .ForQuery($"environment={driver.PendingDeployment!.Environment}")
             .Responds()
             .WithJsonContent(deployments)
@@ -833,7 +833,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     {
         CreateDefaultBuilder()
             .Requests()
-            .ForPath($"/repos/{repository.Owner.Login}/{repository.Name}/actions/runs/{runId}/pending_deployments")
+            .ForPath($"/repos/{repository.FullName}/actions/runs/{runId}/pending_deployments")
             .Responds()
             .WithJsonContent(deployments)
             .RegisterWith(Fixture.Interceptor);
@@ -843,7 +843,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     {
         CreateDefaultBuilder()
             .Requests()
-            .ForPath($"/repos/{driver.Repository.Owner.Login}/{driver.Repository.Name}/actions/runs/{driver.WorkflowRun.Id}/pending_deployments")
+            .ForPath($"/repos/{driver.Repository.FullName}/actions/runs/{driver.WorkflowRun.Id}/pending_deployments")
             .Responds()
             .WithJsonContent(driver.PendingDeployment!.CreatePendingDeployment())
             .RegisterWith(Fixture.Interceptor);
@@ -852,20 +852,6 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     private void RegisterPullRequestForCommit(GitHubCommitBuilder commit)
     {
         var pullRequest = CreatePullRequestForCommit(commit);
-
-        CreateDefaultBuilder()
-            .Requests()
-            .ForPath($"/repos/{commit.Repository.Owner.Login}/{commit.Repository.Name}/commits/{commit.Sha}/pulls")
-            .Responds()
-            .WithJsonContent(pullRequest)
-            .RegisterWith(Fixture.Interceptor);
-
-        CreateDefaultBuilder()
-            .Requests()
-            .ForPath($"/repos/{pullRequest.Repository.Owner.Login}/{pullRequest.Repository.Name}/pulls/{pullRequest.Number}")
-            .ForRequestHeader("Accept", "application/vnd.github.v3.diff")
-            .Responds()
-            .WithContent(string.Empty)
-            .RegisterWith(Fixture.Interceptor);
+        RegisterCommitAndDiff(pullRequest, commit);
     }
 }

--- a/tests/Costellobot.Tests/Handlers/IssueCommentHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/IssueCommentHandlerTests.cs
@@ -97,7 +97,7 @@ public class IssueCommentHandlerTests(AppFixture fixture, ITestOutputHelper outp
     {
         CreateDefaultBuilder()
             .Requests()
-            .ForPath($"/repos/{driver.Repository.Owner.Login}/{driver.Repository.Name}/pulls/{driver.Issue.PullRequest!.Number}")
+            .ForPath($"/repos/{driver.Repository.FullName}/pulls/{driver.Issue.PullRequest!.Number}")
             .Responds()
             .WithJsonContent(driver.Issue.PullRequest.Build())
             .RegisterWith(Fixture.Interceptor);
@@ -138,7 +138,7 @@ public class IssueCommentHandlerTests(AppFixture fixture, ITestOutputHelper outp
                 var number = clientPayload.GetProperty("number").GetInt32();
 
                 return
-                    string.Equals(repository, $"{driver.Owner.Login}/{driver.Repository.Name}", StringComparison.Ordinal) &&
+                    string.Equals(repository, driver.Repository.FullName, StringComparison.Ordinal) &&
                     string.Equals(baseRef, driver.Issue.PullRequest?.RefBase, StringComparison.Ordinal) &&
                     string.Equals(headRef, driver.Issue.PullRequest?.RefHead, StringComparison.Ordinal) &&
                     number == driver.Issue.Number;
@@ -158,7 +158,7 @@ public class IssueCommentHandlerTests(AppFixture fixture, ITestOutputHelper outp
         CreateDefaultBuilder()
             .Requests()
             .ForPost()
-            .ForPath($"/repos/{driver.Issue.Repository.Owner.Login}/{driver.Issue.Repository.Name}/issues/comments/{driver.Comment.Id}/reactions")
+            .ForPath($"/repos/{driver.Issue.Repository.FullName}/issues/comments/{driver.Comment.Id}/reactions")
             .ForContent(async (request) =>
             {
                 request.ShouldNotBeNull();

--- a/tests/Costellobot.Tests/Handlers/PushHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PushHandlerTests.cs
@@ -164,7 +164,7 @@ public class PushHandlerTests(AppFixture fixture, ITestOutputHelper outputHelper
                 var sha = clientPayload.GetProperty("sha").GetString();
 
                 return
-                    string.Equals(repository, $"{driver.Owner.Login}/{driver.Repository.Name}", StringComparison.Ordinal) &&
+                    string.Equals(repository, driver.Repository.FullName, StringComparison.Ordinal) &&
                     string.Equals(reference, driver.Ref, StringComparison.Ordinal) &&
                     string.Equals(referenceName, branch, StringComparison.Ordinal) &&
                     string.Equals(sha, driver.After, StringComparison.Ordinal);

--- a/tests/Costellobot.Tests/Infrastructure/InMemoryTrustStore.cs
+++ b/tests/Costellobot.Tests/Infrastructure/InMemoryTrustStore.cs
@@ -7,6 +7,8 @@ internal sealed class InMemoryTrustStore : ITrustStore
 {
     private readonly HashSet<(DependencyEcosystem Ecosystem, string Id, string Version)> _trustStore = [];
 
+    public int Count => _trustStore.Count;
+
     public Task DistrustAsync(DependencyEcosystem ecosystem, string id, string version, CancellationToken cancellationToken = default)
     {
         _trustStore.Remove((ecosystem, id, version));
@@ -34,4 +36,6 @@ internal sealed class InMemoryTrustStore : ITrustStore
         _trustStore.Add((ecosystem, id, version));
         return Task.CompletedTask;
     }
+
+    public void Clear() => _trustStore.Clear();
 }


### PR DESCRIPTION
- Simplify builder for repositories.
- Support clearing the in-memory trust store.
- Make HTTP interception for pull requests re-usable.

Contributes to #2021.
