### PR TITLE
Fix QuotaExceeded ServiceBusException

### DIFF
--- a/src/Costellobot/GitHubEventHandler.cs
+++ b/src/Costellobot/GitHubEventHandler.cs
@@ -45,7 +45,7 @@ public sealed partial class GitHubEventHandler(
                     Activity.Current?.SetTag("messaging.message.conversation_id", message.CorrelationId);
                     Activity.Current?.SetTag("messaging.message.id", message.MessageId);
 
-                    var sender = client.CreateSender(config.QueueName);
+                    await using var sender = client.CreateSender(config.QueueName);
                     await sender.SendMessageAsync(message, combined.Token);
                 }
             }

--- a/tests/Costellobot.Tests/Infrastructure/InMemoryServiceBusClient.cs
+++ b/tests/Costellobot.Tests/Infrastructure/InMemoryServiceBusClient.cs
@@ -142,10 +142,33 @@ internal sealed class InMemoryServiceBusClient : ServiceBusClient
             => Task.CompletedTask;
     }
 
-    private sealed class InMemoryServiceBusSender(ChannelWriter<Payload> writer) : ServiceBusSender
+    private sealed class InMemoryServiceBusSender : ServiceBusSender
     {
+        private const int MaxHandles = 50;
+        private static int _handles;
+        private readonly ChannelWriter<Payload> _writer;
+
+        public InMemoryServiceBusSender(ChannelWriter<Payload> writer)
+        {
+            // Simulate "Cannot allocate more handles. The maximum number of handles is 4999. (QuotaExceeded)"
+            var handles = Interlocked.Increment(ref _handles);
+
+            if (handles > MaxHandles)
+            {
+                throw new InvalidOperationException($"Too many ServiceBusSender instances: {handles}.");
+            }
+
+            _writer = writer;
+        }
+
+        public override Task CloseAsync(CancellationToken cancellationToken = default)
+        {
+            _ = Interlocked.Decrement(ref _handles);
+            return Task.CompletedTask;
+        }
+
         public override async Task SendMessageAsync(ServiceBusMessage message, CancellationToken cancellationToken = default)
-            => await writer.WriteAsync(new(message.MessageId, message.ContentType, message.Subject, message.Body.ToArray()), cancellationToken);
+            => await _writer.WriteAsync(new(message.MessageId, message.ContentType, message.Subject, message.Body.ToArray()), cancellationToken);
     }
 
     private sealed record Payload(string MessageId, string ContentType, string Subject, byte[] Body);


### PR DESCRIPTION
- Fix `ServiceBusException` when publishing messages caused by `ServiceBusSender` not being disposed of by disposing of it.
- Add an artificial resource leak detector to the in-memory implementation that checks.
