### PR TITLE
Trust Google NuGet packages

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -256,6 +256,7 @@
           "dotnetframework",
           "EntityFramework",
           "GitHub",
+          "google-apis-packages",
           "martin_costello",
           "Microsoft",
           "NodaTime",


### PR DESCRIPTION
Trust NuGet packages owned by `google-apis-packages`.
