### PR TITLE
Enable PKCE for GitHub OAuth

### DIFF
--- a/src/Costellobot/AuthenticationEndpoints.cs
+++ b/src/Costellobot/AuthenticationEndpoints.cs
@@ -59,6 +59,7 @@ public static class AuthenticationEndpoints
                 options.ClientSecret = configuration.Value.ClientSecret;
                 options.CorrelationCookie.Name = CookiePrefix + "correlation";
                 options.EnterpriseDomain = configuration.Value.EnterpriseDomain;
+                options.UsePkce = true;
 
                 foreach (string scope in configuration.Value.Scopes)
                 {

--- a/tests/Costellobot.Tests/Infrastructure/LoopbackOAuthEvents.cs
+++ b/tests/Costellobot.Tests/Infrastructure/LoopbackOAuthEvents.cs
@@ -14,6 +14,10 @@ public sealed class LoopbackOAuthEvents : OAuthEvents
         var query = new UriBuilder(context.RedirectUri).Uri.Query;
         var queryString = HttpUtility.ParseQueryString(query);
 
+        // Ensure PKCE is in use
+        queryString["code_challenge"].ShouldNotBeNullOrWhiteSpace();
+        queryString["code_challenge_method"].ShouldBe("S256");
+
         var location = queryString["redirect_uri"];
         var state = queryString["state"];
 


### PR DESCRIPTION
Enable use of PKCE when signing in with GitHub OAuth.

See [_PKCE support for OAuth and GitHub App authentication_](https://github.blog/changelog/2025-07-14-pkce-support-for-oauth-and-github-app-authentication/).
