### PR TITLE
Approve protection rules during holidays

### DIFF
--- a/src/Costellobot/Handlers/DeploymentProtectionRuleHandler.cs
+++ b/src/Costellobot/Handlers/DeploymentProtectionRuleHandler.cs
@@ -10,7 +10,6 @@ namespace MartinCostello.Costellobot.Handlers;
 
 public sealed partial class DeploymentProtectionRuleHandler(
     GitHubWebhookContext context,
-    PublicHolidayProvider publicHolidayProvider,
     ILogger<DeploymentProtectionRuleHandler> logger) : IHandler
 {
     private static readonly ResiliencePipeline Pipeline = CreateResiliencePipeline();
@@ -37,17 +36,6 @@ public sealed partial class DeploymentProtectionRuleHandler(
         if (!options.Deploy)
         {
             Log.DeploymentProtectionRuleApprovalIsDisabled(
-                logger,
-                repository,
-                body.Environment,
-                body.Deployment.Id);
-
-            return;
-        }
-
-        if (publicHolidayProvider.IsPublicHoliday())
-        {
-            Log.TodayIsAPublicHoliday(
                 logger,
                 repository,
                 body.Environment,
@@ -137,16 +125,6 @@ public sealed partial class DeploymentProtectionRuleHandler(
            Level = LogLevel.Information,
            Message = "Ignoring deployment protection rule check for {Repository} for environment {EnvironmentName} for deployment {DeploymentId} as deployment approval is disabled.")]
         public static partial void DeploymentProtectionRuleApprovalIsDisabled(
-            ILogger logger,
-            RepositoryId repository,
-            string? environmentName,
-            long deploymentId);
-
-        [LoggerMessage(
-           EventId = 5,
-           Level = LogLevel.Information,
-           Message = "Ignoring deployment protection rule check for {Repository} for environment {EnvironmentName} for deployment {DeploymentId} as it is a public holiday.")]
-        public static partial void TodayIsAPublicHoliday(
             ILogger logger,
             RepositoryId repository,
             string? environmentName,

--- a/tests/Costellobot.Tests/Handlers/DeploymentProtectionRuleHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/DeploymentProtectionRuleHandlerTests.cs
@@ -61,7 +61,7 @@ public sealed class DeploymentProtectionRuleHandlerTests : IntegrationTests<AppF
     }
 
     [Fact]
-    public async Task Deployment_Is_Not_Approved_On_Public_Holiday()
+    public async Task Deployment_Is_Approved_On_Public_Holiday()
     {
         // Arrange
         Fixture.ChangeClock(new(2023, 12, 25, 12, 00, 00, TimeSpan.Zero));
@@ -79,7 +79,7 @@ public sealed class DeploymentProtectionRuleHandlerTests : IntegrationTests<AppF
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
-        await AssertTaskNotRun(deploymentApproved);
+        await deploymentApproved.Task.WaitAsync(ResultTimeout, CancellationToken);
     }
 
     [Fact]

--- a/tests/Costellobot.Tests/Handlers/HandlerFactoryTests.cs
+++ b/tests/Costellobot.Tests/Handlers/HandlerFactoryTests.cs
@@ -78,7 +78,6 @@ public static class HandlerFactoryTests
             {
                 return new DeploymentProtectionRuleHandler(
                     context,
-                    publicHolidayProvider,
                     NullLoggerFactory.Instance.CreateLogger<DeploymentProtectionRuleHandler>());
             });
 


### PR DESCRIPTION
Approve protection rules on public holidays to reduce manual approvals from two to one.
