### PR TITLE
Approve digest updates

### DIFF
--- a/src/Costellobot/GitDiffParser.cs
+++ b/src/Costellobot/GitDiffParser.cs
@@ -234,7 +234,6 @@ public static partial class GitDiffParser
             }
         }
 
-        // TODO
         return false;
     }
 

--- a/tests/Costellobot.Tests/GitDiffParserTests.Docker.OneFile.diff
+++ b/tests/Costellobot.Tests/GitDiffParserTests.Docker.OneFile.diff
@@ -1,0 +1,10 @@
+diff --git a/Dockerfile b/Dockerfile
+index 882d5ae..32ec3c5 100644
+--- a/Dockerfile
++++ b/Dockerfile
+@@ -1,4 +1,4 @@
+-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0.301@sha256:faa2daf2b72cbe787ee1882d9651fa4ef3e938ee56792b8324516f5a448f3abe AS build
++FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0.301@sha256:b768b444028d3c531de90a356836047e48658cd1e26ba07a539a6f1a052a35d9 AS build
+ ARG TARGETARCH
+ 
+ COPY . /source

--- a/tests/Costellobot.Tests/GitDiffParserTests.cs
+++ b/tests/Costellobot.Tests/GitDiffParserTests.cs
@@ -103,6 +103,22 @@ public static class GitDiffParserTests
     }
 
     [Fact]
+    public static void TryParseUpdatedPackages_Parses_Diff_Correctly_Docker_Image()
+    {
+        // Arrange
+        string diff = GetDiff("Docker.OneFile");
+
+        // Act
+        bool actual = GitDiffParser.TryParseUpdatedPackages(diff, out var packages);
+
+        // Assert
+        actual.ShouldBeTrue();
+        packages.ShouldNotBeNull();
+        packages.ShouldContainKeyAndValue("mcr.microsoft.com/dotnet/sdk", ("9.0.301-faa2daf2b72cbe787ee1882d9651fa4ef3e938ee56792b8324516f5a448f3abe", "9.0.301-b768b444028d3c531de90a356836047e48658cd1e26ba07a539a6f1a052a35d9"));
+        packages.Count.ShouldBe(1);
+    }
+
+    [Fact]
     public static void TryParseUpdatedPackages_Parses_Diff_Correctly_For_No_Package_Updates_Npm()
     {
         // Arrange

--- a/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
@@ -124,7 +124,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
     [Theory]
     [InlineData("dependencies")]
     [InlineData("merge-approved")]
-    public async Task Pull_Request_Is_Approved_And_Automerge_Is_Enabled_For_Trusted_User_With_Untusted_Dependency_When_Labelled_By_Collaborator(
+    public async Task Pull_Request_Is_Approved_And_Automerge_Is_Enabled_For_Trusted_User_With_Untrusted_Dependency_When_Labelled_By_Collaborator(
         string label)
     {
         // Arrange
@@ -161,7 +161,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
     [Theory]
     [InlineData("dependencies")]
     [InlineData("merge-approved")]
-    public async Task Pull_Request_Is_Approved_And_Merged_For_Trusted_User_With_Untusted_Dependency_When_Labelled_By_Collaborator(
+    public async Task Pull_Request_Is_Approved_And_Merged_For_Trusted_User_With_Untrusted_Dependency_When_Labelled_By_Collaborator(
         string label)
     {
         // Arrange
@@ -256,7 +256,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
     }
 
     [Fact]
-    public async Task Pull_Request_Is_Not_Approved_For_Trusted_User_But_Untusted_Dependency()
+    public async Task Pull_Request_Is_Not_Approved_For_Trusted_User_But_Untrusted_Dependency()
     {
         // Arrange
         Fixture.ApprovePullRequests();
@@ -414,7 +414,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
     }
 
     [Fact]
-    public async Task Pull_Request_Is_Not_Approved_For_Trusted_User_With_Untusted_Dependency_When_Not_Labelled_By_Collaborator()
+    public async Task Pull_Request_Is_Not_Approved_For_Trusted_User_With_Untrusted_Dependency_When_Not_Labelled_By_Collaborator()
     {
         // Arrange
         Fixture.ApprovePullRequests();
@@ -446,7 +446,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
     }
 
     [Fact]
-    public async Task Pull_Request_Is_Not_Approved_For_Trusted_User_With_Untusted_Dependency_When_Invalid_Label()
+    public async Task Pull_Request_Is_Not_Approved_For_Trusted_User_With_Untrusted_Dependency_When_Invalid_Label()
     {
         // Arrange
         Fixture.ApprovePullRequests();
@@ -480,7 +480,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
     [Theory]
     [InlineData("dependencies")]
     [InlineData("merge-approved")]
-    public async Task Pull_Request_Is_Not_Approved_For_Trusted_User_With_Untusted_Dependency_When_Required_Label_Missing(string label)
+    public async Task Pull_Request_Is_Not_Approved_For_Trusted_User_With_Untrusted_Dependency_When_Required_Label_Missing(string label)
     {
         // Arrange
         Fixture.ApprovePullRequests();


### PR DESCRIPTION
- Add support for extracting the version of an updated container image digest from Renovate using the Git diff (e.g. https://github.com/martincostello/eurovision-hue/pull/18).
- Fix spelling mistake in "untrusted".
