### PR TITLE
Refactor HttpClient creation

### DIFF
--- a/tests/Costellobot.Tests/HealthCheckTests.cs
+++ b/tests/Costellobot.Tests/HealthCheckTests.cs
@@ -24,7 +24,7 @@ public sealed class HealthCheckTests(HttpServerFixture fixture, ITestOutputHelpe
     public async Task Cannot_Get_Health_Resource_Unauthenticated(string requestUri)
     {
         // Arrange
-        using var client = Fixture.CreateClient();
+        using var client = Fixture.CreateHttpClientForApp();
 
         // Act
         using var response = await client.GetAsync(requestUri, CancellationToken);
@@ -39,7 +39,7 @@ public sealed class HealthCheckTests(HttpServerFixture fixture, ITestOutputHelpe
     public async Task Cannot_Get_Health_Resource_Unauthenticated_With_Invalid_Token(string requestUri)
     {
         // Arrange
-        using var client = Fixture.CreateClient();
+        using var client = Fixture.CreateHttpClientForApp();
 
         client.DefaultRequestHeaders.Add("x-ms-auth-internal-token", "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=");
 
@@ -56,7 +56,7 @@ public sealed class HealthCheckTests(HttpServerFixture fixture, ITestOutputHelpe
     public async Task Can_Get_Health_Resource_Unauthenticated_With_Token(string requestUri)
     {
         // Arrange
-        using var client = Fixture.CreateClient();
+        using var client = Fixture.CreateHttpClientForApp();
         client.DefaultRequestHeaders.Add("x-ms-auth-internal-token", "I3eGXFWsxHOxEhULepTolmX9jSd/rcSs9CAjao2DgGk=");
 
         // Act

--- a/tests/Costellobot.Tests/Infrastructure/AppFixture.cs
+++ b/tests/Costellobot.Tests/Infrastructure/AppFixture.cs
@@ -59,7 +59,8 @@ public class AppFixture : WebApplicationFactory<Program>, ITestOutputHelperAcces
     public async Task ClearCacheAsync() =>
         await Services.GetRequiredService<HybridCache>().RemoveByTagAsync("all");
 
-    public virtual HttpClient CreateHttpClientForApp() => CreateDefaultClient();
+    public virtual HttpClient CreateHttpClientForApp(params DelegatingHandler[] handlers)
+        => CreateDefaultClient(handlers);
 
     public void OverrideConfiguration(string key, string value, bool reload = true)
     {

--- a/tests/Costellobot.Tests/Infrastructure/HttpServerFixture.cs
+++ b/tests/Costellobot.Tests/Infrastructure/HttpServerFixture.cs
@@ -43,13 +43,25 @@ public sealed class HttpServerFixture : AppFixture
         }
     }
 
-    public override HttpClient CreateHttpClientForApp()
+    public override HttpClient CreateHttpClientForApp(params DelegatingHandler[] handlers)
     {
-        var handler = new HttpClientHandler()
+        HttpMessageHandler handler = new HttpClientHandler()
         {
+            AllowAutoRedirect = ClientOptions.AllowAutoRedirect,
             CheckCertificateRevocationList = true,
             ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
         };
+
+        if (handlers.Length > 0)
+        {
+            for (var i = handlers.Length - 1; i > 0; i--)
+            {
+                handlers[i - 1].InnerHandler = handlers[i];
+            }
+
+            handlers[^1].InnerHandler = handler;
+            handler = handlers[0];
+        }
 
         return new HttpClient(handler, disposeHandler: true)
         {

--- a/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
+++ b/tests/Costellobot.Tests/Infrastructure/IntegrationTests`1.cs
@@ -122,7 +122,7 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
             Fixture.ServerUri,
             new Cookie(anonymousTokens.CookieName, anonymousTokens.CookieValue));
 
-        using var anonymousClient = Fixture.CreateDefaultClient(redirectHandler, anonymousCookieHandler);
+        using var anonymousClient = Fixture.CreateHttpClientForApp(redirectHandler, anonymousCookieHandler);
         anonymousClient.DefaultRequestHeaders.Add(anonymousTokens.HeaderName, anonymousTokens.RequestToken);
 
         using var content = new FormUrlEncodedContent([]);
@@ -136,7 +136,7 @@ public abstract class IntegrationTests<T> : IAsyncLifetime, IDisposable
 
         try
         {
-            var authenticatedClient = Fixture.CreateDefaultClient(authenticatedCookieHandler);
+            var authenticatedClient = Fixture.CreateHttpClientForApp(authenticatedCookieHandler);
 
             try
             {

--- a/tests/Costellobot.Tests/ResourceTests.cs
+++ b/tests/Costellobot.Tests/ResourceTests.cs
@@ -83,7 +83,7 @@ public sealed class ResourceTests(HttpServerFixture fixture, ITestOutputHelper o
     public async Task Cannot_Get_Resource_Unauthenticated(string requestUri)
     {
         // Arrange
-        using var client = Fixture.CreateClient();
+        using var client = Fixture.CreateHttpClientForApp();
 
         // Act
         using var response = await client.GetAsync(requestUri, CancellationToken);
@@ -307,7 +307,7 @@ public sealed class ResourceTests(HttpServerFixture fixture, ITestOutputHelper o
         // Arrange
         HttpMethod[] methods = [HttpMethod.Get, HttpMethod.Head, HttpMethod.Post];
 
-        using var client = Fixture.CreateClient();
+        using var client = Fixture.CreateHttpClientForApp();
 
         foreach (var method in methods)
         {


### PR DESCRIPTION
Refactor after changes from #2645 broke the tests for .NET 10 using Kestrel with `WebApplicationFactory<T>`.
