### PR TITLE
Use docker data source for zizmor

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ env:
   # renovate: datasource=github-releases depName=PSScriptAnalyzer packageName=PowerShell/PSScriptAnalyzer
   PSSCRIPTANALYZER_VERSION: '1.24.0'
   TERM: xterm
-  # renovate: datasource=github-releases depName=zizmor packageName=zizmorcore/zizmor
+  # renovate: datasource=docker depName=zizmor packageName=ghcr.io/zizmorcore/zizmor
   ZIZMOR_VERSION: '1.12.0'
 
 jobs:


### PR DESCRIPTION
Don't assume that the image exists in ghcr.io just because there's a new GitHub release.

https://github.com/zizmorcore/zizmor/issues/1077#issuecomment-3184430742
