### PR TITLE
Use ConfigureResource()

### DIFF
--- a/src/Costellobot/ApplicationTelemetry.cs
+++ b/src/Costellobot/ApplicationTelemetry.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry;
-using OpenTelemetry.Resources;
 using Pyroscope;
 
 namespace MartinCostello.Costellobot;
@@ -14,14 +13,6 @@ public static class ApplicationTelemetry
     public static readonly string ServiceNamespace = "Costellobot";
     public static readonly string ServiceVersion = GitMetadata.Version.Split('+')[0];
     public static readonly ActivitySource ActivitySource = new(ServiceName, ServiceVersion);
-
-    public static ResourceBuilder ResourceBuilder { get; } = ResourceBuilder.CreateDefault()
-        .AddService(ServiceName, ServiceNamespace, ServiceVersion)
-        .AddAzureAppServiceDetector()
-        .AddContainerDetector()
-        .AddHostDetector()
-        .AddOperatingSystemDetector()
-        .AddProcessRuntimeDetector();
 
     internal static bool IsOtlpCollectorConfigured()
         => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT"));

--- a/src/Costellobot/ILoggingBuilderExtensions.cs
+++ b/src/Costellobot/ILoggingBuilderExtensions.cs
@@ -20,8 +20,6 @@ public static class ILoggingBuilderExtensions
             options.IncludeFormattedMessage = true;
             options.IncludeScopes = true;
 
-            options.SetResourceBuilder(ApplicationTelemetry.ResourceBuilder);
-
             if (ApplicationTelemetry.IsOtlpCollectorConfigured())
             {
                 options.AddOtlpExporter();

--- a/src/Costellobot/TelemetryExtensions.cs
+++ b/src/Costellobot/TelemetryExtensions.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using OpenTelemetry.Instrumentation.AspNetCore;
 using OpenTelemetry.Instrumentation.Http;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 namespace MartinCostello.Costellobot;
@@ -17,10 +18,18 @@ public static class TelemetryExtensions
 
         services
             .AddOpenTelemetry()
+            .ConfigureResource((builder) =>
+            {
+                builder.AddService(ApplicationTelemetry.ServiceName, ApplicationTelemetry.ServiceNamespace, ApplicationTelemetry.ServiceVersion)
+                       .AddAzureAppServiceDetector()
+                       .AddContainerDetector()
+                       .AddHostDetector()
+                       .AddOperatingSystemDetector()
+                       .AddProcessRuntimeDetector();
+            })
             .WithMetrics((builder) =>
             {
-                builder.SetResourceBuilder(ApplicationTelemetry.ResourceBuilder)
-                       .AddAspNetCoreInstrumentation()
+                builder.AddAspNetCoreInstrumentation()
                        .AddHttpClientInstrumentation()
                        .AddProcessInstrumentation()
                        .AddMeter("System.Runtime");
@@ -32,8 +41,7 @@ public static class TelemetryExtensions
             })
             .WithTracing((builder) =>
             {
-                builder.SetResourceBuilder(ApplicationTelemetry.ResourceBuilder)
-                       .AddAspNetCoreInstrumentation()
+                builder.AddAspNetCoreInstrumentation()
                        .AddHttpClientInstrumentation()
                        .AddSource(ApplicationTelemetry.ServiceName)
                        .AddSource("Azure.*")


### PR DESCRIPTION
Use `ConfigureResource()` and configure once, rather than using `SetResourceBuilder()` with a static `ResourceBuilder`.
