### PR TITLE
Fix connect-src CSP

### DIFF
--- a/src/Costellobot/CustomHttpHeadersMiddleware.cs
+++ b/src/Costellobot/CustomHttpHeadersMiddleware.cs
@@ -18,7 +18,7 @@ public sealed class CustomHttpHeadersMiddleware(RequestDelegate next)
         "style-src-elem 'self' cdnjs.cloudflare.com use.fontawesome.com",
         "img-src 'self' data: avatars.githubusercontent.com cdn.martincostello.com",
         "font-src 'self' cdnjs.cloudflare.com use.fontawesome.com",
-        "connect-src 'self' {1}",
+        "connect-src 'self' cdnjs.cloudflare.com {1}",
         "media-src 'none'",
         "object-src 'none'",
         "child-src 'none'",


### PR DESCRIPTION
Allow downloading source maps from `cdnjs.cloudflare.com`.

```text
Connecting to 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.8/js/bootstrap.bundle.min.js.map' violates the following Content Security Policy directive: "connect-src 'self' faro-collector-prod-gb-south-0.grafana.net". The request has been blocked.
Connecting to 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.8/css/bootstrap.min.css.map' violates the following Content Security Policy directive: "connect-src 'self' faro-collector-prod-gb-south-0.grafana.net". The request has been blocked.
```