### PR TITLE
Bump OpenTelemetry.Resources.Host

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -56,7 +56,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.12.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.Azure" Version="1.12.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.Container" Version="1.12.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Resources.Host" Version="1.12.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Resources.Host" Version="1.13.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.OperatingSystem" Version="1.12.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.ProcessRuntime" Version="1.12.0-beta.1" />
     <PackageVersion Include="Polly.Extensions" Version="8.6.4" />


### PR DESCRIPTION
Update OpenTelemetry.Resources.Host to version 1.13.0-beta.1.
