### PR TITLE
Update trust list

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -171,7 +171,11 @@
         "^Microsoft.NET.Sdk$",
         "^Microsoft.NET.Test.Sdk$",
         "^NodaTime$",
-        "^NodaTime.Testing$"
+        "^NodaTime.Testing$",
+        "^Polly$",
+        "^Polly\\..*$",
+        "^Swashbuckle.AspNetCore",
+        "^Swashbuckle.AspNetCore\\..*$"
       ],
       "Publishers": {
         "GitHubActions": [
@@ -200,7 +204,6 @@
           "dotnetframework",
           "EntityFramework",
           "GitHub",
-          "JUSTEAT_OSS",
           "martin_costello",
           "Microsoft",
           "NodaTime",


### PR DESCRIPTION
- Remove `JUSTEAT_OSS` as a trusted publisher.
- Add `Polly.*` NuGet packages.
- Add `Swashbuckle.AspNetCore*` NuGet packages.
