### PR TITLE
Revoke trust if attestation lost

### DIFF
--- a/src/Costellobot/GitCommitAnalyzer.cs
+++ b/src/Costellobot/GitCommitAnalyzer.cs
@@ -495,7 +495,12 @@ public sealed partial class GitCommitAnalyzer(
                         // Revoke trust if any dependencies lost their attestation
                         Log.PackageIsNoLongerAttested(logger, dependency, update.Previous, update.Version, ecosystem);
                         dependencyTrust[dependency] = (false, update.Version);
-                        break;
+
+                        if (stopAfterFirstUntrustedDependency)
+                        {
+                            // We only care if all dependencies are trusted, so stop looking on the first failure
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
If a dependency update moves from an attested version to an unattested version, revoke any positive trust decisions.

This should mitigate against an otherwise trusted dependency having a new compromised version published similar to GHSA-f29h-pxvx-f335 but being auto-approved and merged.
