### PR TITLE
Fix-up antiforgery

### DIFF
--- a/src/Costellobot/Handlers/PullRequestAnalyzer.cs
+++ b/src/Costellobot/Handlers/PullRequestAnalyzer.cs
@@ -77,7 +77,7 @@ public sealed partial class PullRequestAnalyzer(
             return false;
         }
 
-        bool isTrusted = _options.CurrentValue.TrustedEntities.Users.Contains(
+        bool isTrusted = options.TrustedEntities.Users.Contains(
             authorLogin,
             StringComparer.Ordinal);
 

--- a/src/Costellobot/ITrustStore.cs
+++ b/src/Costellobot/ITrustStore.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using MartinCostello.Costellobot.Models;
+
 namespace MartinCostello.Costellobot;
 
 public interface ITrustStore
@@ -11,7 +13,7 @@ public interface ITrustStore
         string version,
         CancellationToken cancellationToken = default);
 
-    Task<IReadOnlyList<KeyValuePair<string, string>>> GetTrustAsync(
+    Task<IReadOnlyList<TrustedDependency>> GetTrustAsync(
        DependencyEcosystem ecosystem,
        CancellationToken cancellationToken = default);
 

--- a/src/Costellobot/Models/TrustedDependency.cs
+++ b/src/Costellobot/Models/TrustedDependency.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Costellobot.Models;
+
+public sealed record TrustedDependency(
+    string Id,
+    string Version)
+{
+    public DateTimeOffset? TrustedAt { get; set; }
+}

--- a/src/Costellobot/TrustedEntitiesOptions.cs
+++ b/src/Costellobot/TrustedEntitiesOptions.cs
@@ -9,5 +9,7 @@ public sealed class TrustedEntitiesOptions
 
     public IDictionary<DependencyEcosystem, IList<string>> Publishers { get; set; } = new Dictionary<DependencyEcosystem, IList<string>>();
 
+    public IList<string> Reviewers { get; set; } = [];
+
     public IList<string> Users { get; set; } = [];
 }

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -148,6 +148,9 @@
           "xunit"
         ]
       },
+      "Reviewers": [
+        "costellobot[bot]"
+      ],
       "Users": [
         "costellobot",
         "costellobot[bot]",

--- a/tests/Costellobot.Tests/Builders/DeploymentBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/DeploymentBuilder.cs
@@ -7,7 +7,7 @@ public sealed class DeploymentBuilder : ResponseBuilder
 {
     public string Environment { get; set; } = RandomString();
 
-    public string Sha { get; set; } = RandomString();
+    public string Sha { get; set; } = RandomGitSha();
 
     public PendingDeploymentBuilder CreatePendingDeployment()
         => new() { Environment = Environment };

--- a/tests/Costellobot.Tests/Builders/GitHubCommitBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/GitHubCommitBuilder.cs
@@ -15,7 +15,7 @@ public sealed class GitHubCommitBuilder(RepositoryBuilder repository) : Response
 
     public RepositoryBuilder Repository { get; set; } = repository;
 
-    public string Sha { get; set; } = RandomString().Replace("-", string.Empty, StringComparison.Ordinal);
+    public string Sha { get; set; } = RandomGitSha();
 
     public override object Build()
     {

--- a/tests/Costellobot.Tests/Builders/PullRequestBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/PullRequestBuilder.cs
@@ -27,9 +27,9 @@ public sealed class PullRequestBuilder(RepositoryBuilder repository, UserBuilder
 
     public string RefHead { get; set; } = "dependabot/nuget/Foo-1.2.3";
 
-    public string ShaBase { get; set; } = RandomString();
+    public string ShaBase { get; set; } = RandomGitSha();
 
-    public string ShaHead { get; set; } = RandomString();
+    public string ShaHead { get; set; } = RandomGitSha();
 
     public string State { get; set; } = "open";
 

--- a/tests/Costellobot.Tests/Builders/ResponseBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/ResponseBuilder.cs
@@ -13,5 +13,7 @@ public abstract class ResponseBuilder
 
     protected static int RandomNumber() => RandomNumberGenerator.GetInt32(int.MaxValue);
 
+    protected static string RandomGitSha() => Guid.NewGuid().ToString().Replace("-", string.Empty, StringComparison.Ordinal);
+
     protected static string RandomString() => Guid.NewGuid().ToString();
 }

--- a/tests/Costellobot.Tests/Infrastructure/InMemoryTrustStore.cs
+++ b/tests/Costellobot.Tests/Infrastructure/InMemoryTrustStore.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using MartinCostello.Costellobot.Models;
+
 namespace MartinCostello.Costellobot.Infrastructure;
 
 internal sealed class InMemoryTrustStore : ITrustStore
@@ -15,14 +17,14 @@ internal sealed class InMemoryTrustStore : ITrustStore
         return Task.CompletedTask;
     }
 
-    public Task<IReadOnlyList<KeyValuePair<string, string>>> GetTrustAsync(DependencyEcosystem ecosystem, CancellationToken cancellationToken = default)
+    public Task<IReadOnlyList<TrustedDependency>> GetTrustAsync(DependencyEcosystem ecosystem, CancellationToken cancellationToken = default)
     {
         var trusted = _trustStore
             .Where((p) => p.Ecosystem == ecosystem)
-            .Select((p) => KeyValuePair.Create(p.Id, p.Version))
+            .Select((p) => new TrustedDependency(p.Id, p.Version))
             .ToList();
 
-        return Task.FromResult<IReadOnlyList<KeyValuePair<string, string>>>(trusted);
+        return Task.FromResult<IReadOnlyList<TrustedDependency>>(trusted);
     }
 
     public Task<bool> IsTrustedAsync(DependencyEcosystem ecosystem, string id, string version, CancellationToken cancellationToken = default)


### PR DESCRIPTION
- Add missing antiforgery filter to redelivery webhooks.
- Remove redundant antiforgery filters for GET endpoints.
- Add configuration option for trusted reviewers.
- Use local variable to get the options instead of accessing `IOptionsSnapshot<T>.CurrentValue` again.
- Replace all GUIDs for Git SHA properties with a string without dashes in tests.
- Replace key-value pairs with a `TrustedDependency` model.
