### PR TITLE
Use UseKestrel() with WebApplicationFactory<T>

### DIFF
--- a/tests/Costellobot.Tests/Infrastructure/HttpServerFixture.cs
+++ b/tests/Costellobot.Tests/Infrastructure/HttpServerFixture.cs
@@ -1,26 +1,28 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Net;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Hosting.Server;
-using Microsoft.AspNetCore.Hosting.Server.Features;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 
 namespace MartinCostello.Costellobot.Infrastructure;
 
 public sealed class HttpServerFixture : AppFixture
 {
-    private bool _disposed;
-    private IHost? _host;
+    public HttpServerFixture()
+    {
+        UseKestrel(
+            (server) => server.Listen(
+                IPAddress.Loopback, 0, (listener) => listener.UseHttps(
+                    (https) => https.ServerCertificate = LoadDevelopmentCertificate())));
+    }
 
     public string ServerAddress
     {
         get
         {
-            EnsureServer();
+            StartServer();
             return ServerUri.ToString();
         }
     }
@@ -29,17 +31,8 @@ public sealed class HttpServerFixture : AppFixture
     {
         get
         {
-            EnsureServer();
+            StartServer();
             return base.ServerUri;
-        }
-    }
-
-    public override IServiceProvider Services
-    {
-        get
-        {
-            EnsureServer();
-            return _host!.Services!;
         }
     }
 
@@ -57,51 +50,6 @@ public sealed class HttpServerFixture : AppFixture
         };
     }
 
-    protected override void ConfigureWebHost(IWebHostBuilder builder)
-    {
-        base.ConfigureWebHost(builder);
-
-        builder.ConfigureKestrel(
-            (serverOptions) => serverOptions.ConfigureHttpsDefaults(
-                (httpsOptions) => httpsOptions.ServerCertificate = LoadDevelopmentCertificate()));
-
-        builder.UseUrls("https://127.0.0.1:0");
-    }
-
-    protected override IHost CreateHost(IHostBuilder builder)
-    {
-        var testHost = builder.Build();
-
-        builder.ConfigureWebHost((webHostBuilder) => webHostBuilder.UseKestrel());
-
-        _host = builder.Build();
-        _host.Start();
-
-        var server = _host.Services.GetRequiredService<IServer>();
-        var addresses = server.Features.Get<IServerAddressesFeature>();
-
-        ClientOptions.BaseAddress = addresses!.Addresses
-            .Select((p) => new Uri(p))
-            .Last();
-
-        return testHost;
-    }
-
-    protected override void Dispose(bool disposing)
-    {
-        base.Dispose(disposing);
-
-        if (!_disposed)
-        {
-            if (disposing)
-            {
-                _host?.Dispose();
-            }
-
-            _disposed = true;
-        }
-    }
-
     private static X509Certificate2 LoadDevelopmentCertificate()
     {
         var metadata = typeof(HttpServerFixture).Assembly
@@ -112,15 +60,5 @@ public sealed class HttpServerFixture : AppFixture
         var password = metadata.First((p) => p.Key is "DevCertificatePassword").Value;
 
         return X509CertificateLoader.LoadPkcs12(File.ReadAllBytes(fileName), password);
-    }
-
-    private void EnsureServer()
-    {
-        if (_host is null)
-        {
-            using (CreateDefaultClient())
-            {
-            }
-        }
     }
 }


### PR DESCRIPTION
Use the new `UseKestrel()` method for `WebApplicationFactory<T>` to remove the customisation needed to host the application on an HTTP port.

Depends on https://github.com/dotnet/aspnetcore/pull/62231.
