### PR TITLE
Fix Faro service name

### DIFF
--- a/exclusion.dic
+++ b/exclusion.dic
@@ -17,6 +17,8 @@ noreply
 NuGet
 Octokit
 OpenTelemetry
+Otlp
+Pyroscope
 SemVer
 serializer
 startup

--- a/src/Costellobot/ApplicationTelemetry.cs
+++ b/src/Costellobot/ApplicationTelemetry.cs
@@ -15,6 +15,8 @@ public static class ApplicationTelemetry
     public static readonly string ServiceVersion = GitMetadata.Version.Split('+')[0];
     public static readonly ActivitySource ActivitySource = new(ServiceName, ServiceVersion);
 
+    private static string? _serviceName;
+
     public static ResourceBuilder ResourceBuilder { get; } = ResourceBuilder.CreateDefault()
         .AddService(ServiceName, ServiceNamespace, ServiceVersion)
         .AddAzureAppServiceDetector()
@@ -22,6 +24,17 @@ public static class ApplicationTelemetry
         .AddHostDetector()
         .AddOperatingSystemDetector()
         .AddProcessRuntimeDetector();
+
+    public static string EffectiveServiceName()
+    {
+        if (_serviceName is null)
+        {
+            var resource = ApplicationTelemetry.ResourceBuilder.Build();
+            _serviceName = resource.Attributes.FirstOrDefault((a) => a.Key == "service.name").Value?.ToString() ?? ServiceName;
+        }
+
+        return _serviceName;
+    }
 
     internal static bool IsOtlpCollectorConfigured()
         => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT"));

--- a/src/Costellobot/Slices/_Layout.cshtml
+++ b/src/Costellobot/Slices/_Layout.cshtml
@@ -90,7 +90,7 @@
     <meta name="x-telemetry-collector-url" content="@(telemetry)" />
     <meta name="x-telemetry-sample-rate" content="" />
     <meta name="x-telemetry-service-environment" content="@(environment)" />
-    <meta name="x-telemetry-service-name" content="@(ApplicationTelemetry.ServiceName)" />
+    <meta name="x-telemetry-service-name" content="@(ApplicationTelemetry.EffectiveServiceName())" />
     <meta name="x-telemetry-service-version" content="@(ApplicationTelemetry.ServiceVersion)" />
 </head>
 <body>


### PR DESCRIPTION
Fix Faro using the default `service.name`, rather than the actual runtime value which may be overridden when running in a cloud provider from resource detectors.
