### PR TITLE
Trust the protobuf-packages publisher

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -263,6 +263,7 @@
           "OpenTelemetry",
           "Polly",
           "PowerShellTeam",
+          "protobuf-packages",
           "xunit"
         ]
       },


### PR DESCRIPTION
Trust NuGet packages that are owned by `protobuf-packages`.
