### PR TITLE
Trust PowerShellTeam

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -240,6 +240,7 @@
           "NodaTime",
           "OpenTelemetry",
           "Polly",
+          "PowerShellTeam",
           "xunit"
         ]
       },


### PR DESCRIPTION
Trust NuGet packages owned by `PowerShellTeam`.
