### PR TITLE
Move .NET to D drive on Windows runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,6 @@ jobs:
     timeout-minutes: 20
 
     env:
-      NUGET_PACKAGES: '~/.nuget/packages'
       PUBLISH_CONTAINER: ${{ github.event.repository.fork == false && github.ref_name == github.event.repository.default_branch && matrix.os-name == 'linux' }}
 
     outputs:
@@ -60,13 +59,18 @@ jobs:
 
     steps:
 
-    - name: Update Windows agent configuration
+    - name: Update agent configuration
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        "DOTNET_INSTALL_DIR=D:\tools\dotnet" >> ${env:GITHUB_ENV}
-        "DOTNET_ROOT=D:\tools\dotnet" >> ${env:GITHUB_ENV}
-        "NUGET_PACKAGES=D:\.nuget\packages" >> ${env:GITHUB_ENV}
+        if ($IsWindows) {
+          "DOTNET_INSTALL_DIR=D:\tools\dotnet" >> ${env:GITHUB_ENV}
+          "DOTNET_ROOT=D:\tools\dotnet" >> ${env:GITHUB_ENV}
+          "NUGET_PACKAGES=D:\.nuget\packages" >> ${env:GITHUB_ENV}
+        } else {
+          $nugetHome = Resolve-Path "~/.nuget/packages"
+          "NUGET_PACKAGES=$nugetHome" >> ${env:GITHUB_ENV}
+        }
 
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,14 @@ jobs:
 
     steps:
 
+    - name: Update Windows agent configuration
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        "DOTNET_INSTALL_DIR=D:\tools\dotnet" >> ${env:GITHUB_ENV}
+        "DOTNET_ROOT=D:\tools\dotnet" >> ${env:GITHUB_ENV}
+        "NUGET_PACKAGES=D:\.nuget\packages" >> ${env:GITHUB_ENV}
+
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,11 @@ jobs:
           "DOTNET_ROOT=D:\tools\dotnet" >> ${env:GITHUB_ENV}
           "NUGET_PACKAGES=D:\.nuget\packages" >> ${env:GITHUB_ENV}
         } else {
-          $nugetHome = Resolve-Path "~/.nuget/packages"
+          $nugetHome = "~/.nuget/packages"
+          if (-Not (Test-Path $nugetHome)) {
+            New-Item -Path $nugetHome -Type Directory -Force | Out-Null
+          }
+          $nugetHome = Resolve-Path $nugetHome
           "NUGET_PACKAGES=$nugetHome" >> ${env:GITHUB_ENV}
         }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
     - name: Setup NuGet cache
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
-        path: ~/.nuget/packages
+        path: ${{ env.NUGET_PACKAGES || "~/.nuget/packages" }}
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props') }}
         restore-keys: ${{ runner.os }}-nuget-
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,7 @@ jobs:
     timeout-minutes: 20
 
     env:
+      NUGET_PACKAGES: '~/.nuget/packages'
       PUBLISH_CONTAINER: ${{ github.event.repository.fork == false && github.ref_name == github.event.repository.default_branch && matrix.os-name == 'linux' }}
 
     outputs:
@@ -98,7 +99,7 @@ jobs:
     - name: Setup NuGet cache
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
-        path: ${{ env.NUGET_PACKAGES || "~/.nuget/packages" }}
+        path: ${{ env.NUGET_PACKAGES }}
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props') }}
         restore-keys: ${{ runner.os }}-nuget-
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,6 @@ jobs:
     steps:
 
     - name: Update agent configuration
-      if: runner.os == 'Windows'
       shell: pwsh
       run: |
         if ($IsWindows) {


### PR DESCRIPTION
Speed up Windows builds by moving .NET from the C drive to the D drive.

See [_GitHub Actions Hosted Windows Runners, Slower-than-expected CI, and You_](https://chadgolden.com/blog/github-actions-hosted-windows-runners-slower-than-expected-ci-and-you).

Appears to save ~3.5 minutes.
