### PR TITLE
Prepare for renovate app rename

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,7 +220,7 @@ jobs:
         !cancelled() &&
         steps.build.outcome == 'failure' &&
         github.event.repository.fork == false &&
-        !contains(fromJSON('["dependabot[bot]", "github-actions[bot]", "renovate[bot]"]'), github.event.pull_request.user.login)
+        !contains(fromJSON('["dependabot[bot]", "github-actions[bot]", "mend[bot]", "renovate[bot]"]'), github.event.pull_request.user.login)
       env:
         AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.CRASH_DUMPS_STORAGE_CONNECTION_STRING }}
         # renovate: datasource=github-releases depName=PSCompression packageName=santisq/PSCompression

--- a/src/Costellobot/Handlers/PullRequestReviewHandler.cs
+++ b/src/Costellobot/Handlers/PullRequestReviewHandler.cs
@@ -22,7 +22,7 @@ public sealed partial class PullRequestReviewHandler(
 
     private static readonly HybridCacheEntryOptions CacheEntryOptions = new() { Expiration = TimeSpan.FromDays(1) };
     private static readonly string[] CacheTags = ["all", "github"];
-    private static readonly string[] PullRequestCreators = ["app/dependabot", "app/renovate"];
+    private static readonly string[] PullRequestCreators = ["app/dependabot", "app/mend", "app/renovate"];
 
     public async Task HandleAsync(WebhookEvent message, CancellationToken cancellationToken)
     {

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -275,6 +275,7 @@
         "costellorgbot[bot]",
         "dependabot[bot]",
         "github-actions[bot]",
+        "mend[bot]",
         "renovate[bot]"
       ]
     }


### PR DESCRIPTION
Handle `mend` as the rename for the `renovate` GitHub app.

Contributes to #2737.
