### PR TITLE
Add more logging

### DIFF
--- a/src/Costellobot/appsettings.Development.json
+++ b/src/Costellobot/appsettings.Development.json
@@ -3,7 +3,6 @@
     "LogLevel": {
       "Default": "Information",
       "Azure": "Information",
-      "MartinCostello.Costellobot.GitHubWebhookDispatcher": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
   }

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -47,7 +47,6 @@
     "LogLevel": {
       "Default": "Information",
       "Azure": "Warning",
-      "MartinCostello.Costellobot.GitHubWebhookDispatcher": "Warning",
       "Microsoft": "Warning",
       "Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager": "Error",
       "Microsoft.AspNetCore.DataProtection.Repositories.EphemeralXmlRepository": "Error",

--- a/tests/Costellobot.Tests/Infrastructure/AppFixture.cs
+++ b/tests/Costellobot.Tests/Infrastructure/AppFixture.cs
@@ -128,7 +128,6 @@ public class AppFixture : WebApplicationFactory<Program>, ITestOutputHelperAcces
                 KeyValuePair.Create<string, string?>("GitHub:PrivateKey", testKey),
                 KeyValuePair.Create<string, string?>("GitHub:WebhookSecret", "github-webhook-secret"),
                 KeyValuePair.Create<string, string?>("HostOptions:ShutdownTimeout", "00:00:01"),
-                KeyValuePair.Create<string, string?>("Logging:LogLevel:MartinCostello.Costellobot.GitHubWebhookDispatcher", "Information"),
                 KeyValuePair.Create<string, string?>("Site:AdminUsers:0", "john-smith"),
                 KeyValuePair.Create<string, string?>("Webhook:DeployEnvironments:0", "production"),
                 KeyValuePair.Create<string, string?>("Webhook:IgnoreRepositories:0", "ignored-org/ignored-repo"),


### PR DESCRIPTION
Reverts #2046 to increase the logging verbosity again now that the logging back-end has been changed to Grafana Cloud from Azure App Insights, as it should be cheaper (i.e. free).
