### PR TITLE
Fix workflow warning

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,5 +1,0 @@
-paths:
-  .github/workflows/build.yml:
-    ignore:
-      # Depends on https://github.com/rhysd/actionlint/pull/602
-      - 'unknown permission scope "artifact-metadata"'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,6 @@ jobs:
       container-tag: ${{ steps.publish-container.outputs.container-tag }}
 
     permissions:
-      artifact-metadata: write
       attestations: write
       contents: read
       id-token: write
@@ -158,6 +157,7 @@ jobs:
       uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8 # v3.1.0
       if: steps.publish-container.outputs.container-digest != ''
       with:
+        create-storage-record: false
         push-to-registry: true
         subject-digest: ${{ steps.publish-container.outputs.container-digest }}
         subject-name: ${{ steps.publish-container.outputs.container-image }}


### PR DESCRIPTION
The original fix doesn't appear to work, so just disable the feature.

See https://github.com/actions/attest-build-provenance/issues/781.
