### PR TITLE
Add JSON endpoint for badges

### DIFF
--- a/src/Costellobot/ApiEndpoints.cs
+++ b/src/Costellobot/ApiEndpoints.cs
@@ -2,16 +2,19 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using MartinCostello.Costellobot.Models;
 using Microsoft.AspNetCore.Mvc;
 using Octokit.Webhooks.AspNetCore;
 
 namespace MartinCostello.Costellobot;
 
-public static class ApiEndpoints
+public static partial class ApiEndpoints
 {
     private static readonly long StartedAt = Stopwatch.GetTimestamp();
 
@@ -27,10 +30,27 @@ public static class ApiEndpoints
             BadgeService service,
             HttpResponse response) =>
         {
-            if (await service.GetBadgeAsync(type, owner, repo, signature) is { Length: > 0 } url)
+            if (await service.GetBadgeUrlAsync(type, owner, repo, signature) is { Length: > 0 } url)
             {
                 response.GetTypedHeaders().CacheControl = new() { NoCache = true };
                 return Results.Redirect(url);
+            }
+
+            return Results.NotFound();
+        }).AllowAnonymous();
+
+        builder.MapGet("/badge/{type}/{owner}/{repo}.json", async (
+            string type,
+            string owner,
+            string repo,
+            [FromQuery(Name = "s")] string? signature,
+            BadgeService service,
+            HttpResponse response) =>
+        {
+            if (await service.GetBadgeAsync(type, owner, repo, signature) is { } badge)
+            {
+                response.GetTypedHeaders().CacheControl = new() { NoCache = true };
+                return Results.Json(badge, BadgeJsonSerializerContext.Default.Badge);
             }
 
             return Results.NotFound();
@@ -81,4 +101,8 @@ public static class ApiEndpoints
         static string GetVersion<T>()
             => typeof(T).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
     }
+
+    [ExcludeFromCodeCoverage]
+    [JsonSerializable(typeof(Badge))]
+    private sealed partial class BadgeJsonSerializerContext : JsonSerializerContext;
 }

--- a/src/Costellobot/Models/Badge.cs
+++ b/src/Costellobot/Models/Badge.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json.Serialization;
+
+namespace MartinCostello.Costellobot.Models;
+
+public sealed class Badge
+{
+    [JsonPropertyName("schemaVersion")]
+    public required int SchemaVersion { get; init; }
+
+    [JsonPropertyName("label")]
+    public required string Label { get; init; }
+
+    [JsonPropertyName("message")]
+    public required string Message { get; init; }
+
+    [JsonPropertyName("color")]
+    public required string Color { get; init; }
+
+    [JsonPropertyName("isError")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool IsError { get; set; }
+
+    [JsonPropertyName("namedLogo")]
+    public required string NamedLogo { get; init; }
+}


### PR DESCRIPTION
Add a JSON variant for the badge endpoint to use with shields.io endpoint badges.

See [Endpoint Badge | Shields.io](https://shields.io/badges/endpoint-badge).
