### PR TITLE
Handle missing installation ID

### DIFF
--- a/src/Costellobot/GitHubWebhookDispatcher.cs
+++ b/src/Costellobot/GitHubWebhookDispatcher.cs
@@ -71,6 +71,12 @@ public sealed partial class GitHubWebhookDispatcher(
             _ => message.Event.Installation?.Id,
         };
 
+        if (installationId is null &&
+            long.TryParse(message.Headers.HookInstallationTargetId, CultureInfo.InvariantCulture, out var installationTargetId))
+        {
+            installationId = installationTargetId;
+        }
+
         return
             installationId is { } id &&
             options.CurrentValue.Installations.TryGetValue(id.ToString(CultureInfo.InvariantCulture), out var install) &&


### PR DESCRIPTION
Fall back to the payload headers for the installation ID if it is not present in the body (e.g. for `ping`).
