### PR TITLE
Pass through CancellationToken

### DIFF
--- a/src/Costellobot/GitHubMessageProcessor.cs
+++ b/src/Costellobot/GitHubMessageProcessor.cs
@@ -30,7 +30,7 @@ public sealed partial class GitHubMessageProcessor(
             using (logger.BeginWebhookScope(webhookEvent))
             {
                 Log.ReceivedWebhook(logger, webhookHeaders.Delivery);
-                await ProcessAsync(new(webhookHeaders, webhookEvent, rawHeaders, rawPayload));
+                await ProcessAsync(new(webhookHeaders, webhookEvent, rawHeaders, rawPayload), cancellationToken);
             }
         }
     }
@@ -53,14 +53,14 @@ public sealed partial class GitHubMessageProcessor(
         return (webhookHeaders, document.RootElement.Clone());
     }
 
-    private async Task ProcessAsync(GitHubEvent message)
+    private async Task ProcessAsync(GitHubEvent message, CancellationToken cancellationToken)
     {
         try
         {
             await using var scope = serviceProvider.CreateAsyncScope();
 
             var dispatcher = scope.ServiceProvider.GetRequiredService<GitHubWebhookDispatcher>();
-            await dispatcher.DispatchAsync(message);
+            await dispatcher.DispatchAsync(message, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Costellobot/GitHubWebhookDispatcher.cs
+++ b/src/Costellobot/GitHubWebhookDispatcher.cs
@@ -12,7 +12,7 @@ public sealed partial class GitHubWebhookDispatcher(
     IOptionsMonitor<GitHubOptions> options,
     ILogger<GitHubWebhookDispatcher> logger)
 {
-    public async Task DispatchAsync(GitHubEvent message)
+    public async Task DispatchAsync(GitHubEvent message, CancellationToken cancellationToken)
     {
         using (logger.BeginWebhookScope(message.Headers))
         using (logger.BeginWebhookScope(message.Event))
@@ -50,7 +50,7 @@ public sealed partial class GitHubWebhookDispatcher(
                 }
 
                 var handler = handlerFactory.Create(message.Headers.Event);
-                await handler.HandleAsync(message.Event);
+                await handler.HandleAsync(message.Event, cancellationToken);
 
                 Log.ProcessedWebhook(logger, message.Headers.Delivery, message);
             }

--- a/src/Costellobot/GitHubWebhookHub.cs
+++ b/src/Costellobot/GitHubWebhookHub.cs
@@ -17,7 +17,7 @@ public class GitHubWebhookHub(ClientLogQueue logs, GitHubWebhookQueue webhooks) 
 
         foreach (var @event in webhooks.History())
         {
-            await Clients.Caller.WebhookAsync(@event.RawHeaders, @event.RawPayload);
+            await Clients.Caller.WebhookAsync(@event.RawHeaders, @event.RawPayload, Context.ConnectionAborted);
         }
     }
 }

--- a/src/Costellobot/GitHubWebhookService.cs
+++ b/src/Costellobot/GitHubWebhookService.cs
@@ -111,7 +111,7 @@ public sealed partial class GitHubWebhookService(
 
         Log.ProcessingMessage(logger, args.Message.MessageId);
 
-        await processor.ProcessWebhookAsync(headers, body);
+        await processor.ProcessWebhookAsync(headers, body, args.CancellationToken);
 
         try
         {

--- a/src/Costellobot/Handlers/CheckSuiteHandler.cs
+++ b/src/Costellobot/Handlers/CheckSuiteHandler.cs
@@ -17,7 +17,7 @@ public sealed partial class CheckSuiteHandler(
 {
     private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
 
-    public async Task HandleAsync(WebhookEvent message)
+    public async Task HandleAsync(WebhookEvent message, CancellationToken cancellationToken)
     {
         if (message is not CheckSuiteEvent body ||
             body.Repository is null ||

--- a/src/Costellobot/Handlers/IHandler.cs
+++ b/src/Costellobot/Handlers/IHandler.cs
@@ -7,5 +7,5 @@ namespace MartinCostello.Costellobot.Handlers;
 
 public interface IHandler
 {
-    Task HandleAsync(WebhookEvent message);
+    Task HandleAsync(WebhookEvent message, CancellationToken cancellationToken);
 }

--- a/src/Costellobot/Handlers/NullHandler.cs
+++ b/src/Costellobot/Handlers/NullHandler.cs
@@ -9,5 +9,6 @@ public sealed class NullHandler : IHandler
 {
     public static readonly NullHandler Instance = new();
 
-    public Task HandleAsync(WebhookEvent message) => Task.CompletedTask;
+    public Task HandleAsync(WebhookEvent message, CancellationToken cancellationToken)
+        => Task.CompletedTask;
 }

--- a/src/Costellobot/Handlers/PullRequestAnalyzer.cs
+++ b/src/Costellobot/Handlers/PullRequestAnalyzer.cs
@@ -16,20 +16,22 @@ public sealed partial class PullRequestAnalyzer(
         RepositoryId repository,
         string pullRequestHeadRef,
         string pullRequestHeadSha,
-        string pullRequestUrl)
+        string pullRequestUrl,
+        CancellationToken cancellationToken)
     {
         var commit = await context.InstallationClient.Repository.Commit.Get(
             repository.Owner,
             repository.Name,
             pullRequestHeadSha);
 
-        var diff = await GetDiffAsync(pullRequestUrl);
+        var diff = await GetDiffAsync(pullRequestUrl, cancellationToken);
 
         return await commitAnalyzer.GetDependencyTrustAsync(
             repository,
             pullRequestHeadRef,
             commit,
-            diff);
+            diff,
+            cancellationToken);
     }
 
     public async Task<bool> HasValidApprovalAsync(IssueId id, string authorLogin)
@@ -81,27 +83,31 @@ public sealed partial class PullRequestAnalyzer(
         RepositoryId repository,
         string pullRequestHeadRef,
         string pullRequestHeadSha,
-        string pullRequestUrl)
+        string pullRequestUrl,
+        CancellationToken cancellationToken)
     {
         var commit = await context.InstallationClient.Repository.Commit.Get(
             repository.Owner,
             repository.Name,
             pullRequestHeadSha);
 
-        var diff = await GetDiffAsync(pullRequestUrl);
+        var diff = await GetDiffAsync(pullRequestUrl, cancellationToken);
 
         return await commitAnalyzer.IsTrustedDependencyUpdateAsync(
             repository,
             pullRequestHeadRef,
             commit,
-            diff);
+            diff,
+            cancellationToken);
     }
 
-    private async Task<string?> GetDiffAsync(string diffUrl)
+    private async Task<string?> GetDiffAsync(
+        string diffUrl,
+        CancellationToken cancellationToken)
     {
         try
         {
-            return await context.InstallationClient.GetDiffAsync(diffUrl);
+            return await context.InstallationClient.GetDiffAsync(diffUrl, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/Costellobot/Handlers/PullRequestHandler.cs
+++ b/src/Costellobot/Handlers/PullRequestHandler.cs
@@ -17,7 +17,7 @@ public sealed partial class PullRequestHandler(
 {
     private readonly IOptionsMonitor<WebhookOptions> _options = options;
 
-    public async Task HandleAsync(WebhookEvent message)
+    public async Task HandleAsync(WebhookEvent message, CancellationToken cancellationToken)
     {
         if (message is not PullRequestEvent body ||
             body.Repository is null ||
@@ -46,13 +46,14 @@ public sealed partial class PullRequestHandler(
                 pull.Repository,
                 pr.Head.Ref,
                 pr.Head.Sha,
-                pr.Url);
+                pr.Url,
+                cancellationToken);
         }
 
         if (isManualApproval || isTrusted)
         {
             var mergeMethod = PullRequestApprover.GetMergeMethod(pr.Base.Repo);
-            await approver.ApproveAndMergeAsync(pull, pr.NodeId, mergeMethod);
+            await approver.ApproveAndMergeAsync(pull, pr.NodeId, mergeMethod, cancellationToken);
         }
     }
 

--- a/src/Costellobot/Handlers/PushHandler.cs
+++ b/src/Costellobot/Handlers/PushHandler.cs
@@ -15,7 +15,7 @@ public sealed partial class PushHandler(
     private const string DefaultBranch = $"{PrefixForBranchName}main";
     private const string DotNetNextBranch = $"{PrefixForBranchName}dotnet-vnext";
 
-    public async Task HandleAsync(WebhookEvent message)
+    public async Task HandleAsync(WebhookEvent message, CancellationToken cancellationToken)
     {
         if (message is not PushEvent push ||
             push.Repository is not { Fork: false, Language: "C#" } repo ||
@@ -48,7 +48,7 @@ public sealed partial class PushHandler(
         if (DependencyFileChanged(filesChanged) && string.IsNullOrWhiteSpace(context.InstallationOrganization))
         {
             Log.CreatedRepositoryDispatchForPush(logger, repository, push.Ref);
-            await CreateDispatchAsync(repository, push.Ref, push.After);
+            await CreateDispatchAsync(repository, push.Ref, push.After, cancellationToken);
         }
     }
 
@@ -74,7 +74,11 @@ public sealed partial class PushHandler(
         }
     }
 
-    private async Task CreateDispatchAsync(RepositoryId repository, string reference, string sha)
+    private async Task CreateDispatchAsync(
+        RepositoryId repository,
+        string reference,
+        string sha,
+        CancellationToken cancellationToken)
     {
         // See https://github.com/martincostello/github-automation/blob/main/.github/workflows/dotnet-dependencies-updated.yml
         var dispatch = new
@@ -89,7 +93,11 @@ public sealed partial class PushHandler(
             },
         };
 
-        await context.InstallationClient.RepositoryDispatchAsync("martincostello", "github-automation", dispatch);
+        await context.InstallationClient.RepositoryDispatchAsync(
+            "martincostello",
+            "github-automation",
+            dispatch,
+            cancellationToken);
     }
 
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/Costellobot/IWebhookClient.cs
+++ b/src/Costellobot/IWebhookClient.cs
@@ -12,5 +12,8 @@ public interface IWebhookClient
     Task LogAsync(ClientLogMessage logEntry);
 
     [HubMethodName("webhook-logs")]
-    Task WebhookAsync(IDictionary<string, string> headers, JsonElement webhookEvent);
+    Task WebhookAsync(
+        IDictionary<string, string> headers,
+        JsonElement webhookEvent,
+        CancellationToken cancellationToken);
 }

--- a/src/Costellobot/Octokit/IGitHubClientExtensions.cs
+++ b/src/Costellobot/Octokit/IGitHubClientExtensions.cs
@@ -8,19 +8,27 @@ public static class IGitHubClientExtensions
     public static IWorkflowRunsClient WorkflowRuns(this IGitHubClient client)
         => new WorkflowRunsClient(new ApiConnection(client.Connection));
 
-    public static async Task<string> GetDiffAsync(this IGitHubClient client, string pullRequestUrl)
+    public static async Task<string> GetDiffAsync(
+        this IGitHubClient client,
+        string pullRequestUrl,
+        CancellationToken cancellationToken)
     {
         // See https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request
         var parameters = new Dictionary<string, string>(0);
-        var response = await client.Connection.Get<string>(new(pullRequestUrl, UriKind.Absolute), parameters, "application/vnd.github.v3.diff");
+        var response = await client.Connection.Get<string>(new(pullRequestUrl, UriKind.Absolute), parameters, "application/vnd.github.v3.diff", cancellationToken);
         return response.Body;
     }
 
-    public static async Task RepositoryDispatchAsync(this IGitHubClient client, string owner, string name, object body)
+    public static async Task RepositoryDispatchAsync(
+        this IGitHubClient client,
+        string owner,
+        string name,
+        object body,
+        CancellationToken cancellationToken)
     {
         // See https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event
         var uri = new Uri($"repos/{owner}/{name}/dispatches", UriKind.Relative);
-        var status = await client.Connection.Post(uri, body, "application/vnd.github+json");
+        var status = await client.Connection.Post(uri, body, "application/vnd.github+json", cancellationToken);
 
         if (status is not System.Net.HttpStatusCode.NoContent)
         {

--- a/src/Costellobot/Octokit/IGitHubClientExtensions.cs
+++ b/src/Costellobot/Octokit/IGitHubClientExtensions.cs
@@ -15,7 +15,13 @@ public static class IGitHubClientExtensions
     {
         // See https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request
         var parameters = new Dictionary<string, string>(0);
-        var response = await client.Connection.Get<string>(new(pullRequestUrl, UriKind.Absolute), parameters, "application/vnd.github.v3.diff", cancellationToken);
+
+        var response = await client.Connection.Get<string>(
+            new(pullRequestUrl, UriKind.Absolute),
+            parameters,
+            "application/vnd.github.v3.diff",
+            cancellationToken);
+
         return response.Body;
     }
 

--- a/src/Costellobot/Octokit/IWorkflowRunsClient.cs
+++ b/src/Costellobot/Octokit/IWorkflowRunsClient.cs
@@ -12,5 +12,6 @@ public interface IWorkflowRunsClient
 
     Task ReviewCustomProtectionRuleAsync(
         string deploymentCallbackUrl,
-        ReviewDeploymentProtectionRule review);
+        ReviewDeploymentProtectionRule review,
+        CancellationToken cancellationToken);
 }

--- a/src/Costellobot/Octokit/WorkflowRunsClient.cs
+++ b/src/Costellobot/Octokit/WorkflowRunsClient.cs
@@ -17,11 +17,12 @@ public sealed class WorkflowRunsClient(IApiConnection connection) : IWorkflowRun
 
     public async Task ReviewCustomProtectionRuleAsync(
         string deploymentCallbackUrl,
-        ReviewDeploymentProtectionRule review)
+        ReviewDeploymentProtectionRule review,
+        CancellationToken cancellationToken)
     {
         // See https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#review-custom-deployment-protection-rules-for-a-workflow-run
         var uri = new Uri(deploymentCallbackUrl, UriKind.Absolute);
-        var status = await connection.Connection.Post(uri, review, "application/vnd.github+json");
+        var status = await connection.Connection.Post(uri, review, "application/vnd.github+json", cancellationToken);
 
         if (status is not System.Net.HttpStatusCode.NoContent)
         {

--- a/src/Costellobot/Registries/DockerPackageRegistry.cs
+++ b/src/Costellobot/Registries/DockerPackageRegistry.cs
@@ -22,14 +22,16 @@ public sealed partial class DockerPackageRegistry(
     public override async Task<IReadOnlyList<string>> GetPackageOwnersAsync(
         RepositoryId repository,
         string id,
-        string version)
+        string version,
+        CancellationToken cancellationToken)
     {
         var isMicrosoftImage = await cache.GetOrCreateAsync(
             $"mar:{id}",
             (Client, id),
             static async (context, _) => await IsImageFromMicrosoftArtifactRegistryAsync(context.Client, context.id),
             CacheEntryOptions,
-            CacheTags);
+            CacheTags,
+            cancellationToken);
 
         if (isMicrosoftImage)
         {

--- a/src/Costellobot/Registries/GitHubActionsPackageRegistry.cs
+++ b/src/Costellobot/Registries/GitHubActionsPackageRegistry.cs
@@ -13,7 +13,8 @@ public sealed class GitHubActionsPackageRegistry(GitHubWebhookContext context)
     public override async Task<IReadOnlyList<string>> GetPackageOwnersAsync(
         RepositoryId repository,
         string id,
-        string version)
+        string version,
+        CancellationToken cancellationToken)
     {
         string[] parts = id.Split('/');
 

--- a/src/Costellobot/Registries/GitHubPackageRegistry.cs
+++ b/src/Costellobot/Registries/GitHubPackageRegistry.cs
@@ -15,22 +15,25 @@ public abstract class GitHubPackageRegistry(GitHubWebhookContext context) : IPac
 
     protected IGitHubClient RestClient => context.InstallationClient;
 
-    public virtual async Task<bool> AreOwnersTrustedAsync(IReadOnlyList<string> owners)
+    public virtual async Task<bool> AreOwnersTrustedAsync(
+        IReadOnlyList<string> owners,
+        CancellationToken cancellationToken)
     {
         if (owners.Count != 1)
         {
             return false;
         }
 
-        return await IsGitHubStarAsync(owners[0]);
+        return await IsGitHubStarAsync(owners[0], cancellationToken);
     }
 
     public abstract Task<IReadOnlyList<string>> GetPackageOwnersAsync(
         RepositoryId repository,
         string id,
-        string version);
+        string version,
+        CancellationToken cancellationToken);
 
-    protected async Task<bool> IsGitHubStarAsync(string login)
+    protected async Task<bool> IsGitHubStarAsync(string login, CancellationToken cancellationToken)
     {
         var query = new Query()
             .User(login)
@@ -39,7 +42,7 @@ public abstract class GitHubPackageRegistry(GitHubWebhookContext context) : IPac
 
         try
         {
-            var result = await GraphQLClient.Run(query);
+            var result = await GraphQLClient.Run(query, cancellationToken: cancellationToken);
             return result.IsGitHubStar;
         }
         catch (Octokit.GraphQL.Core.GraphQLException)

--- a/src/Costellobot/Registries/GitSubmodulePackageRegistry.cs
+++ b/src/Costellobot/Registries/GitSubmodulePackageRegistry.cs
@@ -13,7 +13,8 @@ public sealed class GitSubmodulePackageRegistry(GitHubWebhookContext context)
     public override async Task<IReadOnlyList<string>> GetPackageOwnersAsync(
         RepositoryId repository,
         string id,
-        string version)
+        string version,
+        CancellationToken cancellationToken)
     {
         IReadOnlyList<RepositoryContent> items;
 

--- a/src/Costellobot/Registries/IPackageRegistry.cs
+++ b/src/Costellobot/Registries/IPackageRegistry.cs
@@ -7,10 +7,12 @@ public interface IPackageRegistry
 {
     DependencyEcosystem Ecosystem { get; }
 
-    Task<bool> AreOwnersTrustedAsync(IReadOnlyList<string> owners) => Task.FromResult(false);
+    Task<bool> AreOwnersTrustedAsync(IReadOnlyList<string> owners, CancellationToken cancellationToken)
+        => Task.FromResult(false);
 
     Task<IReadOnlyList<string>> GetPackageOwnersAsync(
         RepositoryId repository,
         string id,
-        string version);
+        string version,
+        CancellationToken cancellationToken);
 }

--- a/src/Costellobot/Registries/NpmPackageRegistry.cs
+++ b/src/Costellobot/Registries/NpmPackageRegistry.cs
@@ -14,7 +14,8 @@ public sealed partial class NpmPackageRegistry(HttpClient client) : PackageRegis
     public override async Task<IReadOnlyList<string>> GetPackageOwnersAsync(
         RepositoryId repository,
         string id,
-        string version)
+        string version,
+        CancellationToken cancellationToken)
     {
         var escapedId = Uri.EscapeDataString(id);
         var escapedVersion = Uri.EscapeDataString(version);
@@ -26,7 +27,7 @@ public sealed partial class NpmPackageRegistry(HttpClient client) : PackageRegis
 
         try
         {
-            package = await Client.GetFromJsonAsync(uri, NpmJsonSerializerContext.Default.Package);
+            package = await Client.GetFromJsonAsync(uri, NpmJsonSerializerContext.Default.Package, cancellationToken);
         }
         catch (HttpRequestException ex) when (IsNotFound(ex))
         {

--- a/src/Costellobot/Registries/PackageRegistry.cs
+++ b/src/Costellobot/Registries/PackageRegistry.cs
@@ -12,5 +12,6 @@ public abstract class PackageRegistry(HttpClient client) : IPackageRegistry
     public abstract Task<IReadOnlyList<string>> GetPackageOwnersAsync(
         RepositoryId repository,
         string id,
-        string version);
+        string version,
+        CancellationToken cancellationToken);
 }

--- a/src/Costellobot/Registries/RubyGemsPackageRegistry.cs
+++ b/src/Costellobot/Registries/RubyGemsPackageRegistry.cs
@@ -14,7 +14,8 @@ public sealed partial class RubyGemsPackageRegistry(HttpClient client) : Package
     public override async Task<IReadOnlyList<string>> GetPackageOwnersAsync(
         RepositoryId repository,
         string id,
-        string version)
+        string version,
+        CancellationToken cancellationToken)
     {
         var escapedId = Uri.EscapeDataString(id);
 
@@ -25,7 +26,7 @@ public sealed partial class RubyGemsPackageRegistry(HttpClient client) : Package
 
         try
         {
-            owners = await Client.GetFromJsonAsync(uri, RubyGemsJsonSerializerContext.Default.OwnerArray);
+            owners = await Client.GetFromJsonAsync(uri, RubyGemsJsonSerializerContext.Default.OwnerArray, cancellationToken);
         }
         catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.NotFound)
         {

--- a/tests/Costellobot.Tests/GitCommitAnalyzerTests.cs
+++ b/tests/Costellobot.Tests/GitCommitAnalyzerTests.cs
@@ -162,7 +162,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBe(expected);
@@ -173,7 +174,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         trust.ShouldContainKeyAndValue(dependency, (expected, null));
@@ -208,7 +210,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(ecosystem);
 
-        registry.GetPackageOwnersAsync(repository, dependency, version)
+        registry.GetPackageOwnersAsync(repository, dependency, version, CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(owners));
 
         var options = new WebhookOptions()
@@ -240,7 +242,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBe(expected);
@@ -253,7 +256,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
                 reference,
                 sha,
                 commitMessage,
-                diff);
+                diff,
+                CancellationToken);
 
             // Assert
             actualEcosystem.ShouldBe(ecosystem);
@@ -281,7 +285,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(ecosystem);
 
-        registry.GetPackageOwnersAsync(repository, dependency, version)
+        registry.GetPackageOwnersAsync(repository, dependency, version, CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(owners));
 
         var options = new WebhookOptions()
@@ -325,7 +329,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBe(expected);
@@ -378,7 +383,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeFalse();
@@ -389,7 +395,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.Unknown);
@@ -420,7 +427,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeFalse();
@@ -431,7 +439,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.NuGet);
@@ -471,7 +480,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeFalse();
@@ -482,7 +492,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.NuGet);
@@ -506,7 +517,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
         registry.Ecosystem
                 .Returns(DependencyEcosystem.GitHubActions);
 
-        registry.When((p) => p.GetPackageOwnersAsync(repository, "actions/checkout", "3"))
+        registry.When((p) => p.GetPackageOwnersAsync(repository, "actions/checkout", "3", CancellationToken))
                 .Throw(new InvalidOperationException("Expected exception."));
 
         var options = new WebhookOptions()
@@ -536,7 +547,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeFalse();
@@ -547,7 +559,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.GitHubActions);
@@ -569,10 +582,10 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.NuGet);
 
-        registry.GetPackageOwnersAsync(repository, "OpenTelemetry.Instrumentation.AspNetCore", "1.0.0-rc9.12")
+        registry.GetPackageOwnersAsync(repository, "OpenTelemetry.Instrumentation.AspNetCore", "1.0.0-rc9.12", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["OpenTelemetry"]));
 
-        registry.GetPackageOwnersAsync(repository, "OpenTelemetry.Instrumentation.Http", "1.0.0-rc9.12")
+        registry.GetPackageOwnersAsync(repository, "OpenTelemetry.Instrumentation.Http", "1.0.0-rc9.12", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["OpenTelemetry"]));
 
         var options = new WebhookOptions()
@@ -625,7 +638,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeTrue();
@@ -636,7 +650,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.NuGet);
@@ -659,7 +674,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.NuGet);
 
-        registry.GetPackageOwnersAsync(repository, "xunit", "2.6.3")
+        registry.GetPackageOwnersAsync(repository, "xunit", "2.6.3", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["dotnetfoundation", "xunit"]));
 
         var options = new WebhookOptions()
@@ -701,7 +716,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeTrue();
@@ -712,7 +728,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.NuGet);
@@ -734,10 +751,10 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.NuGet);
 
-        registry.GetPackageOwnersAsync(repository, "xunit", "2.6.3")
+        registry.GetPackageOwnersAsync(repository, "xunit", "2.6.3", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["dotnetfoundation", "xunit"]));
 
-        registry.GetPackageOwnersAsync(repository, "xunit.runner.visualstudio", "2.5.5")
+        registry.GetPackageOwnersAsync(repository, "xunit.runner.visualstudio", "2.5.5", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["dotnetfoundation", "xunit"]));
 
         var options = new WebhookOptions()
@@ -790,7 +807,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeTrue();
@@ -801,7 +819,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.NuGet);
@@ -824,10 +843,10 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.NuGet);
 
-        registry.GetPackageOwnersAsync(repository, "xunit", "2.9.0")
+        registry.GetPackageOwnersAsync(repository, "xunit", "2.9.0", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["dotnetfoundation", "xunit"]));
 
-        registry.GetPackageOwnersAsync(repository, "xunit.runner.visualstudio", "2.8.2")
+        registry.GetPackageOwnersAsync(repository, "xunit.runner.visualstudio", "2.8.2", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["dotnetfoundation", "xunit"]));
 
         var options = new WebhookOptions()
@@ -876,7 +895,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeTrue();
@@ -887,7 +907,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.NuGet);
@@ -911,7 +932,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
         registry.Ecosystem
             .Returns(DependencyEcosystem.NuGet);
 
-        registry.GetPackageOwnersAsync(repository, "Microsoft.TypeScript.MSBuild", "4.9.5")
+        registry.GetPackageOwnersAsync(repository, "Microsoft.TypeScript.MSBuild", "4.9.5", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["Microsoft", "TypeScriptTeam"]));
 
         var options = new WebhookOptions()
@@ -951,7 +972,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeTrue();
@@ -962,7 +984,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.NuGet);
@@ -984,16 +1007,16 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.NuGet);
 
-        registry.GetPackageOwnersAsync(repository, "Microsoft.Extensions.Configuration.Binder", "7.0.4")
+        registry.GetPackageOwnersAsync(repository, "Microsoft.Extensions.Configuration.Binder", "7.0.4", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["Microsoft", "aspnet"]));
 
-        registry.GetPackageOwnersAsync(repository, "Microsoft.Extensions.Http.Polly", "7.0.5")
+        registry.GetPackageOwnersAsync(repository, "Microsoft.Extensions.Http.Polly", "7.0.5", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["Microsoft", "aspnet"]));
 
-        registry.GetPackageOwnersAsync(repository, "Microsoft.NET.Test.Sdk", "17.5.0")
+        registry.GetPackageOwnersAsync(repository, "Microsoft.NET.Test.Sdk", "17.5.0", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["Microsoft", "aspnet"]));
 
-        registry.GetPackageOwnersAsync(repository, "System.Text.Json", "7.0.2")
+        registry.GetPackageOwnersAsync(repository, "System.Text.Json", "7.0.2", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["Microsoft", "dotnetframework"]));
 
         var options = new WebhookOptions()
@@ -1042,7 +1065,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeTrue();
@@ -1053,7 +1077,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.NuGet);
@@ -1078,10 +1103,10 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.NuGet);
 
-        registry.GetPackageOwnersAsync(repository, "AWSSDK.SecurityToken", "3.7.300.118")
+        registry.GetPackageOwnersAsync(repository, "AWSSDK.SecurityToken", "3.7.300.118", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["awsdotnet"]));
 
-        registry.GetPackageOwnersAsync(repository, "AWSSDK.SimpleSystemsManagement", "3.7.305.8")
+        registry.GetPackageOwnersAsync(repository, "AWSSDK.SimpleSystemsManagement", "3.7.305.8", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["awsdotnet"]));
 
         var options = new WebhookOptions()
@@ -1141,7 +1166,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeTrue();
@@ -1152,7 +1178,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.NuGet);
@@ -1175,10 +1202,10 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.NuGet);
 
-        registry.GetPackageOwnersAsync(repository, "AWSSDK.SecurityToken", "3.7.300.118")
+        registry.GetPackageOwnersAsync(repository, "AWSSDK.SecurityToken", "3.7.300.118", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["awsdotnet"]));
 
-        registry.GetPackageOwnersAsync(repository, "AWSSDK.SimpleSystemsManagement", "3.7.305.8")
+        registry.GetPackageOwnersAsync(repository, "AWSSDK.SimpleSystemsManagement", "3.7.305.8", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["awsdotnet"]));
 
         var options = new WebhookOptions()
@@ -1223,7 +1250,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeTrue();
@@ -1234,7 +1262,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.NuGet);
@@ -1257,7 +1286,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.NuGet);
 
-        registry.GetPackageOwnersAsync(repository, "Microsoft.IdentityModel.JsonWebTokens", "8.0.0")
+        registry.GetPackageOwnersAsync(repository, "Microsoft.IdentityModel.JsonWebTokens", "8.0.0", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["AzureAD", "Microsoft"]));
 
         var options = new WebhookOptions()
@@ -1348,7 +1377,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeTrue();
@@ -1359,7 +1389,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.NuGet);
@@ -1384,7 +1415,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.NuGet);
 
-        registry.GetPackageOwnersAsync(repository, "Microsoft.IdentityModel.JsonWebTokens", "8.0.0")
+        registry.GetPackageOwnersAsync(repository, "Microsoft.IdentityModel.JsonWebTokens", "8.0.0", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["AzureAD", "Microsoft"]));
 
         var options = new WebhookOptions()
@@ -1521,7 +1552,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeFalse();
@@ -1532,7 +1564,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.NuGet);
@@ -1566,7 +1599,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.NuGet);
 
-        registry.GetPackageOwnersAsync(repository, "Microsoft.IdentityModel.JsonWebTokens", dependencyVersion)
+        registry.GetPackageOwnersAsync(repository, "Microsoft.IdentityModel.JsonWebTokens", dependencyVersion, CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["AzureAD", "Microsoft"]));
 
         var options = new WebhookOptions()
@@ -1704,7 +1737,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBe(expected);
@@ -1715,7 +1749,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.NuGet);
@@ -1740,7 +1775,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.NuGet);
 
-        registry.GetPackageOwnersAsync(repository, "Microsoft.IdentityModel.JsonWebTokens", "8.0.0")
+        registry.GetPackageOwnersAsync(repository, "Microsoft.IdentityModel.JsonWebTokens", "8.0.0", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["AzureAD", "Microsoft"]));
 
         var options = new WebhookOptions()
@@ -1899,7 +1934,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeFalse();
@@ -1910,7 +1946,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.NuGet);
@@ -1936,10 +1973,10 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.NuGet);
 
-        registry.GetPackageOwnersAsync(repository, "Microsoft.AspNetCore.AzureAppServices.HostingStartup", "9.0.6")
+        registry.GetPackageOwnersAsync(repository, "Microsoft.AspNetCore.AzureAppServices.HostingStartup", "9.0.6", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["aspnet", "dotnetframework", "Microsoft"]));
 
-        registry.GetPackageOwnersAsync(repository, "Microsoft.AspNetCore.Mvc.Testing", "9.0.6")
+        registry.GetPackageOwnersAsync(repository, "Microsoft.AspNetCore.Mvc.Testing", "9.0.6", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["aspnet", "dotnetframework", "Microsoft"]));
 
         var options = new WebhookOptions()
@@ -1977,7 +2014,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeTrue();
@@ -1988,7 +2026,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.NuGet);
@@ -2012,7 +2051,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.GitSubmodule);
 
-        registry.GetPackageOwnersAsync(repository, "src/submodules/dependabot-helper", "aca93c2")
+        registry.GetPackageOwnersAsync(repository, "src/submodules/dependabot-helper", "aca93c2", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["https://github.com/martincostello"]));
 
         var options = new WebhookOptions()
@@ -2047,7 +2086,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeTrue();
@@ -2058,7 +2098,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.GitSubmodule);
@@ -2080,7 +2121,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.GitHubActions);
 
-        registry.GetPackageOwnersAsync(repository, "github/codeql-action", "3.29.0")
+        registry.GetPackageOwnersAsync(repository, "github/codeql-action", "3.29.0", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["github"]));
 
         var options = new WebhookOptions()
@@ -2115,7 +2156,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeTrue();
@@ -2126,7 +2168,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.GitHubActions);
@@ -2148,10 +2191,10 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.Npm);
 
-        registry.GetPackageOwnersAsync(repository, "@typescript-eslint/eslint-plugin", "8.34.0")
+        registry.GetPackageOwnersAsync(repository, "@typescript-eslint/eslint-plugin", "8.34.0", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["bradzacher", "jameshenry"]));
 
-        registry.GetPackageOwnersAsync(repository, "@typescript-eslint/parser", "8.34.0")
+        registry.GetPackageOwnersAsync(repository, "@typescript-eslint/parser", "8.34.0", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["bradzacher", "jameshenry"]));
 
         var options = new WebhookOptions()
@@ -2188,7 +2231,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeTrue();
@@ -2199,7 +2243,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.Npm);
@@ -2222,7 +2267,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.Npm);
 
-        registry.GetPackageOwnersAsync(repository, "@stylistic/eslint-plugin", "4.4.1")
+        registry.GetPackageOwnersAsync(repository, "@stylistic/eslint-plugin", "4.4.1", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["eslint-stylistic-bot"]));
 
         var options = new WebhookOptions()
@@ -2255,7 +2300,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeFalse();
@@ -2266,7 +2312,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.Npm);
@@ -2288,7 +2335,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.NuGet);
 
-        registry.GetPackageOwnersAsync(repository, "Microsoft.NET.Test.Sdk", "17.14.1")
+        registry.GetPackageOwnersAsync(repository, "Microsoft.NET.Test.Sdk", "17.14.1", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["Microsoft", "vstest"]));
 
         var options = new WebhookOptions()
@@ -2323,7 +2370,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeTrue();
@@ -2334,7 +2382,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.NuGet);
@@ -2356,7 +2405,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.Docker);
 
-        registry.GetPackageOwnersAsync(repository, "mcr.microsoft.com/dotnet/sdk", "9.0.301-b768b444028d3c531de90a356836047e48658cd1e26ba07a539a6f1a052a35d9")
+        registry.GetPackageOwnersAsync(repository, "mcr.microsoft.com/dotnet/sdk", "9.0.301-b768b444028d3c531de90a356836047e48658cd1e26ba07a539a6f1a052a35d9", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["mcr.microsoft.com"]));
 
         var options = new WebhookOptions()
@@ -2399,7 +2448,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeTrue();
@@ -2410,7 +2460,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.Docker);
@@ -2432,7 +2483,7 @@ Signed-off-by: dependabot[bot] <support@github.com>";
 
         registry.Ecosystem.Returns(DependencyEcosystem.Docker);
 
-        registry.GetPackageOwnersAsync(repository, "mcr.microsoft.com/azure-sql-edge", "2.0.0-52605ea3251cbc4a7e03eccd458e775ae8a626a3afb4019bec66520a81e78170")
+        registry.GetPackageOwnersAsync(repository, "mcr.microsoft.com/azure-sql-edge", "2.0.0-52605ea3251cbc4a7e03eccd458e775ae8a626a3afb4019bec66520a81e78170", CancellationToken)
                 .Returns(Task.FromResult<IReadOnlyList<string>>(["mcr.microsoft.com"]));
 
         var options = new WebhookOptions()
@@ -2478,7 +2529,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         actual.ShouldBeTrue();
@@ -2489,7 +2541,8 @@ Signed-off-by: dependabot[bot] <support@github.com>";
             reference,
             sha,
             commitMessage,
-            diff);
+            diff,
+            CancellationToken);
 
         // Assert
         ecosystem.ShouldBe(DependencyEcosystem.Docker);

--- a/tests/Costellobot.Tests/GitHubWebhookDispatcherTests.cs
+++ b/tests/Costellobot.Tests/GitHubWebhookDispatcherTests.cs
@@ -20,7 +20,7 @@ public class GitHubWebhookDispatcherTests(ITestOutputHelper outputHelper)
         var message = Builders.GitHubFixtures.CreateEvent("pull_request", installationId: 99);
 
         // Act and Assert
-        await Should.NotThrowAsync(() => target.DispatchAsync(message));
+        await Should.NotThrowAsync(() => target.DispatchAsync(message, TestContext.Current.CancellationToken));
     }
 
     [Theory]
@@ -34,7 +34,7 @@ public class GitHubWebhookDispatcherTests(ITestOutputHelper outputHelper)
         var handler = Substitute.For<IHandler>();
         var handlerFactory = Substitute.For<IHandlerFactory>();
 
-        handler.HandleAsync(Arg.Any<WebhookEvent>())
+        handler.HandleAsync(Arg.Any<WebhookEvent>(), TestContext.Current.CancellationToken)
                .Returns(Task.CompletedTask);
 
         handlerFactory.Create(eventName)
@@ -45,11 +45,11 @@ public class GitHubWebhookDispatcherTests(ITestOutputHelper outputHelper)
         var target = CreateTarget(handlerFactory, installationId);
 
         // Act
-        await target.DispatchAsync(message);
+        await target.DispatchAsync(message, TestContext.Current.CancellationToken);
 
         // Assert
         handlerFactory.Received(1).Create(eventName);
-        await handler.Received(1).HandleAsync(Arg.Is<WebhookEvent>((p) => p != null));
+        await handler.Received(1).HandleAsync(Arg.Is<WebhookEvent>((p) => p != null), TestContext.Current.CancellationToken);
     }
 
     private GitHubWebhookDispatcher CreateTarget(

--- a/tests/Costellobot.Tests/GitHubWebhookServiceTests.cs
+++ b/tests/Costellobot.Tests/GitHubWebhookServiceTests.cs
@@ -43,7 +43,7 @@ public class GitHubWebhookServiceTests(ITestOutputHelper outputHelper)
         var args = new ProcessMessageEventArgs(
             message,
             receiver,
-            CancellationToken.None);
+            TestContext.Current.CancellationToken);
 
         // Act and Assert
         await Should.ThrowAsync<InvalidOperationException>(() => target.ProcessAsync(args));

--- a/tests/Costellobot.Tests/Handlers/CheckSuiteHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/CheckSuiteHandlerTests.cs
@@ -424,7 +424,7 @@ public class CheckSuiteHandlerTests(AppFixture fixture, ITestOutputHelper output
         var message = new Octokit.Webhooks.Events.IssueComment.IssueCommentCreatedEvent();
 
         // Act
-        await Should.NotThrowAsync(() => target.HandleAsync(message));
+        await Should.NotThrowAsync(() => target.HandleAsync(message, TestContext.Current.CancellationToken));
     }
 
     private async Task<HttpResponseMessage> PostWebhookAsync(CheckSuiteDriver driver, string action = "completed")

--- a/tests/Costellobot.Tests/Handlers/DeploymentProtectionRuleHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/DeploymentProtectionRuleHandlerTests.cs
@@ -91,7 +91,7 @@ public sealed class DeploymentProtectionRuleHandlerTests : IntegrationTests<AppF
         var message = new Octokit.Webhooks.Events.IssueComment.IssueCommentCreatedEvent();
 
         // Act
-        await Should.NotThrowAsync(() => target.HandleAsync(message));
+        await Should.NotThrowAsync(() => target.HandleAsync(message, TestContext.Current.CancellationToken));
     }
 
     protected override void Dispose(bool disposing)

--- a/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
@@ -717,7 +717,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
         var message = new Octokit.Webhooks.Events.IssueComment.IssueCommentCreatedEvent();
 
         // Act
-        await Should.NotThrowAsync(() => target.HandleAsync(message));
+        await Should.NotThrowAsync(() => target.HandleAsync(message, TestContext.Current.CancellationToken));
     }
 
     protected override void Dispose(bool disposing)

--- a/tests/Costellobot.Tests/Handlers/IssueCommentHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/IssueCommentHandlerTests.cs
@@ -84,7 +84,7 @@ public class IssueCommentHandlerTests(AppFixture fixture, ITestOutputHelper outp
         var message = new Octokit.Webhooks.Events.PullRequest.PullRequestOpenedEvent();
 
         // Act
-        await Should.NotThrowAsync(() => target.HandleAsync(message));
+        await Should.NotThrowAsync(() => target.HandleAsync(message, TestContext.Current.CancellationToken));
     }
 
     private async Task<HttpResponseMessage> PostWebhookAsync(string action, IssueCommentDriver driver)

--- a/tests/Costellobot.Tests/Handlers/NullHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/NullHandlerTests.cs
@@ -12,6 +12,6 @@ public static class NullHandlerTests
         var target = NullHandler.Instance;
 
         // Act
-        await Should.NotThrowAsync(() => target.HandleAsync(new Octokit.Webhooks.Events.PingEvent()));
+        await Should.NotThrowAsync(() => target.HandleAsync(new Octokit.Webhooks.Events.PingEvent(), TestContext.Current.CancellationToken));
     }
 }

--- a/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
@@ -592,7 +592,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
         var message = new Octokit.Webhooks.Events.IssueComment.IssueCommentCreatedEvent();
 
         // Act
-        await Should.NotThrowAsync(() => target.HandleAsync(message));
+        await Should.NotThrowAsync(() => target.HandleAsync(message, TestContext.Current.CancellationToken));
     }
 
     [Fact]

--- a/tests/Costellobot.Tests/Handlers/PullRequestReviewHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PullRequestReviewHandlerTests.cs
@@ -488,7 +488,7 @@ public class PullRequestReviewHandlerTests(AppFixture fixture, ITestOutputHelper
         var message = new Octokit.Webhooks.Events.IssueComment.IssueCommentCreatedEvent();
 
         // Act
-        await Should.NotThrowAsync(() => target.HandleAsync(message));
+        await Should.NotThrowAsync(() => target.HandleAsync(message, TestContext.Current.CancellationToken));
     }
 
     protected override async ValueTask DisposeAsync(bool disposing)

--- a/tests/Costellobot.Tests/Handlers/PushHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PushHandlerTests.cs
@@ -120,7 +120,7 @@ public class PushHandlerTests(AppFixture fixture, ITestOutputHelper outputHelper
         var message = new Octokit.Webhooks.Events.IssueComment.IssueCommentCreatedEvent();
 
         // Act
-        await Should.NotThrowAsync(() => target.HandleAsync(message));
+        await Should.NotThrowAsync(() => target.HandleAsync(message, TestContext.Current.CancellationToken));
     }
 
     private async Task<HttpResponseMessage> PostWebhookAsync(PushDriver driver)

--- a/tests/Costellobot.Tests/Handlers/RepositoryDispatchHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/RepositoryDispatchHandlerTests.cs
@@ -73,7 +73,7 @@ public sealed class RepositoryDispatchHandlerTests : IntegrationTests<AppFixture
         var message = new Octokit.Webhooks.Events.IssueComment.IssueCommentCreatedEvent();
 
         // Act
-        await Should.NotThrowAsync(() => target.HandleAsync(message));
+        await Should.NotThrowAsync(() => target.HandleAsync(message, TestContext.Current.CancellationToken));
     }
 
     private async Task<HttpResponseMessage> PostWebhookAsync(RepositoryDispatchDriver driver, string action)

--- a/tests/Costellobot.Tests/Registries/DockerPackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/DockerPackageRegistryTests.cs
@@ -31,7 +31,8 @@ public class DockerPackageRegistryTests
         var actual = await target.GetPackageOwnersAsync(
             repository,
             id,
-            version);
+            version,
+            TestContext.Current.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();

--- a/tests/Costellobot.Tests/Registries/GitHubActionsPackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/GitHubActionsPackageRegistryTests.cs
@@ -61,7 +61,8 @@ public static class GitHubActionsPackageRegistryTests
         var actual = await target.GetPackageOwnersAsync(
             repository,
             id,
-            version);
+            version,
+            TestContext.Current.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();

--- a/tests/Costellobot.Tests/Registries/GitSubmodulePackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/GitSubmodulePackageRegistryTests.cs
@@ -57,7 +57,8 @@ public static class GitSubmodulePackageRegistryTests
         var actual = await target.GetPackageOwnersAsync(
             repository,
             id,
-            version);
+            version,
+            TestContext.Current.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();

--- a/tests/Costellobot.Tests/Registries/NpmPackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/NpmPackageRegistryTests.cs
@@ -31,7 +31,8 @@ public static class NpmPackageRegistryTests
         var actual = await target.GetPackageOwnersAsync(
             repository,
             id,
-            version);
+            version,
+            TestContext.Current.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();

--- a/tests/Costellobot.Tests/Registries/NuGetPackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/NuGetPackageRegistryTests.cs
@@ -38,7 +38,8 @@ public class NuGetPackageRegistryTests(ITestOutputHelper outputHelper)
         var actual = await target.GetPackageOwnersAsync(
             repository,
             id,
-            version);
+            version,
+            TestContext.Current.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();

--- a/tests/Costellobot.Tests/Registries/RubyGemsPackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/RubyGemsPackageRegistryTests.cs
@@ -29,7 +29,8 @@ public class RubyGemsPackageRegistryTests
         var actual = await target.GetPackageOwnersAsync(
             repository,
             id,
-            version);
+            version,
+            TestContext.Current.CancellationToken);
 
         // Assert
         actual.ShouldNotBeNull();


### PR DESCRIPTION
Pass through `CancellationToken` from webhook handlers after webhooks pass one through since changes in #2474.
