### PR TITLE
Test refactoring

### DIFF
--- a/src/Costellobot/AzureTableTrustStore.cs
+++ b/src/Costellobot/AzureTableTrustStore.cs
@@ -9,7 +9,6 @@ using MartinCostello.Costellobot.Models;
 
 namespace MartinCostello.Costellobot;
 
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public sealed class AzureTableTrustStore(TableServiceClient client) : ITrustStore
 {
     private const string TableName = "TrustStore";
@@ -138,7 +137,7 @@ public sealed class AzureTableTrustStore(TableServiceClient client) : ITrustStor
     /// <summary>
     /// A class representing an entity in the trust store. This class cannot be inherited.
     /// </summary>
-    private sealed class TrustEntity : ITableEntity
+    public sealed class TrustEntity : ITableEntity
     {
         public string DependencyEcosystem { get; set; } = default!;
 

--- a/src/Costellobot/ChannelQueue`1.cs
+++ b/src/Costellobot/ChannelQueue`1.cs
@@ -30,9 +30,16 @@ public abstract class ChannelQueue<T>
     {
         T? item = default;
 
-        if (await _queue.Reader.WaitToReadAsync(cancellationToken))
+        try
         {
-            item = await _queue.Reader.ReadAsync(cancellationToken);
+            if (await _queue.Reader.WaitToReadAsync(cancellationToken))
+            {
+                item = await _queue.Reader.ReadAsync(cancellationToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Ignore
         }
 
         return item;

--- a/src/Costellobot/GitCommitAnalyzer.cs
+++ b/src/Costellobot/GitCommitAnalyzer.cs
@@ -187,7 +187,7 @@ public sealed partial class GitCommitAnalyzer(
         // * dependabot/github_actions/actions/dependency-review-action-2
         // * dependabot/npm_and_yarn/src/Costellobot/typescript-eslint/eslint-plugin-5.31.0
         // * dependabot/nuget/Microsoft.IdentityModel.JsonWebTokens-6.22.0
-        string[]? parts = reference?.Split('/');
+        string[] parts = reference?.Split('/') ?? [];
 
         if (parts is null ||
             parts.Length < 3 ||

--- a/src/Costellobot/Handlers/PullRequestApprover.cs
+++ b/src/Costellobot/Handlers/PullRequestApprover.cs
@@ -19,7 +19,13 @@ public sealed partial class PullRequestApprover(
 {
     private readonly IOptionsMonitor<WebhookOptions> _options = options;
 
-    public async Task ApproveAndMergeAsync(IssueId pull, string nodeId, Octokit.Webhooks.Models.Repository repo)
+    public static PullRequestMergeMethod GetMergeMethod(Octokit.Repository repo)
+        => GetMergeMethod((repo.AllowMergeCommit, repo.AllowSquashMerge, repo.AllowRebaseMerge));
+
+    public static PullRequestMergeMethod GetMergeMethod(Octokit.Webhooks.Models.Repository repo)
+        => GetMergeMethod((repo.AllowMergeCommit, repo.AllowSquashMerge, repo.AllowRebaseMerge));
+
+    public async Task ApproveAndMergeAsync(IssueId pull, string nodeId, PullRequestMergeMethod mergeMethod)
     {
         var options = _options.CurrentValue;
 
@@ -33,11 +39,11 @@ public sealed partial class PullRequestApprover(
             await EnableAutoMergeAsync(
                 pull,
                 nodeId,
-                GetMergeMethod(repo));
+                mergeMethod);
         }
     }
 
-    private static PullRequestMergeMethod GetMergeMethod(Octokit.Webhooks.Models.Repository repo)
+    private static PullRequestMergeMethod GetMergeMethod((bool? AllowMergeCommit, bool? AllowSquashMerge, bool? AllowRebaseMerge) repo)
     {
         if (repo.AllowMergeCommit == true)
         {

--- a/src/Costellobot/Handlers/PullRequestHandler.cs
+++ b/src/Costellobot/Handlers/PullRequestHandler.cs
@@ -51,7 +51,8 @@ public sealed partial class PullRequestHandler(
 
         if (isManualApproval || isTrusted)
         {
-            await approver.ApproveAndMergeAsync(pull, pr.NodeId, pr.Base.Repo);
+            var mergeMethod = PullRequestApprover.GetMergeMethod(pr.Base.Repo);
+            await approver.ApproveAndMergeAsync(pull, pr.NodeId, mergeMethod);
         }
     }
 

--- a/src/Costellobot/ITrustStore.cs
+++ b/src/Costellobot/ITrustStore.cs
@@ -13,6 +13,8 @@ public interface ITrustStore
         string version,
         CancellationToken cancellationToken = default);
 
+    Task DistrustAllAsync(CancellationToken cancellationToken = default);
+
     Task<IReadOnlyList<TrustedDependency>> GetTrustAsync(
        DependencyEcosystem ecosystem,
        CancellationToken cancellationToken = default);

--- a/src/Costellobot/Slices/_Layout.cshtml
+++ b/src/Costellobot/Slices/_Layout.cshtml
@@ -104,7 +104,7 @@
                         </li>
                         @*
                         <li class="nav-item">
-                            <a class="nav-link" href="@(this.RouteUrl("~/dependencies"))" title="Dependencies">
+                            <a class="nav-link" href="@(this.RouteUrl("~/dependencies"))" title="Dependencies" id="dependencies-link">
                                 Dependencies
                                 <span class="fa-solid fa-cubes" aria-hidden="true"></span>
                             </a>

--- a/tests/Costellobot.Tests/AzureTableTrustStoreTests.cs
+++ b/tests/Costellobot.Tests/AzureTableTrustStoreTests.cs
@@ -1,0 +1,186 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Linq.Expressions;
+using Azure;
+using Azure.Data.Tables;
+using MartinCostello.Costellobot.Models;
+using NSubstitute;
+using TrustEntity = MartinCostello.Costellobot.AzureTableTrustStore.TrustEntity;
+
+namespace MartinCostello.Costellobot;
+
+public class AzureTableTrustStoreTests
+{
+    [Fact]
+    public async Task DistrustAllAsync_Distrusts_All_Entities()
+    {
+        // Arrange
+        var table = Substitute.For<TableClient>();
+        var client = Substitute.For<TableServiceClient>();
+
+        client.GetTableClient("TrustStore")
+              .Returns(table);
+
+        var page = Substitute.For<Page<TrustEntity>>();
+        page.Values.Returns([new(), new()]);
+
+        var pages = Substitute.For<AsyncPageable<TrustEntity>>();
+        pages.AsPages().Returns(Pages([page]));
+
+        table.QueryAsync<TrustEntity>(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string[]>(), Arg.Any<CancellationToken>())
+             .ReturnsForAnyArgs(pages);
+
+        var target = new AzureTableTrustStore(client);
+
+        // Act and Assert
+        await Should.NotThrowAsync(() => target.DistrustAllAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Theory]
+    [InlineData(DependencyEcosystem.GitHubActions, "martincostello/rebaser", "2.0.1", "GITHUBACTIONS", "MARTINCOSTELLO~REBASER@2.0.1")]
+    [InlineData(DependencyEcosystem.Npm, "@octokit/request", "9.2.2", "NPM", "@OCTOKIT~REQUEST@9.2.2")]
+    [InlineData(DependencyEcosystem.NuGet, "Polly.Core", "8.5.2", "NUGET", "POLLY.CORE@8.5.2")]
+    public async Task DistrustAsync_Distrusts_Entity(
+        DependencyEcosystem ecosystem,
+        string id,
+        string version,
+        string expectedPartitionKey,
+        string expectedRowKey)
+    {
+        // Arrange
+        var table = Substitute.For<TableClient>();
+        var client = Substitute.For<TableServiceClient>();
+
+        client.GetTableClient("TrustStore")
+              .Returns(table);
+
+        var target = new AzureTableTrustStore(client);
+
+        // Act
+        await target.DistrustAsync(
+            ecosystem,
+            id,
+            version,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await table.Received().DeleteEntityAsync(
+            expectedPartitionKey,
+            expectedRowKey,
+            cancellationToken: TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task GetTrustAsync_Returns_Correct_Values()
+    {
+        // Arrange
+        var ecosystem = DependencyEcosystem.NuGet;
+        var table = Substitute.For<TableClient>();
+        var client = Substitute.For<TableServiceClient>();
+
+        client.GetTableClient("TrustStore")
+              .Returns(table);
+
+        TrustEntity[] entities =
+        [
+            new()
+            {
+                DependencyEcosystem = "NuGet",
+                DependencyId = "Polly",
+                DependencyVersion = "8.5.2",
+                Timestamp = new(2025, 02, 23, 12, 34, 55, TimeSpan.Zero),
+            },
+            new()
+            {
+                DependencyEcosystem = "NuGet",
+                DependencyId = "Polly.Core",
+                DependencyVersion = "8.5.2",
+                Timestamp = new(2025, 02, 23, 12, 34, 56, TimeSpan.Zero),
+            },
+        ];
+
+        var page = Substitute.For<Page<TrustEntity>>();
+        page.Values.Returns(entities);
+
+        var pages = Substitute.For<AsyncPageable<TrustEntity>>();
+        pages.AsPages().Returns(Pages([page]));
+
+        table.QueryAsync<TrustEntity>(Arg.Any<Expression<Func<TrustEntity, bool>>>(), Arg.Any<int>(), Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+             .ReturnsForAnyArgs(pages);
+
+        var target = new AzureTableTrustStore(client);
+
+        // Act
+        var actual = await target.GetTrustAsync(ecosystem, TestContext.Current.CancellationToken);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ShouldNotBeEmpty();
+        actual.ShouldContain(new TrustedDependency("Polly", "8.5.2") { TrustedAt = new(2025, 02, 23, 12, 34, 55, TimeSpan.Zero) });
+        actual.ShouldContain(new TrustedDependency("Polly.Core", "8.5.2") { TrustedAt = new(2025, 02, 23, 12, 34, 56, TimeSpan.Zero) });
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public async Task IsTrustedAsync_Returns_Correct_Value(bool hasValue, bool expected)
+    {
+        // Arrange
+        var ecosystem = DependencyEcosystem.NuGet;
+        var id = "Polly.Core";
+        var version = "8.5.2";
+
+        var table = Substitute.For<TableClient>();
+        var client = Substitute.For<TableServiceClient>();
+
+        client.GetTableClient("TrustStore")
+              .Returns(table);
+
+        var response = Substitute.For<NullableResponse<TrustEntity>>();
+        response.HasValue.Returns(hasValue);
+
+        table.GetEntityIfExistsAsync<TrustEntity>(
+            "NUGET",
+            "POLLY.CORE@8.5.2",
+            cancellationToken: TestContext.Current.CancellationToken).Returns(response);
+
+        var target = new AzureTableTrustStore(client);
+
+        // Act
+        var actual = await target.IsTrustedAsync(ecosystem, id, version, TestContext.Current.CancellationToken);
+
+        // Assert
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
+    public async Task TrustAsync_Does_Not_Throw()
+    {
+        // Arrange
+        var ecosystem = DependencyEcosystem.NuGet;
+        var id = "Polly.Core";
+        var version = "8.5.2";
+
+        var table = Substitute.For<TableClient>();
+        var client = Substitute.For<TableServiceClient>();
+
+        client.GetTableClient("TrustStore")
+              .Returns(table);
+
+        var target = new AzureTableTrustStore(client);
+
+        // Act and Assert
+        await Should.NotThrowAsync(() => target.TrustAsync(ecosystem, id, version, TestContext.Current.CancellationToken));
+    }
+
+    private static async IAsyncEnumerable<Page<TrustEntity>> Pages(IEnumerable<Page<TrustEntity>> pages)
+    {
+        foreach (var page in pages)
+        {
+            yield return page;
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/tests/Costellobot.Tests/Builders/GitHubAppBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/GitHubAppBuilder.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Costellobot.Builders;
+
+public sealed class GitHubAppBuilder(string slug, UserBuilder owner) : ResponseBuilder
+{
+    public string ClientId { get; set; } = RandomString();
+
+    public string Name { get; set; } = RandomString();
+
+    public string NodeId { get; set; } = RandomString();
+
+    public UserBuilder Owner { get; set; } = owner;
+
+    public string Slug { get; } = slug;
+
+    public override object Build()
+    {
+        return new
+        {
+            client_id = ClientId,
+            id = Id,
+            name = Name,
+            node_id = NodeId,
+            owner = Owner.Build(),
+            slug = Slug,
+        };
+    }
+}

--- a/tests/Costellobot.Tests/Builders/InstallationRepositoriesBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/InstallationRepositoriesBuilder.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Costellobot.Builders;
+
+public sealed class InstallationRepositoriesBuilder(IEnumerable<RepositoryBuilder> repositories) : ResponseBuilder
+{
+    public IList<RepositoryBuilder> Repositories { get; } = [.. repositories];
+
+    public override object Build()
+    {
+        return new
+        {
+            total_count = Repositories.Count,
+            repositories = Repositories.Select((p) => p.Build()).ToArray(),
+        };
+    }
+}

--- a/tests/Costellobot.Tests/Builders/IssueBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/IssueBuilder.cs
@@ -23,7 +23,10 @@ public sealed class IssueBuilder(RepositoryBuilder repository, UserBuilder? user
     {
         PullRequest = new(Repository, User)
         {
+            AuthorAssociation = AuthorAssociation,
             Number = Number,
+            State = State,
+            Title = Title,
         };
         return this;
     }

--- a/tests/Costellobot.Tests/Builders/PullRequestBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/PullRequestBuilder.cs
@@ -48,6 +48,19 @@ public sealed class PullRequestBuilder(RepositoryBuilder repository, UserBuilder
         return this;
     }
 
+    public IssueBuilder ToIssue()
+    {
+        return new IssueBuilder(Repository, User)
+        {
+            AuthorAssociation = AuthorAssociation,
+            Id = Id,
+            Number = Number,
+            PullRequest = this,
+            State = State,
+            Title = Title,
+        };
+    }
+
     public override object Build()
     {
         return new

--- a/tests/Costellobot.Tests/Builders/PullRequestReviewBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/PullRequestReviewBuilder.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Costellobot.Builders;
+
+public sealed class PullRequestReviewBuilder(
+    PullRequestBuilder pullRequest,
+    UserBuilder user) : ResponseBuilder
+{
+    public string AuthorAssociation { get; set; } = "OWNER";
+
+    public string Body { get; set; } = "This looks great.";
+
+    public string NodeId { get; set; } = RandomString();
+
+    public PullRequestBuilder PullRequest { get; } = pullRequest;
+
+    public string State { get; set; } = "commented";
+
+    public UserBuilder User { get; set; } = user;
+
+    public override object Build()
+    {
+        return new
+        {
+            author_association = AuthorAssociation,
+            body = Body,
+            commit_id = PullRequest.RefHead,
+            id = Id,
+            node_id = NodeId,
+            pull_request_url = PullRequest.Url,
+            state = State,
+            user = User.Build(),
+        };
+    }
+}

--- a/tests/Costellobot.Tests/Builders/RepositoryBuilder.cs
+++ b/tests/Costellobot.Tests/Builders/RepositoryBuilder.cs
@@ -13,6 +13,8 @@ public sealed class RepositoryBuilder(UserBuilder owner, string? name = null) : 
 
     public string FullName => $"{Owner.Login}/{Name}";
 
+    public bool IsArchived { get; set; }
+
     public bool IsFork { get; set; }
 
     public bool IsPrivate { get; set; }
@@ -42,6 +44,7 @@ public sealed class RepositoryBuilder(UserBuilder owner, string? name = null) : 
             allow_merge_commit = AllowMergeCommit,
             allow_rebase_merge = AllowRebaseMerge,
             allow_squash_merge = AllowSquashMerge,
+            archived = IsArchived,
             fork = IsFork,
             full_name = FullName,
             html_url = $"https://github.com/{FullName}",

--- a/tests/Costellobot.Tests/Handlers/CheckSuiteHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/CheckSuiteHandlerTests.cs
@@ -322,7 +322,7 @@ public class CheckSuiteHandlerTests(AppFixture fixture, ITestOutputHelper output
 
         RegisterCheckSuiteWithNoWorkflowRun(driver);
 
-        var rerequestCheckSuite = new TaskCompletionSource();
+        var rerequestCheckSuite = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         RegisterRerequestCheckSuite(driver, (p) =>
         {
             p.WithStatus(HttpStatusCode.BadRequest)
@@ -350,7 +350,7 @@ public class CheckSuiteHandlerTests(AppFixture fixture, ITestOutputHelper output
 
         RegisterCheckSuiteWithWorkflowRun(driver);
 
-        var failedJobsRetried = new TaskCompletionSource();
+        var failedJobsRetried = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         RegisterRerunFailedJobs(driver, (p) =>
         {
             p.WithStatus(HttpStatusCode.BadRequest)
@@ -501,7 +501,7 @@ public class CheckSuiteHandlerTests(AppFixture fixture, ITestOutputHelper output
 
     private TaskCompletionSource RegisterRerequestCheckSuite(CheckSuiteDriver driver)
     {
-        var rerequestCheckSuite = new TaskCompletionSource();
+        var rerequestCheckSuite = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         RegisterRerequestCheckSuite(
             driver,
@@ -529,7 +529,7 @@ public class CheckSuiteHandlerTests(AppFixture fixture, ITestOutputHelper output
 
     private TaskCompletionSource RegisterRerunFailedJobs(CheckSuiteDriver driver)
     {
-        var failedJobsRetried = new TaskCompletionSource();
+        var failedJobsRetried = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         RegisterRerunFailedJobs(
             driver,

--- a/tests/Costellobot.Tests/Handlers/DeploymentProtectionRuleHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/DeploymentProtectionRuleHandlerTests.cs
@@ -107,7 +107,7 @@ public sealed class DeploymentProtectionRuleHandlerTests : IntegrationTests<AppF
 
     private TaskCompletionSource RegisterApprovePendingDeployment(DeploymentProtectionRuleDriver driver)
     {
-        var deploymentApproved = new TaskCompletionSource();
+        var deploymentApproved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         RegisterApproveDeploymentProtectionRule(
             driver,

--- a/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
@@ -154,7 +154,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
         RegisterCommitComparison(driver);
         RegisterPullRequestForCommit(driver.HeadCommit);
 
-        var deploymentApproved = new TaskCompletionSource();
+        var deploymentApproved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         RegisterApprovePendingDeployment(driver, (p) =>
         {
             p.WithStatus(HttpStatusCode.Forbidden)
@@ -714,7 +714,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
 
     private TaskCompletionSource RegisterApprovePendingDeployment(DeploymentStatusDriver driver)
     {
-        var deploymentApproved = new TaskCompletionSource();
+        var deploymentApproved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         RegisterApprovePendingDeployment(
             driver,

--- a/tests/Costellobot.Tests/Handlers/IssueCommentHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/IssueCommentHandlerTests.cs
@@ -105,7 +105,7 @@ public class IssueCommentHandlerTests(AppFixture fixture, ITestOutputHelper outp
 
     private TaskCompletionSource RegisterDispatch(IssueCommentDriver driver)
     {
-        var dispatched = new TaskCompletionSource();
+        var dispatched = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         CreateDefaultBuilder()
             .Requests()
@@ -153,7 +153,7 @@ public class IssueCommentHandlerTests(AppFixture fixture, ITestOutputHelper outp
 
     private TaskCompletionSource RegisterReaction(IssueCommentDriver driver, string reaction)
     {
-        var dispatched = new TaskCompletionSource();
+        var dispatched = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         CreateDefaultBuilder()
             .Requests()

--- a/tests/Costellobot.Tests/Handlers/PushHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PushHandlerTests.cs
@@ -131,7 +131,7 @@ public class PushHandlerTests(AppFixture fixture, ITestOutputHelper outputHelper
 
     private TaskCompletionSource RegisterDispatch(PushDriver driver, string branch = "main")
     {
-        var dispatched = new TaskCompletionSource();
+        var dispatched = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         CreateDefaultBuilder()
             .Requests()

--- a/tests/Costellobot.Tests/HomeTests.cs
+++ b/tests/Costellobot.Tests/HomeTests.cs
@@ -68,7 +68,7 @@ public class HomeTests(HttpServerFixture fixture, ITestOutputHelper outputHelper
         var browser = new BrowserFixture(options, OutputHelper);
         await browser.WithPageAsync(async page =>
         {
-            var connected = new TaskCompletionSource();
+            var connected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             page.WebSocket += (_, p) =>
                 p.FrameReceived += (_, _) => connected.TrySetResult();
 

--- a/tests/Costellobot.Tests/Infrastructure/AppFixture.cs
+++ b/tests/Costellobot.Tests/Infrastructure/AppFixture.cs
@@ -141,7 +141,11 @@ public class AppFixture : WebApplicationFactory<Program>, ITestOutputHelperAcces
         builder.ConfigureAntiforgeryTokenResource();
 
         builder.ConfigureLogging(
-            (loggingBuilder) => loggingBuilder.ClearProviders().AddXUnit(this).AddSignalR());
+            (loggingBuilder) =>
+                loggingBuilder.ClearProviders()
+                              .AddXUnit(this)
+                              .AddSignalR()
+                              .AddFilter("MartinCostello.Costellobot", (_) => true));
 
         builder.UseEnvironment(Environments.Production);
 

--- a/tests/Costellobot.Tests/Infrastructure/InMemoryTrustStore.cs
+++ b/tests/Costellobot.Tests/Infrastructure/InMemoryTrustStore.cs
@@ -1,25 +1,26 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using MartinCostello.Costellobot.Models;
 
 namespace MartinCostello.Costellobot.Infrastructure;
 
 internal sealed class InMemoryTrustStore : ITrustStore
 {
-    private readonly HashSet<(DependencyEcosystem Ecosystem, string Id, string Version)> _trustStore = [];
+    private readonly ConcurrentDictionary<(DependencyEcosystem Ecosystem, string Id, string Version), bool> _trustStore = new();
 
     public int Count => _trustStore.Count;
 
     public Task DistrustAsync(DependencyEcosystem ecosystem, string id, string version, CancellationToken cancellationToken = default)
     {
-        _trustStore.Remove((ecosystem, id, version));
+        _trustStore.Remove((ecosystem, id, version), out _);
         return Task.CompletedTask;
     }
 
     public Task<IReadOnlyList<TrustedDependency>> GetTrustAsync(DependencyEcosystem ecosystem, CancellationToken cancellationToken = default)
     {
-        var trusted = _trustStore
+        var trusted = _trustStore.Keys
             .Where((p) => p.Ecosystem == ecosystem)
             .Select((p) => new TrustedDependency(p.Id, p.Version))
             .ToList();
@@ -29,13 +30,13 @@ internal sealed class InMemoryTrustStore : ITrustStore
 
     public Task<bool> IsTrustedAsync(DependencyEcosystem ecosystem, string id, string version, CancellationToken cancellationToken = default)
     {
-        bool isTrusted = _trustStore.Contains((ecosystem, id, version));
+        bool isTrusted = _trustStore.ContainsKey((ecosystem, id, version));
         return Task.FromResult(isTrusted);
     }
 
     public Task TrustAsync(DependencyEcosystem ecosystem, string id, string version, CancellationToken cancellationToken = default)
     {
-        _trustStore.Add((ecosystem, id, version));
+        _trustStore[(ecosystem, id, version)] = true;
         return Task.CompletedTask;
     }
 

--- a/tests/Costellobot.Tests/Infrastructure/InMemoryTrustStore.cs
+++ b/tests/Costellobot.Tests/Infrastructure/InMemoryTrustStore.cs
@@ -12,6 +12,12 @@ internal sealed class InMemoryTrustStore : ITrustStore
 
     public int Count => _trustStore.Count;
 
+    public Task DistrustAllAsync(CancellationToken cancellationToken = default)
+    {
+        _trustStore.Clear();
+        return Task.CompletedTask;
+    }
+
     public Task DistrustAsync(DependencyEcosystem ecosystem, string id, string version, CancellationToken cancellationToken = default)
     {
         _trustStore.Remove((ecosystem, id, version), out _);
@@ -39,6 +45,4 @@ internal sealed class InMemoryTrustStore : ITrustStore
         _trustStore[(ecosystem, id, version)] = true;
         return Task.CompletedTask;
     }
-
-    public void Clear() => _trustStore.Clear();
 }

--- a/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
+++ b/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
@@ -223,7 +223,7 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
 
     protected TaskCompletionSource RegisterReview(PullRequestDriver driver)
     {
-        var pullRequestApproved = new TaskCompletionSource();
+        var pullRequestApproved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
         RegisterReview(
             driver,

--- a/tests/Costellobot.Tests/Pages/AppPage.cs
+++ b/tests/Costellobot.Tests/Pages/AppPage.cs
@@ -42,6 +42,19 @@ public abstract class AppPage(IPage page)
         protected IElementHandle Handle { get; } = handle;
 
         protected IPage Page { get; } = page;
+
+        protected async Task<IElementHandle> SelectAsync(string selector)
+        {
+            var element = await Handle.QuerySelectorAsync(selector);
+            element.ShouldNotBeNull();
+            return element;
+        }
+
+        protected async Task<string> StringAsync(string selector)
+        {
+            var element = await SelectAsync(selector);
+            return await element.InnerTextAsync();
+        }
     }
 
     private sealed class Selectors

--- a/tests/Costellobot.Tests/Pages/DeliveriesPage.cs
+++ b/tests/Costellobot.Tests/Pages/DeliveriesPage.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Martin Costello, 2022. All rights reserved.
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using Microsoft.Playwright;
@@ -64,19 +64,6 @@ public sealed class DeliveriesPage(IPage page) : AppPage(page)
             await page.WaitForContentAsync();
 
             return page;
-        }
-
-        private async Task<IElementHandle> SelectAsync(string selector)
-        {
-            var element = await Handle.QuerySelectorAsync(selector);
-            element.ShouldNotBeNull();
-            return element;
-        }
-
-        private async Task<string> StringAsync(string selector)
-        {
-            var element = await SelectAsync(selector);
-            return await element.InnerTextAsync();
         }
     }
 


### PR DESCRIPTION
Cherry-pick changes from #2022:

- Avoid `OperationCanceledException` when reading the channel queue is cancelled so it stops gracefully.
- Guard against any concurrency issues with the in-memory trust store.
- Add test ID to dependencies link.
- Always set `TaskCreationOptions.RunContinuationsAsynchronously` on `TaskCompletionSource` ([reference](https://devblogs.microsoft.com/premier-developer/the-danger-of-taskcompletionsourcet-class/)).
- Move the page helpers from specific class down to `Item` for re-use.
- Add a method to the trust store to remove all entries.
- Add basic unit tests for `AzureTableTrustStore` for coverage.
- Refactor `GetMergeMethod()` to reduce duplication.
- Always log the application's own log messages at debug in the tests.
- Move PR approval interceptions for re-use.
- Add builders for GitHub app installation and repos.
- Copy state between issue and PR builders.
- Support repositories being archived.
- Fix GraphQL interceptions not validating that the query is for the specific request.

Contributes to #2021.