### PR TITLE
Do not cache redirects

### DIFF
--- a/src/Costellobot/ApiEndpoints.cs
+++ b/src/Costellobot/ApiEndpoints.cs
@@ -19,10 +19,17 @@ public static class ApiEndpoints
     {
         builder.MapGitHubWebhooks("/github-webhook");
 
-        builder.MapGet("/badge/{type}/{owner}/{repo}", async (string type, string owner, string repo, [FromQuery(Name = "s")] string? signature, BadgeService service) =>
+        builder.MapGet("/badge/{type}/{owner}/{repo}", async (
+            string type,
+            string owner,
+            string repo,
+            [FromQuery(Name = "s")] string? signature,
+            BadgeService service,
+            HttpResponse response) =>
         {
-            if (await service.GetBadgeAsync(type, owner, repo, signature) is { } url)
+            if (await service.GetBadgeAsync(type, owner, repo, signature) is { Length: > 0 } url)
             {
+                response.GetTypedHeaders().CacheControl = new() { NoCache = true };
                 return Results.Redirect(url);
             }
 

--- a/tests/Costellobot.Tests/BadgeTests.cs
+++ b/tests/Costellobot.Tests/BadgeTests.cs
@@ -73,6 +73,8 @@ public sealed class BadgeTests(AppFixture fixture, ITestOutputHelper outputHelpe
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
         response.Headers.Location.ShouldBe(new("https://img.shields.io/badge/security-0-brightgreen?logo=github"));
+        response.Headers.CacheControl.ShouldNotBeNull();
+        response.Headers.CacheControl.NoCache.ShouldBeTrue();
     }
 
     [Fact]
@@ -97,6 +99,8 @@ public sealed class BadgeTests(AppFixture fixture, ITestOutputHelper outputHelpe
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
         response.Headers.Location.ShouldBe(new("https://img.shields.io/badge/security-0-brightgreen?logo=github"));
+        response.Headers.CacheControl.ShouldNotBeNull();
+        response.Headers.CacheControl.NoCache.ShouldBeTrue();
     }
 
     [Fact]
@@ -121,6 +125,8 @@ public sealed class BadgeTests(AppFixture fixture, ITestOutputHelper outputHelpe
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
         response.Headers.Location.ShouldBe(new("https://img.shields.io/badge/security-9-red?logo=github"));
+        response.Headers.CacheControl.ShouldNotBeNull();
+        response.Headers.CacheControl.NoCache.ShouldBeTrue();
 
         static object[] Alerts(int count)
             => [.. Enumerable.Range(0, count).Select((i) => new { })];
@@ -175,6 +181,8 @@ public sealed class BadgeTests(AppFixture fixture, ITestOutputHelper outputHelpe
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.Redirect);
         response.Headers.Location.ShouldBe(new($"https://img.shields.io/badge/release-{expected}-blue?logo=github"));
+        response.Headers.CacheControl.ShouldNotBeNull();
+        response.Headers.CacheControl.NoCache.ShouldBeTrue();
     }
 
     private static string CreateSignature(string type, string owner, string repo)


### PR DESCRIPTION
Set an explicit No-Cache header for redirects served by the badge endpoint.
