### PR TITLE
Update Faro configuration

### DIFF
--- a/src/Costellobot/Slices/_Layout.cshtml
+++ b/src/Costellobot/Slices/_Layout.cshtml
@@ -91,6 +91,7 @@
     <meta name="x-telemetry-sample-rate" content="" />
     <meta name="x-telemetry-service-environment" content="@(environment)" />
     <meta name="x-telemetry-service-name" content="@(ApplicationTelemetry.EffectiveServiceName())" />
+    <meta name="x-telemetry-service-namespace" content="@(ApplicationTelemetry.ServiceNamespace)" />
     <meta name="x-telemetry-service-version" content="@(ApplicationTelemetry.ServiceVersion)" />
 </head>
 <body>

--- a/src/Costellobot/scripts/Telemetry.ts
+++ b/src/Costellobot/scripts/Telemetry.ts
@@ -21,6 +21,7 @@ export class Telemetry {
         const url = getOption('collector-url');
         const environment = getOption('service-environment');
         const name = getOption('service-name');
+        const namespace = getOption('service-namespace');
         const version = getOption('service-version');
 
         if (!url || !name || !version || !environment) {
@@ -41,6 +42,7 @@ export class Telemetry {
             app: {
                 environment,
                 name,
+                namespace,
                 version,
             },
             sessionTracking: tracking,

--- a/src/Costellobot/scripts/Telemetry.ts
+++ b/src/Costellobot/scripts/Telemetry.ts
@@ -19,7 +19,7 @@ export class Telemetry {
         };
 
         const url = getOption('collector-url');
-        const environment = getOption('service-environment');
+        const environment = getOption('service-environment')?.toLowerCase();
         const name = getOption('service-name');
         const namespace = getOption('service-namespace');
         const version = getOption('service-version');


### PR DESCRIPTION
- Set the `service.namespace` attribute.
- Normalize the environment value.
