### PR TITLE
Speed-up OATS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,11 @@ services:
       - DOTNET_ENVIRONMENT=Production
       - GitHub__ClientId=github-client-id
       - GitHub__ClientSecret=github-client-secret
+      - OTEL_BLRP_SCHEDULE_DELAY=2000
+      - OTEL_BSP_SCHEDULE_DELAY=2000
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://lgtm:4318
       - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_METRIC_EXPORT_INTERVAL=2000
       - Webhook__QueueName=queue.1
       - WEBSITE_SITE_NAME=Costellobot
   servicebus-emulator:


### PR DESCRIPTION
Export telemetry signals every 2 seconds to speed up the tests.
