### PR TITLE
Add custom metrics

### DIFF
--- a/src/Costellobot/ApplicationTelemetry.cs
+++ b/src/Costellobot/ApplicationTelemetry.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using OpenTelemetry;
 using OpenTelemetry.Resources;
 using Pyroscope;
@@ -14,6 +15,7 @@ public static class ApplicationTelemetry
     public static readonly string ServiceNamespace = "Costellobot";
     public static readonly string ServiceVersion = GitMetadata.Version.Split('+')[0];
     public static readonly ActivitySource ActivitySource = new(ServiceName, ServiceVersion);
+    public static readonly Meter Meter = new(ServiceName, ServiceVersion);
 
     public static ResourceBuilder ResourceBuilder { get; } = ResourceBuilder.CreateDefault()
         .AddService(ServiceName, ServiceNamespace, ServiceVersion)

--- a/src/Costellobot/CostellobotBuilder.cs
+++ b/src/Costellobot/CostellobotBuilder.cs
@@ -48,6 +48,9 @@ public static class CostellobotBuilder
             options.Providers.Add<GzipCompressionProvider>();
         });
 
+        builder.Services.AddMetrics();
+        builder.Services.AddSingleton<CostellobotMetrics>();
+
         builder.Services.AddSignalR();
         builder.Services.AddSingleton<ClientLogQueue>();
         builder.Services.AddHostedService<ClientLogBroadcastService>();

--- a/src/Costellobot/CostellobotMetrics.cs
+++ b/src/Costellobot/CostellobotMetrics.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Metrics;
+
+namespace MartinCostello.Costellobot;
+
+public sealed class CostellobotMetrics : IDisposable
+{
+    private readonly Meter _meter;
+    private readonly Counter<long> _webhookDeliveriesCounter;
+
+    public CostellobotMetrics(IMeterFactory meterFactory)
+    {
+        _meter = meterFactory.Create(ApplicationTelemetry.ServiceName, ApplicationTelemetry.ServiceVersion);
+
+        _webhookDeliveriesCounter = _meter.CreateCounter<long>(
+            "costellobot.github.webhook.delivery",
+            unit: "{count}",
+            description: "The number of GitHub webhook deliveries received.");
+    }
+
+    public void Dispose() => _meter?.Dispose();
+
+    public void WebhookDelivery(string? @event, string? targetId)
+        => _webhookDeliveriesCounter.Add(
+               1,
+               new KeyValuePair<string, object?>("github.webhook.event", @event),
+               new KeyValuePair<string, object?>("github.webhook.hook.installation.target.id", targetId));
+}

--- a/src/Costellobot/GitHubEventProcessor.cs
+++ b/src/Costellobot/GitHubEventProcessor.cs
@@ -12,6 +12,7 @@ namespace MartinCostello.Costellobot;
 public sealed partial class GitHubEventProcessor(
     GitHubEventHandler handler,
     IHubContext<GitHubWebhookHub, IWebhookClient> hub,
+    CostellobotMetrics metrics,
     IOptionsMonitor<WebhookOptions> options,
     ILogger<GitHubEventProcessor> logger) : WebhookEventProcessor
 {
@@ -48,6 +49,8 @@ public sealed partial class GitHubEventProcessor(
 
         using (logger.BeginWebhookScope(webhookHeaders))
         {
+            metrics.WebhookDelivery(webhookHeaders.Event, webhookHeaders.HookInstallationTargetId);
+
             var webhookEvent = DeserializeWebhookEvent(webhookHeaders, body);
 
             using (logger.BeginWebhookScope(webhookEvent))

--- a/src/Costellobot/TelemetryExtensions.cs
+++ b/src/Costellobot/TelemetryExtensions.cs
@@ -29,6 +29,7 @@ public static class TelemetryExtensions
                           .AddAspNetCoreInstrumentation()
                           .AddHttpClientInstrumentation()
                           .AddProcessInstrumentation()
+                          .AddMeter(ApplicationTelemetry.ServiceName)
                           .AddMeter("System.Runtime");
                })
                .WithTracing((builder) =>

--- a/tests/Costellobot.Oats/oats.yml
+++ b/tests/Costellobot.Oats/oats.yml
@@ -43,6 +43,8 @@ expected:
       contains:
         - 'Application started'
   metrics:
+    - promql: costellobot.github.webhook.delivery{ github_webhook_event="ping" }
+      value: '>= 0'
     - promql: dotnet_process_memory_working_set_bytes{}
       value: '>= 0'
     - promql: http_client_request_duration_seconds_count{}


### PR DESCRIPTION
Add custom metrics, with an initial counter for the types of GitHub webhook payloads received.
