### PR TITLE
Add uptime to version response

### DIFF
--- a/src/Costellobot/ApiEndpoints.cs
+++ b/src/Costellobot/ApiEndpoints.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -12,6 +13,8 @@ namespace MartinCostello.Costellobot;
 
 public static class ApiEndpoints
 {
+    private static readonly long StartedAt = Stopwatch.GetTimestamp();
+
     public static IEndpointRouteBuilder MapApiRoutes(this IEndpointRouteBuilder builder)
     {
         builder.MapGitHubWebhooks("/github-webhook");
@@ -25,6 +28,8 @@ public static class ApiEndpoints
 
             return Results.NotFound();
         }).AllowAnonymous();
+
+        var started = Stopwatch.GetTimestamp();
 
         builder.MapGet("/version", () => new JsonObject()
         {
@@ -49,6 +54,7 @@ public static class ApiEndpoints
                 ["is64BitProcess"] = Environment.Is64BitProcess,
                 ["isNativeAoT"] = !RuntimeFeature.IsDynamicCodeSupported,
                 ["isPrivilegedProcess"] = Environment.IsPrivilegedProcess,
+                ["uptime"] = Stopwatch.GetElapsedTime(StartedAt).ToString(@"%d\.hh\:mm\:ss", CultureInfo.InvariantCulture),
             },
             ["dotnetVersions"] = new JsonObject()
             {

--- a/src/Costellobot/ApiEndpoints.cs
+++ b/src/Costellobot/ApiEndpoints.cs
@@ -29,8 +29,6 @@ public static class ApiEndpoints
             return Results.NotFound();
         }).AllowAnonymous();
 
-        var started = Stopwatch.GetTimestamp();
-
         builder.MapGet("/version", () => new JsonObject()
         {
             ["application"] = new JsonObject()

--- a/tests/Costellobot.Tests/ApiTests.cs
+++ b/tests/Costellobot.Tests/ApiTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using NuGet.Versioning;
 using static MartinCostello.Costellobot.Builders.GitHubFixtures;
 
 namespace MartinCostello.Costellobot;
@@ -112,7 +113,16 @@ public sealed class ApiTests(HttpServerFixture fixture, ITestOutputHelper output
 
         // Assert
         actual.TryGetProperty("application", out var application).ShouldBeTrue();
-        application.TryGetProperty("version", out _).ShouldBeTrue();
+
+        application.TryGetProperty("version", out var version).ShouldBeTrue();
+        version.ValueKind.ShouldBe(JsonValueKind.String);
+        NuGetVersion.TryParse(version.GetString(), out var nugetVersion).ShouldBeTrue();
+
+        actual.TryGetProperty("process", out var process).ShouldBeTrue();
+        process.TryGetProperty("uptime", out var uptime).ShouldBeTrue();
+        uptime.ValueKind.ShouldBe(JsonValueKind.String);
+        TimeSpan.TryParseExact(uptime.GetString(), @"d\.hh\:mm\:ss", CultureInfo.InvariantCulture, out var uptimeSpan).ShouldBeTrue();
+        uptimeSpan.ShouldBeGreaterThanOrEqualTo(TimeSpan.Zero);
     }
 
     [Theory]


### PR DESCRIPTION
Add the process' uptime to the response from `/version`.
