### PR TITLE
Avoid obsolete warning

### DIFF
--- a/src/Costellobot/CostellobotBuilder.cs
+++ b/src/Costellobot/CostellobotBuilder.cs
@@ -27,7 +27,7 @@ public static class CostellobotBuilder
 
         if (builder.Configuration["ConnectionStrings:AzureBlobStorage"] is { Length: > 0 })
         {
-            builder.AddAzureBlobClient("AzureBlobStorage", (p) => p.Credential = credential);
+            builder.AddAzureBlobServiceClient("AzureBlobStorage", (p) => p.Credential = credential);
         }
 
         if (builder.Configuration["ConnectionStrings:AzureTableStorage"] is { Length: > 0 })


### PR DESCRIPTION
Use `AddAzureBlobServiceClient()` instead of `AddAzureBlobClient()`, which is obsolete in Aspire 9.4.0.
