### PR TITLE
Simplify test analytics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,6 @@ jobs:
       uses: codecov/test-results-action@f2dba722c67b86c6caa034178c6e4d35335f6706 # v1.1.0
       if: ${{ !cancelled() }}
       with:
-        files: ./tests/Costellobot.EndToEndTests/TestResults/TestResults.xml,./tests/Costellobot.Tests/TestResults/TestResults.xml
         flags: ${{ matrix.os-name }}
         token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/build.ps1
+++ b/build.ps1
@@ -75,9 +75,7 @@ function DotNetTest {
         [string]$TestFilter
     )
 
-    $additionalArgs = @(
-        "--logger:junit"
-    )
+    $additionalArgs = @()
 
     if (-Not [string]::IsNullOrEmpty($TestFilter)) {
         $additionalArgs += "--filter"
@@ -86,6 +84,7 @@ function DotNetTest {
 
     if (-Not [string]::IsNullOrEmpty(${env:GITHUB_SHA})) {
         $additionalArgs += "--logger:GitHubActions;report-warnings=false"
+        $additionalArgs += "--logger:junit;LogFilePath=junit.xml"
     }
 
     & $dotnet test --configuration "Release" $additionalArgs


### PR DESCRIPTION
- Only enable JUnit output in CI.
- Change the default JUnit file name so codecov/test-results-action finds the files automatically.
