### PR TITLE
Trust Microsoft.DotNet.XliffTasks

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -208,6 +208,7 @@
         "^dotnet-sdk$",
         "^eslint$",
         "^Microsoft\\.AspNetCore\\..*$",
+        "^Microsoft\\.DotNet\\.XliffTasks$",
         "^Microsoft\\.EntityFrameworkCore\\..*$",
         "^Microsoft\\.Extensions\\..*$",
         "^Microsoft\\.NET\\.Sdk$",


### PR DESCRIPTION
Trust the `Microsoft.DotNet.XliffTasks` dependency by name, as it's published from the .NET internal engineering systems so the publisher can't be determined from a lookup to the NuGet API.
