### PR TITLE
Sort dependency versions numerically

### DIFF
--- a/src/Costellobot/Slices/Dependencies.cshtml
+++ b/src/Costellobot/Slices/Dependencies.cshtml
@@ -34,7 +34,7 @@
                 <tbody>
                     @foreach ((var ecosystem, var dependencies) in Model)
                     {
-                        foreach (var dependency in dependencies.OrderBy((p) => p.Id).ThenByDescending((p) => p.Version))
+                        foreach (var dependency in dependencies)
                         {
                             (var name, var url, var icon) = DependencyHelpers.GetPackageMetadata(ecosystem, dependency.Id, dependency.Version);
 


### PR DESCRIPTION
Sort `1.9.0` before `1.10.0`, for example.
