### PR TITLE
Remove GitHub app rate limits

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   lighthouse:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
 

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ PublishProfiles
 *.sln.ide
 *.suo
 *.user
+!.packages/*.nupkg

--- a/src/Costellobot/AdminEndpoints.cs
+++ b/src/Costellobot/AdminEndpoints.cs
@@ -104,17 +104,15 @@ public static class AdminEndpoints
             .MapGet(
                 "/configuration",
                 async (
-                    IGitHubClientForApp appClient,
                     IGitHubClientForInstallation installationClient,
                     IGitHubClientForUser userClient,
                     IOptions<GitHubOptions> github,
                     IOptions<WebhookOptions> webhook) =>
                 {
-                    var appLimits = await GetRateLimitsAsync(appClient);
                     var installationLimits = await GetRateLimitsAsync(installationClient);
                     var userLimits = await GetRateLimitsAsync(userClient);
 
-                    var model = new ConfigurationModel(github.Value, webhook.Value, appLimits, installationLimits, userLimits);
+                    var model = new ConfigurationModel(github.Value, webhook.Value, installationLimits, userLimits);
                     return Results.Extensions.RazorSlice<Configuration, ConfigurationModel>(model);
 
                     static async Task<MiscellaneousRateLimit?> GetRateLimitsAsync(IGitHubClient client)

--- a/src/Costellobot/Models/ConfigurationModel.cs
+++ b/src/Costellobot/Models/ConfigurationModel.cs
@@ -10,6 +10,5 @@ namespace MartinCostello.Costellobot.Models;
 public sealed record ConfigurationModel(
     GitHubOptions GitHub,
     WebhookOptions Webhook,
-    MiscellaneousRateLimit? AppRateLimits,
     MiscellaneousRateLimit? InstallationRateLimits,
     MiscellaneousRateLimit? UserRateLimits);

--- a/src/Costellobot/Slices/Configuration.cshtml
+++ b/src/Costellobot/Slices/Configuration.cshtml
@@ -279,17 +279,13 @@
                 </div>
                 <div class="card-body">
                     <p class="card-text font-weight-light">
-                        The GitHub app, installation and user rate limits.
+                        The GitHub installation and user rate limits.
                     </p>
                     <hr />
                     <div class="align-items-start d-flex">
                         <div class="flex-column me-3 nav nav-fill nav-pills" role="tablist" aria-orientation="vertical">
-                            <button class="nav-link text-start active" id="settings-tab-rate-limits-app" role="tab" type="button" aria-controls="tab-rate-limits-app" aria-selected="true" data-bs-target="#tab-rate-limits-app" data-bs-toggle="pill">
-                                <span class="fa-solid fa-robot" aria-hidden="true"></span>
-                                App
-                            </button>
                             <button class="nav-link text-start" id="settings-tab-rate-limits-installation" role="tab" type="button" aria-controls="tab-rate-limits-installation" aria-selected="true" data-bs-target="#tab-rate-limits-installation" data-bs-toggle="pill">
-                                <span class="fa-solid fa-gear" aria-hidden="true"></span>
+                                <span class="fa-solid fa-robot" aria-hidden="true"></span>
                                 Installation
                             </button>
                             <button class="nav-link text-start" id="settings-tab-rate-limits-user" role="tab" type="button" aria-controls="tab-rate-limits-user" aria-selected="true" data-bs-target="#tab-rate-limits-user" data-bs-toggle="pill">
@@ -298,17 +294,7 @@
                             </button>
                         </div>
                         <div class="tab-content w-75" id="tab-content-rate-limits">
-                            <div class="tab-pane fade show active" id="tab-rate-limits-app" role="tabpanel" aria-labelledby="settings-tab-rate-limits-app">
-                                <div class="card my-2">
-                                    <div class="card-header card-title">
-                                        GitHub App
-                                    </div>
-                                    <div class="card-body">
-                                        @(RateLimitTable("App", Model.AppRateLimits))
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="tab-pane fade" id="tab-rate-limits-installation" role="tabpanel" aria-labelledby="settings-tab-rate-limits-installation">
+                            <div class="tab-pane fade show active" id="tab-rate-limits-installation" role="tabpanel" aria-labelledby="settings-tab-rate-limits-installation">
                                 <div class="card my-2">
                                     <div class="card-header card-title">
                                         GitHub Installation

--- a/tests/Costellobot.Tests/Handlers/HandlerFactoryTests.cs
+++ b/tests/Costellobot.Tests/Handlers/HandlerFactoryTests.cs
@@ -29,8 +29,7 @@ public static class HandlerFactoryTests
     public static void Create_Creates_Correct_Handler_Type(string? eventType, Type expected)
     {
         // Arrange
-        var gitHubOptions = new GitHubOptions().ToMonitor();
-        var webhookOptions = new WebhookOptions().ToMonitor();
+        var options = new WebhookOptions().ToMonitor();
 
         var gitHubAppClient = Substitute.For<IGitHubClientForApp>();
         var gitHubInstallationClient = Substitute.For<IGitHubClientForInstallation>();
@@ -43,19 +42,19 @@ public static class HandlerFactoryTests
             gitHubInstallationClient,
             [],
             trustStore,
-            webhookOptions,
+            options,
             NullLoggerFactory.Instance.CreateLogger<GitCommitAnalyzer>());
 
         var pullRequestAnalyzer = new PullRequestAnalyzer(
             gitHubInstallationClient,
             commitAnalyzer,
-            webhookOptions,
+            options,
             NullLoggerFactory.Instance.CreateLogger<PullRequestAnalyzer>());
 
         var pullRequestApprover = new PullRequestApprover(
             gitHubInstallationClient,
             Substitute.For<Octokit.GraphQL.IConnection>(),
-            webhookOptions,
+            options,
             NullLoggerFactory.Instance.CreateLogger<PullRequestApprover>());
 
         var publicHolidayProvider = new PublicHolidayProvider(
@@ -69,7 +68,7 @@ public static class HandlerFactoryTests
             {
                 return new CheckSuiteHandler(
                     gitHubInstallationClient,
-                    webhookOptions,
+                    options,
                     NullLoggerFactory.Instance.CreateLogger<CheckSuiteHandler>());
             });
 
@@ -79,7 +78,7 @@ public static class HandlerFactoryTests
                 return new DeploymentProtectionRuleHandler(
                     gitHubInstallationClient,
                     publicHolidayProvider,
-                    webhookOptions,
+                    options,
                     NullLoggerFactory.Instance.CreateLogger<DeploymentProtectionRuleHandler>());
             });
 
@@ -91,7 +90,7 @@ public static class HandlerFactoryTests
                     gitHubUserClient,
                     commitAnalyzer,
                     publicHolidayProvider,
-                    webhookOptions,
+                    options,
                     NullLoggerFactory.Instance.CreateLogger<DeploymentStatusHandler>());
             });
 
@@ -109,7 +108,7 @@ public static class HandlerFactoryTests
                 return new PullRequestHandler(
                     pullRequestAnalyzer,
                     pullRequestApprover,
-                    webhookOptions,
+                    options,
                     NullLoggerFactory.Instance.CreateLogger<PullRequestHandler>());
             });
 
@@ -123,7 +122,7 @@ public static class HandlerFactoryTests
                     pullRequestApprover,
                     cache,
                     trustStore,
-                    webhookOptions,
+                    options,
                     NullLoggerFactory.Instance.CreateLogger<PullRequestReviewHandler>());
             });
 


### PR DESCRIPTION
- Turns out the GitHub API endpoint for rate limits won't work for GitHub App authentication at all.
- Remove unused variable to resolve https://github.com/martincostello/costellobot/security/code-scanning/224.
- Do not ignore `.nupkg` files in the `.packages` folder.
