### PR TITLE
Customise Lighthouse

### DIFF
--- a/.github/lighthouse.config.json
+++ b/.github/lighthouse.config.json
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "settings": {
+      "skipAudits": [
+        "render-blocking-resources",
+        "unused-css-rules",
+        "unused-javascript",
+        "uses-long-cache-ttl",
+        "uses-text-compression"
+      ]
+    }
+  }
+}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -74,8 +74,9 @@ jobs:
         device: 'all'
         gitHubAccessToken: ${{ secrets.LIGHTHOUSE_ACCESS_TOKEN }}
         outputDirectory: ${{ github.workspace }}/artifacts/lighthouse
+        overridesJsonFile: ./.github/lighthouse.config.json
         prCommentEnabled: true
-        urls: ${{ env.APPLICATION_URL }}
+        urls: '${{ env.APPLICATION_URL }}/sign-in'
         wait: true
 
     - name: Check Lighthouse scores

--- a/src/Costellobot/Slices/_Layout.cshtml
+++ b/src/Costellobot/Slices/_Layout.cshtml
@@ -8,13 +8,12 @@
     string title = $"{Model.Title} - {name}";
     string twitter = "@martin_costello";
 
-    string imageUrl = string.Empty;
+    string imageUrl = "https://cdn.martincostello.com/favicon-costellobot.png";
     string siteUrl = string.Empty;
 
     if (!string.IsNullOrEmpty(domain))
     {
         siteUrl = $"https://{domain}/";
-        imageUrl = $"https://{domain}/favicon.png";
     }
 
     string environment = HttpContext.RequestServices.GetRequiredService<IHostEnvironment>().EnvironmentName;
@@ -82,7 +81,7 @@
     <meta name="twitter:label1" content="Created by" />
     <meta name="twitter:data1" content="@(author)" />
     <link rel="manifest" href="@(this.Content("~/manifest.webmanifest"))" />
-    <link rel="shortcut icon" type="image/x-icon" href="@(this.Content("~/favicon.png"))" />
+    <link rel="shortcut icon" type="image/x-icon" href="@(imageUrl)" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/css/bootstrap.min.css" integrity="sha512-jnSuA4Ss2PkkikSOLtYs8BlYIeeIK1h99ty4YfvRPAlzr377vr3CXDb7sb7eEEBYjDtcYj+AjBH3FLv5uSJuXg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="@(this.Content("~/static/css/main.css"))" />
@@ -98,7 +97,7 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container">
             <a class="navbar-brand" href="/" id="admin-link">
-                <img src="@(this.Content("~/favicon.png"))" width="30" height="30" class="d-inline-block align-top" alt="costellobot" aria-hidden="true">
+                <img src="https://cdn.martincostello.com/favicon-costellobot.png" width="30" height="30" class="d-inline-block align-top" alt="costellobot" aria-hidden="true">
                 costellobot
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#site-navbar" aria-controls="site-navbar" aria-expanded="false" aria-label="Toggle navigation">
@@ -206,7 +205,7 @@
     </main>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.bundle.min.js" integrity="sha512-7Pi/otdlbbCR+LnW+F7PwFcSDJOuUJB3OxtEHbg4vSMvzvJjde4Po1v4BR9Gdc9aXNUNFVUY+SK51wWT8WF0Gg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     @await RenderSectionAsync("scripts")
-    <script src="@(this.Content("~/static/js/main.js"))"></script>
+    <script src="@(this.Content("~/static/js/main.js"))" defer></script>
 </body>
 <!--
     Deployment:    @(build)

--- a/src/Costellobot/wwwroot/bad-request.html
+++ b/src/Costellobot/wwwroot/bad-request.html
@@ -15,7 +15,7 @@
     <meta name="robots" content="NOINDEX" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
+    <link rel="shortcut icon" type="image/x-icon" href="https://cdn.martincostello.com/favicon-costellobot.png" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/css/bootstrap.min.css" integrity="sha512-jnSuA4Ss2PkkikSOLtYs8BlYIeeIK1h99ty4YfvRPAlzr377vr3CXDb7sb7eEEBYjDtcYj+AjBH3FLv5uSJuXg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="/static/css/main.css" />
@@ -24,7 +24,7 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container">
             <a class="navbar-brand" href="/">
-                <img src="/favicon.png" width="30" height="30" class="d-inline-block align-top" alt="costellobot" aria-hidden="true">
+                <img src="https://cdn.martincostello.com/favicon-costellobot.png" width="30" height="30" class="d-inline-block align-top" alt="costellobot" aria-hidden="true">
                 costellobot
             </a>
         </div>

--- a/src/Costellobot/wwwroot/error.html
+++ b/src/Costellobot/wwwroot/error.html
@@ -15,7 +15,7 @@
     <meta name="robots" content="NOINDEX" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
+    <link rel="shortcut icon" type="image/x-icon" href="https://cdn.martincostello.com/favicon-costellobot.png" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/css/bootstrap.min.css" integrity="sha512-jnSuA4Ss2PkkikSOLtYs8BlYIeeIK1h99ty4YfvRPAlzr377vr3CXDb7sb7eEEBYjDtcYj+AjBH3FLv5uSJuXg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="/static/css/main.css" />
@@ -24,7 +24,7 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container">
             <a class="navbar-brand" href="/">
-                <img src="/favicon.png" width="30" height="30" class="d-inline-block align-top" alt="costellobot" aria-hidden="true">
+                <img src="https://cdn.martincostello.com/favicon-costellobot.png" width="30" height="30" class="d-inline-block align-top" alt="costellobot" aria-hidden="true">
                 costellobot
             </a>
         </div>

--- a/src/Costellobot/wwwroot/forbidden.html
+++ b/src/Costellobot/wwwroot/forbidden.html
@@ -15,7 +15,7 @@
     <meta name="robots" content="NOINDEX" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
+    <link rel="shortcut icon" type="image/x-icon" href="https://cdn.martincostello.com/favicon-costellobot.png" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/css/bootstrap.min.css" integrity="sha512-jnSuA4Ss2PkkikSOLtYs8BlYIeeIK1h99ty4YfvRPAlzr377vr3CXDb7sb7eEEBYjDtcYj+AjBH3FLv5uSJuXg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="/static/css/main.css" />
@@ -24,7 +24,7 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container">
             <a class="navbar-brand" href="/">
-                <img src="/favicon.png" width="30" height="30" class="d-inline-block align-top" alt="costellobot" aria-hidden="true">
+                <img src="https://cdn.martincostello.com/favicon-costellobot.png" width="30" height="30" class="d-inline-block align-top" alt="costellobot" aria-hidden="true">
                 costellobot
             </a>
         </div>

--- a/src/Costellobot/wwwroot/manifest.webmanifest
+++ b/src/Costellobot/wwwroot/manifest.webmanifest
@@ -11,7 +11,7 @@
     "dir": "ltr",
     "icons": [
         {
-            "src": "./favicon.png",
+            "src": "https://cdn.martincostello.com/favicon-costellobot.png",
             "sizes": "64x64",
             "type": "image/png",
             "purpose": "any"

--- a/src/Costellobot/wwwroot/not-found.html
+++ b/src/Costellobot/wwwroot/not-found.html
@@ -15,7 +15,7 @@
     <meta name="robots" content="NOINDEX" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
+    <link rel="shortcut icon" type="image/x-icon" href="https://cdn.martincostello.com/favicon-costellobot.png" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/css/bootstrap.min.css" integrity="sha512-jnSuA4Ss2PkkikSOLtYs8BlYIeeIK1h99ty4YfvRPAlzr377vr3CXDb7sb7eEEBYjDtcYj+AjBH3FLv5uSJuXg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="/static/css/main.css" />
@@ -24,7 +24,7 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container">
             <a class="navbar-brand" href="/">
-                <img src="/favicon.png" width="30" height="30" class="d-inline-block align-top" alt="costellobot" aria-hidden="true">
+                <img src="https://cdn.martincostello.com/favicon-costellobot.png" width="30" height="30" class="d-inline-block align-top" alt="costellobot" aria-hidden="true">
                 costellobot
             </a>
         </div>

--- a/src/Costellobot/wwwroot/unauthorized.html
+++ b/src/Costellobot/wwwroot/unauthorized.html
@@ -15,7 +15,7 @@
     <meta name="robots" content="NOINDEX" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
+    <link rel="shortcut icon" type="image/x-icon" href="https://cdn.martincostello.com/favicon-costellobot.png" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/css/bootstrap.min.css" integrity="sha512-jnSuA4Ss2PkkikSOLtYs8BlYIeeIK1h99ty4YfvRPAlzr377vr3CXDb7sb7eEEBYjDtcYj+AjBH3FLv5uSJuXg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="/static/css/main.css" />
@@ -24,7 +24,7 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container">
             <a class="navbar-brand" href="/">
-                <img src="/favicon.png" width="30" height="30" class="d-inline-block align-top" alt="costellobot" aria-hidden="true">
+                <img src="https://cdn.martincostello.com/favicon-costellobot.png" width="30" height="30" class="d-inline-block align-top" alt="costellobot" aria-hidden="true">
                 costellobot
             </a>
         </div>


### PR DESCRIPTION
- Disable audits for third-party assessments.
- Audit the sign-in page to save a redirect.
- Defer JavaScript loading.
- Use favicon from CDN.
