### PR TITLE
Remove KubernetesClient version override

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,8 +29,6 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="JunitXml.TestLogger" Version="6.1.0" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="5.1.2" />
-    <!-- HACK Resolves GHSA-w7r3-mgwf-4mqq -->
-    <PackageVersion Include="KubernetesClient" Version="17.0.14" />
     <PackageVersion Include="Markdig" Version="0.42.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.6.0" />
     <PackageVersion Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="9.0.9" />


### PR DESCRIPTION
Remove package version override for KubernetesClient as this is resolved in Aspire 9.5.
