### PR TITLE
Update environment tag for deployment annotations

### DIFF
--- a/src/Costellobot/Handlers/RepositoryDispatchHandler.cs
+++ b/src/Costellobot/Handlers/RepositoryDispatchHandler.cs
@@ -87,7 +87,7 @@ public sealed partial class RepositoryDispatchHandler(
 
         if (!string.IsNullOrWhiteSpace(environment))
         {
-            tags.Add($"deployment.environment={environment}");
+            tags.Add($"deployment.environment.name={environment}");
         }
 
         if (!string.IsNullOrWhiteSpace(@namespace))


### PR DESCRIPTION
Update to match the semantic convention used at runtime so annotations render correctly when the environment is filtered.
