### PR TITLE
Reuse ServiceBusSender

### DIFF
--- a/src/Costellobot/GitHubEventHandler.cs
+++ b/src/Costellobot/GitHubEventHandler.cs
@@ -82,17 +82,17 @@ public sealed partial class GitHubEventHandler(
 
     private ServiceBusSender EnsureSender()
     {
-        if (_sender == null)
+        var sender = _sender;
+
+        if (sender == null)
         {
             using (_lock.EnterScope())
             {
-#pragma warning disable CA1508
-                _sender ??= client.CreateSender(_queueName);
-#pragma warning restore CA1508
+                sender = _sender = client.CreateSender(_queueName);
             }
         }
 
-        return _sender;
+        return sender;
     }
 
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/src/Costellobot/GitHubEventHandler.cs
+++ b/src/Costellobot/GitHubEventHandler.cs
@@ -84,7 +84,7 @@ public sealed partial class GitHubEventHandler(
     {
         if (_sender == null)
         {
-            lock (_lock)
+            using (_lock.EnterScope())
             {
 #pragma warning disable CA1508
                 _sender ??= client.CreateSender(_queueName);


### PR DESCRIPTION
- Create a single `ServiceBusSender` in `GitHubEventHandler` and re-use for all message publishing, rather than create a new one per publish.
- Remove leak detection code.
