### PR TITLE
Cache calendar entries

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <GlobalPackageReference Include="MartinCostello.BuildKit" Version="0.6.5-beta.359" />
+    <GlobalPackageReference Include="MartinCostello.BuildKit" Version="0.6.5" />
     <GlobalPackageReference Include="ReferenceTrimmer" Version="3.3.11" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
   </ItemGroup>

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,13 +2,9 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="build-kit" value="https://f.feedz.io/martincostello/build-kit/nuget/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="build-kit">
-      <package pattern="MartinCostello.BuildKit" />
-    </packageSource>
     <packageSource key="NuGet">
       <package pattern="*" />
     </packageSource>

--- a/src/Costellobot/GitHubEventProcessor.cs
+++ b/src/Costellobot/GitHubEventProcessor.cs
@@ -59,7 +59,7 @@ public sealed partial class GitHubEventProcessor(
     {
         try
         {
-            // HACK Cannot serialize the parsed webhook objects as-is because DateTimeOffset does
+            // Cannot serialize the parsed webhook objects as-is because DateTimeOffset does
             // not support being serialized and throws an exception, which breaks the SignalR connection.
             // See https://github.com/octokit/webhooks.net/blob/1a6ce29f8312c555227703057ba45723e3c78574/src/Octokit.Webhooks/Converter/DateTimeOffsetConverter.cs#L14.
             using var document = JsonDocument.Parse(body);

--- a/src/Costellobot/GitHubMessageProcessor.cs
+++ b/src/Costellobot/GitHubMessageProcessor.cs
@@ -36,7 +36,7 @@ public sealed partial class GitHubMessageProcessor(
         IDictionary<string, StringValues> headers,
         string body)
     {
-        // HACK Cannot serialize the parsed webhook objects as-is because DateTimeOffset does not support being serialized and throws an exception.
+        // Cannot serialize the parsed webhook objects as-is because DateTimeOffset does not support being serialized and throws an exception.
         // See https://github.com/octokit/webhooks.net/blob/1a6ce29f8312c555227703057ba45723e3c78574/src/Octokit.Webhooks/Converter/DateTimeOffsetConverter.cs#L14.
         using var document = JsonDocument.Parse(body);
 

--- a/tests/Costellobot.Tests/UITests.cs
+++ b/tests/Costellobot.Tests/UITests.cs
@@ -22,7 +22,7 @@ public abstract class UITests(HttpServerFixture fixture, ITestOutputHelper outpu
             { BrowserType.Firefox, null },
         };
 
-        // HACK Skip on macOS. See https://github.com/microsoft/playwright-dotnet/issues/2920.
+        // Skip on macOS. See https://github.com/microsoft/playwright-dotnet/issues/2920.
         if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
         {
             browsers.Add(BrowserType.Chromium, "msedge");


### PR DESCRIPTION
- Cache entries from Google Calendar for 3 hours.
- Remove `HACK` from things there's nothing to change.
- Remove prerelease feed for BuildKit.
