### PR TITLE
Revert "Use docker data source for zizmor"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ env:
   # renovate: datasource=github-releases depName=PSScriptAnalyzer packageName=PowerShell/PSScriptAnalyzer
   PSSCRIPTANALYZER_VERSION: '1.24.0'
   TERM: xterm
-  # renovate: datasource=docker depName=zizmor packageName=ghcr.io/zizmorcore/zizmor
+  # renovate: datasource=github-releases depName=zizmor packageName=zizmorcore/zizmor
   ZIZMOR_VERSION: '1.12.0'
 
 jobs:


### PR DESCRIPTION
Reverts martincostello/costellobot#2633 as renovate tries to pin it, which fails and generates an error.

For now just accept the lag until I can work out how to configure it to do the intended thing.
