### PR TITLE
Fix HTTP 500 if no delivery ID

### DIFF
--- a/src/Costellobot/GitHubMessageSerializer.cs
+++ b/src/Costellobot/GitHubMessageSerializer.cs
@@ -84,9 +84,13 @@ public sealed partial class GitHubMessageSerializer
         {
             ContentType = GitHubMessage.ContentType,
             CorrelationId = Activity.Current?.Id,
-            MessageId = deliveryId,
             Subject = GitHubMessage.Subject,
         };
+
+        if (deliveryId is { Length: > 0 })
+        {
+            message.MessageId = deliveryId;
+        }
 
         if (encoding is not null)
         {


### PR DESCRIPTION
If `X-GitHub-Delivery` is not specified, do not set the message ID to avoid an `ArgumentException` being thrown causing an HTTP 500 error.
