### PR TITLE
Handle repository_dispatch

### DIFF
--- a/exclusion.dic
+++ b/exclusion.dic
@@ -10,6 +10,7 @@ dockerfile
 DotNet
 eslint
 GitHub
+Grafana
 monorepo
 Newtonsoft
 noreply

--- a/src/Costellobot/GitHubExtensions.cs
+++ b/src/Costellobot/GitHubExtensions.cs
@@ -64,6 +64,7 @@ public static class GitHubExtensions
         services.Configure<GitHubOptions>(configuration.GetSection("GitHub"));
         services.Configure<GitHubWebhookOptions>((p) => p.Secret = configuration["GitHub:WebhookSecret"]);
         services.Configure<GoogleOptions>(configuration.GetSection("Google"));
+        services.Configure<GrafanaOptions>(configuration.GetSection("Grafana"));
         services.Configure<SiteOptions>(configuration.GetSection("Site"));
         services.Configure<WebhookOptions>(configuration.GetSection("Webhook"));
 
@@ -170,6 +171,7 @@ public static class GitHubExtensions
         services.AddTransient<PullRequestHandler>();
         services.AddTransient<PullRequestReviewHandler>();
         services.AddTransient<PushHandler>();
+        services.AddTransient<RepositoryDispatchHandler>();
 
         services.AddHostedService<GitHubWebhookService>();
 

--- a/src/Costellobot/GrafanaOptions.cs
+++ b/src/Costellobot/GrafanaOptions.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Costellobot;
+
+public sealed class GrafanaOptions
+{
+    public string Token { get; set; } = string.Empty;
+
+    public string Url { get; set; } = string.Empty;
+}

--- a/src/Costellobot/Handlers/HandlerFactory.cs
+++ b/src/Costellobot/Handlers/HandlerFactory.cs
@@ -18,6 +18,7 @@ public sealed class HandlerFactory(IServiceProvider serviceProvider) : IHandlerF
             WebhookEventType.PullRequest => serviceProvider.GetRequiredService<PullRequestHandler>(),
             WebhookEventType.PullRequestReview => serviceProvider.GetRequiredService<PullRequestReviewHandler>(),
             WebhookEventType.Push => serviceProvider.GetRequiredService<PushHandler>(),
+            WebhookEventType.RepositoryDispatch => serviceProvider.GetRequiredService<RepositoryDispatchHandler>(),
             _ => NullHandler.Instance,
         };
     }

--- a/src/Costellobot/Handlers/RepositoryDispatchHandler.cs
+++ b/src/Costellobot/Handlers/RepositoryDispatchHandler.cs
@@ -1,0 +1,178 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Options;
+using Octokit.Webhooks;
+using Octokit.Webhooks.Events;
+
+namespace MartinCostello.Costellobot.Handlers;
+
+public sealed partial class RepositoryDispatchHandler(
+    HybridCache cache,
+    HttpClient client,
+    IOptionsMonitor<GrafanaOptions> options,
+    ILogger<RepositoryDispatchHandler> logger) : IHandler
+{
+    private static readonly HybridCacheEntryOptions CacheEntryOptions = new() { Expiration = TimeSpan.FromHours(1) };
+    private static readonly string[] CacheTags = ["all", "annotations"];
+
+    public async Task HandleAsync(WebhookEvent message)
+    {
+        if (message is not RepositoryDispatchEvent body || body.ClientPayload is not { } payload)
+        {
+            return;
+        }
+
+        var grafana = options.CurrentValue;
+
+        client.BaseAddress = new(grafana.Url, UriKind.Absolute);
+        client.DefaultRequestHeaders.Accept.Add(new("application/json"));
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", grafana.Token);
+
+        var context = GrafanaJsonSerializerContext.Default;
+
+        if (body.Action is "deployment_started")
+        {
+            string environment = payload.environment;
+            string repository = payload.repository;
+            string runAttempt = payload.runAttempt;
+            string runId = payload.runId;
+            string runNumber = payload.runNumber;
+            string serverUrl = payload.serverUrl;
+            string service = payload.service;
+            string sha = payload.sha;
+            long timestamp = payload.timestamp;
+
+            string commitSha = sha[0..7];
+            string commitUrl = $"{serverUrl}/{repository}/commit/{sha}";
+            string workflowUrl = $"{serverUrl}/{repository}/actions/runs/{runId}";
+
+            string text = $@"Deployed <a href=""${workflowUrl}"">#{runNumber}:{runAttempt}</a> with commit <a href=""${commitUrl}"">${commitSha}</a>";
+
+            var request = new CreateAnnotationRequest()
+            {
+                Tags =
+                [
+                    "deployment",
+                    $"environment:{environment}",
+                    $"service:{service}",
+                ],
+                Text = text,
+                Time = timestamp,
+            };
+
+            using var response = await client.PostAsJsonAsync("/api/annotations", request, context.CreateAnnotationRequest);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var annotation = await response.Content.ReadFromJsonAsync(context.CreateAnnotationResponse);
+
+                Log.CreatedAnnotation(logger, annotation!.Id);
+
+                await cache.SetAsync(
+                    CacheKey(repository, runNumber, runAttempt),
+                    annotation.Id,
+                    CacheEntryOptions,
+                    CacheTags);
+            }
+            else
+            {
+                Log.CreateAnnotationFailed(logger, response.StatusCode);
+            }
+        }
+        else if (body.Action is "deployment_completed")
+        {
+            string repository = payload.repository;
+            string runAttempt = payload.runAttempt;
+            string runNumber = payload.runNumber;
+            long timestamp = payload.timestamp;
+
+            var id = await cache.GetOrCreateAsync<long>(
+                CacheKey(repository, runNumber, runAttempt),
+                (_) => ValueTask.FromResult(-1L));
+
+            if (id is not -1)
+            {
+                using var response = await client.PatchAsJsonAsync(
+                    $"/api/annotations/{id}",
+                    new() { TimeEnd = timestamp },
+                    GrafanaJsonSerializerContext.Default.UpdateAnnotationRequest);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    Log.UpdatedAnnotation(logger, id);
+                }
+                else
+                {
+                    Log.UpdateAnnotationFailed(logger, id, response.StatusCode);
+                }
+            }
+        }
+
+        static string CacheKey(string repository, string runNumber, string runAttempt)
+            => $"annotation:{repository}:{runNumber}:{runAttempt}";
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    private static partial class Log
+    {
+        [LoggerMessage(
+            EventId = 1,
+            Level = LogLevel.Debug,
+            Message = "Created annotation {Id}.")]
+        public static partial void CreatedAnnotation(ILogger logger, long id);
+
+        [LoggerMessage(
+            EventId = 2,
+            Level = LogLevel.Warning,
+            Message = "Creating annotation failed with HTTP status code {StatusCode}.")]
+        public static partial void CreateAnnotationFailed(ILogger logger, HttpStatusCode statusCode);
+
+        [LoggerMessage(
+            EventId = 3,
+            Level = LogLevel.Debug,
+            Message = "Updated annotation {Id}.")]
+        public static partial void UpdatedAnnotation(ILogger logger, long id);
+
+        [LoggerMessage(
+            EventId = 4,
+            Level = LogLevel.Warning,
+            Message = "Updating annotation {Id} failed with HTTP status code {StatusCode}.")]
+        public static partial void UpdateAnnotationFailed(ILogger logger, long id, HttpStatusCode statusCode);
+    }
+
+    private sealed class CreateAnnotationRequest
+    {
+        [JsonPropertyName("tags")]
+        public required IList<string> Tags { get; init; }
+
+        [JsonPropertyName("text")]
+        public required string Text { get; init; }
+
+        [JsonPropertyName("time")]
+        public required long Time { get; init; }
+    }
+
+    private sealed class CreateAnnotationResponse
+    {
+        [JsonPropertyName("id")]
+        public long Id { get; set; }
+    }
+
+    private sealed class UpdateAnnotationRequest
+    {
+        [JsonPropertyName("timeEnd")]
+        public required long TimeEnd { get; init; }
+    }
+
+    [ExcludeFromCodeCoverage]
+    [JsonSerializable(typeof(CreateAnnotationRequest))]
+    [JsonSerializable(typeof(CreateAnnotationResponse))]
+    [JsonSerializable(typeof(UpdateAnnotationRequest))]
+    private sealed partial class GrafanaJsonSerializerContext : JsonSerializerContext;
+}

--- a/src/Costellobot/Slices/Debug.cshtml
+++ b/src/Costellobot/Slices/Debug.cshtml
@@ -37,6 +37,7 @@
                 (WebhookEventType.PullRequestReview, false),
                 (WebhookEventType.Push, false),
                 (WebhookEventType.Status, false),
+                (WebhookEventType.RepositoryDispatch, false),
             };
         }
         @foreach (var item in events)

--- a/src/Costellobot/WellKnownGitHubEvents.cs
+++ b/src/Costellobot/WellKnownGitHubEvents.cs
@@ -18,8 +18,8 @@ public static class WellKnownGitHubEvents
 {
     private static readonly HashSet<(string? Event, string? Action)> KnownEvents =
     [
-        (WebhookEventType.CheckSuite, CheckSuiteAction.Completed),
-        (WebhookEventType.DeploymentProtectionRule, DeploymentProtectionRuleAction.Requested),
+        (WebhookEventType.CheckSuite, CheckSuiteActionValue.Completed),
+        (WebhookEventType.DeploymentProtectionRule, DeploymentProtectionRuleActionValue.Requested),
         (WebhookEventType.DeploymentStatus, DeploymentStatusActionValue.Created),
         (WebhookEventType.IssueComment, IssueCommentActionValue.Created),
         (WebhookEventType.Ping, null),

--- a/src/Costellobot/WellKnownGitHubEvents.cs
+++ b/src/Costellobot/WellKnownGitHubEvents.cs
@@ -27,6 +27,8 @@ public static class WellKnownGitHubEvents
         (WebhookEventType.PullRequest, PullRequestActionValue.Labeled),
         (WebhookEventType.PullRequest, PullRequestActionValue.Opened),
         (WebhookEventType.PullRequestReview, PullRequestReviewActionValue.Submitted),
+        (WebhookEventType.RepositoryDispatch, "deployment_started"),
+        (WebhookEventType.RepositoryDispatch, "deployment_completed"),
     ];
 
     public static bool IsKnown(GitHubEvent message)

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -69,6 +69,10 @@
     "ProjectId": "",
     "Scopes": ["https://www.googleapis.com/auth/calendar.readonly"]
   },
+  "Grafana": {
+    "Token": "",
+    "Url": "https://logs.martincostello.com"
+  },
   "HostOptions": {
     "ShutdownTimeout": "00:00:10"
   },

--- a/tests/Costellobot.Tests/Infrastructure/AppFixture.cs
+++ b/tests/Costellobot.Tests/Infrastructure/AppFixture.cs
@@ -125,6 +125,8 @@ public class AppFixture : WebApplicationFactory<Program>, ITestOutputHelperAcces
                 KeyValuePair.Create<string, string?>("Google:PrivateKey", CreateSigningCertificate()),
                 KeyValuePair.Create<string, string?>("Google:PrivateKeyId", "github-app-client-id"),
                 KeyValuePair.Create<string, string?>("Google:ProjectId", "google-project-id"),
+                KeyValuePair.Create<string, string?>("Grafana:Token", "grafana-token"),
+                KeyValuePair.Create<string, string?>("Grafana:Url", "https://grafana.local"),
                 KeyValuePair.Create<string, string?>("HostOptions:ShutdownTimeout", "00:00:01"),
                 KeyValuePair.Create<string, string?>("Site:AdminUsers:0", "john-smith"),
                 KeyValuePair.Create<string, string?>("Webhook:DeployEnvironments:0", "production"),


### PR DESCRIPTION
Handle the `repository_dispatch` webhook for the `deployment_started` and `deployment_completed` actions.

Use the actions to set deployment tags in Grafana.
