### PR TITLE
Update SQL Server image to 2025

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - MSSQL_SA_PASSWORD=C0st3ll0b0t$
       - SQL_SERVER=sql-server:1433
   sql-server:
-    image: mcr.microsoft.com/mssql/server:2025-RTM-ubuntu-22.04@sha256:54b23ca766287dab5f6f55162923325f07cdec6ccb42108f37c55c87e7688ebd
+    image: mcr.microsoft.com/mssql/server:2025-latest@sha256:54b23ca766287dab5f6f55162923325f07cdec6ccb42108f37c55c87e7688ebd
     ports:
       - '1433:1433'
     environment:


### PR DESCRIPTION
Update SQL Server image to 2025 from 2022 for OATs tests.
