### PR TITLE
Fix deployments not being approved

### DIFF
--- a/src/Costellobot/Handlers/DeploymentStatusHandler.cs
+++ b/src/Costellobot/Handlers/DeploymentStatusHandler.cs
@@ -183,7 +183,11 @@ public sealed partial class DeploymentStatusHandler(
             new Uri($"repos/{repository.FullName}/deployments", UriKind.Relative),
             parameters);
 
+        // Because the list is sorted by time descending, we need to skip over any
+        // deployments before the current deployment in the list to find the correct
+        // previous deployment to compare against the deployment for this delivery.
         var previousDeployments = deployments
+            .SkipWhile((p) => p.Id != deploymentId)
             .Where((p) => p.Id != deploymentId)
             .ToList();
 

--- a/tests/Costellobot.Tests/Drivers/DeploymentStatusDriver.cs
+++ b/tests/Costellobot.Tests/Drivers/DeploymentStatusDriver.cs
@@ -32,9 +32,13 @@ public sealed class DeploymentStatusDriver
 
     public IList<DeploymentBuilder> InactiveDeployments { get; } = [];
 
+    public DeploymentBuilder? NextDeployment { get; set; }
+
     public DeploymentBuilder? PendingDeployment { get; set; }
 
     public DeploymentBuilder? SkippedDeployment { get; set; }
+
+    public DeploymentStatusBuilder? NextDeploymentStatus { get; set; }
 
     public DeploymentStatusBuilder? PendingDeploymentStatus { get; set; }
 
@@ -59,6 +63,18 @@ public sealed class DeploymentStatusDriver
         var deployment = CreateDeployment(environmentName ?? PendingDeployment!.Environment, commit?.Sha);
 
         InactiveDeployments.Add(deployment);
+
+        return this;
+    }
+
+    [MemberNotNull(nameof(NextDeployment))]
+    [MemberNotNull(nameof(NextDeploymentStatus))]
+    public DeploymentStatusDriver WithNextDeployment(
+        Func<GitHubCommitBuilder, DeploymentBuilder>? deploymentFactory = null,
+        Func<DeploymentStatusBuilder>? statusFactory = null)
+    {
+        NextDeployment = deploymentFactory?.Invoke(HeadCommit) ?? CreateDeployment();
+        NextDeploymentStatus = statusFactory?.Invoke() ?? CreateDeploymentStatus();
 
         return this;
     }


### PR DESCRIPTION
Fix deployments not being approved in the case where there is a deployment in the array before the current deployment. Otherwise we would find the wrong deployment as being the previous one.
