### PR TITLE
Update OpenTelemetry libraries

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,12 +53,12 @@
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.13.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.13.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.13.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.12.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Resources.Azure" Version="1.12.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Resources.Container" Version="1.12.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.13.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Resources.Azure" Version="1.13.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Resources.Container" Version="1.13.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Resources.Host" Version="1.13.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Resources.OperatingSystem" Version="1.12.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Resources.ProcessRuntime" Version="1.12.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Resources.OperatingSystem" Version="1.13.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Resources.ProcessRuntime" Version="1.13.0-beta.1" />
     <PackageVersion Include="Polly.Extensions" Version="8.6.4" />
     <PackageVersion Include="Polly.RateLimiting" Version="8.6.4" />
     <PackageVersion Include="Pyroscope" Version="0.13.0" />


### PR DESCRIPTION
Update OpenTelemetry versions to 1.13.0-beta.1.
