### PR TITLE
Restore peer.service

### DIFF
--- a/src/Costellobot/TelemetryExtensions.cs
+++ b/src/Costellobot/TelemetryExtensions.cs
@@ -58,6 +58,7 @@ public static class TelemetryExtensions
         services.AddOptions<HttpClientTraceInstrumentationOptions>()
                 .Configure<IServiceProvider>((options, provider) =>
                 {
+                    options.EnrichWithHttpRequestMessage = EnrichHttpActivity;
                     options.EnrichWithHttpResponseMessage = EnrichHttpActivity;
                     options.RecordException = true;
                 });
@@ -73,6 +74,17 @@ public static class TelemetryExtensions
                         }
                     };
                 });
+    }
+
+    private static void EnrichHttpActivity(Activity activity, HttpRequestMessage request)
+    {
+        if (GetTag("server.address", activity.Tags) is { Length: > 0 } hostName)
+        {
+            activity.AddTag("peer.service", hostName);
+        }
+
+        static string? GetTag(string name, IEnumerable<KeyValuePair<string, string?>> tags)
+            => tags.FirstOrDefault((p) => p.Key == name).Value;
     }
 
     private static void EnrichHttpActivity(Activity activity, HttpResponseMessage response)


### PR DESCRIPTION
Add `peer.service` back, but without custom names.
