### PR TITLE
More specific HTTP interception

### DIFF
--- a/tests/Costellobot.Tests/Handlers/DeploymentProtectionRuleHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/DeploymentProtectionRuleHandlerTests.cs
@@ -124,6 +124,7 @@ public sealed class DeploymentProtectionRuleHandlerTests : IntegrationTests<AppF
             .Requests()
             .ForPost()
             .ForPath($"/repos/{driver.Repository.FullName}/actions/runs/{driver.RunId}/deployment_protection_rule")
+            .ForRequestHeader("Accept", "application/vnd.github+json")
             .Responds()
             .WithStatus(HttpStatusCode.NoContent);
 

--- a/tests/Costellobot.Tests/Handlers/IssueCommentHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/IssueCommentHandlerTests.cs
@@ -104,6 +104,7 @@ public class IssueCommentHandlerTests(AppFixture fixture, ITestOutputHelper outp
             .Requests()
             .ForPost()
             .ForPath("/repos/martincostello/github-automation/dispatches")
+            .ForRequestHeader("Accept", "application/vnd.github+json")
             .ForContent(async (request) =>
             {
                 request.ShouldNotBeNull();

--- a/tests/Costellobot.Tests/Handlers/PushHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PushHandlerTests.cs
@@ -137,6 +137,7 @@ public class PushHandlerTests(AppFixture fixture, ITestOutputHelper outputHelper
             .Requests()
             .ForPost()
             .ForPath($"/repos/martincostello/github-automation/dispatches")
+            .ForRequestHeader("Accept", "application/vnd.github+json")
             .ForContent(async (request) =>
             {
                 request.ShouldNotBeNull();

--- a/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
+++ b/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
@@ -82,6 +82,7 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
             .ForHttps()
             .ForHost("api.github.com")
             .ForGet()
+            .ForRequestHeader("Accept", "application/vnd.github.v3+json")
             .Responds()
             .WithStatus(StatusCodes.Status200OK);
 
@@ -225,6 +226,7 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
             .Requests()
             .ForPath($"/repos/{repository.FullName}/contents/.github/dependabot.yml")
             .ForQuery($"ref={reference}")
+            .ForRequestHeader("Accept", "application/vnd.github.v3.raw")
             .Responds()
             .WithContent(configuration)
             .WithContentHeader("Content-Type", "application/vnd.github.v3.raw")
@@ -257,7 +259,6 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
         CreateDefaultBuilder()
             .Requests()
             .ForPath($"/repos/{builder.Repository.FullName}/pulls/{builder.Number}")
-            .ForRequestHeader("Accept", "application/vnd.github.v3+json")
             .Responds()
             .WithJsonContent(builder)
             .RegisterWith(Fixture.Interceptor);
@@ -369,6 +370,7 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
             .Requests()
             .ForPost()
             .ForPath("graphql")
+            .ForRequestHeader("Accept", "application/vnd.github.antiope-preview+json")
             .ForContent(async (request) =>
             {
                 request.ShouldNotBeNull();

--- a/tests/Costellobot.Tests/WebhookTests.cs
+++ b/tests/Costellobot.Tests/WebhookTests.cs
@@ -184,6 +184,7 @@ public class WebhookTests(HttpServerFixture fixture, ITestOutputHelper outputHel
             .Requests()
             .ForPath("/app/hook/deliveries")
             .ForQuery($"per_page=100{(cursor is null ? string.Empty : $"&cursor={cursor}")}")
+            .ForRequestHeader("Accept", "application/vnd.github+json")
             .Responds()
             .WithJsonContent(deliveries.Build());
 
@@ -200,6 +201,7 @@ public class WebhookTests(HttpServerFixture fixture, ITestOutputHelper outputHel
         CreateDefaultBuilder()
             .Requests()
             .ForPath($"/app/hook/deliveries/{payload.Id}")
+            .ForRequestHeader("Accept", "application/vnd.github.v3.raw")
             .Responds()
             .WithJsonContent(payload)
             .RegisterWith(Fixture.Interceptor);


### PR DESCRIPTION
Make HTTP interceptions for the GitHub API always specify the `Accept` header that is expected.
