### PR TITLE
Remove peer.service attribute

### DIFF
--- a/src/Costellobot/TelemetryExtensions.cs
+++ b/src/Costellobot/TelemetryExtensions.cs
@@ -57,7 +57,6 @@ public static class TelemetryExtensions
         services.AddOptions<HttpClientTraceInstrumentationOptions>()
                 .Configure((options) =>
                 {
-                    options.EnrichWithHttpRequestMessage = EnrichHttpActivity;
                     options.EnrichWithHttpResponseMessage = EnrichHttpActivity;
                     options.RecordException = true;
                 });
@@ -73,17 +72,6 @@ public static class TelemetryExtensions
                         }
                     };
                 });
-    }
-
-    private static void EnrichHttpActivity(Activity activity, HttpRequestMessage request)
-    {
-        if (GetTag("server.address", activity.Tags) is { Length: > 0 } hostName)
-        {
-            activity.AddTag("peer.service", hostName);
-        }
-
-        static string? GetTag(string name, IEnumerable<KeyValuePair<string, string?>> tags)
-            => tags.FirstOrDefault((p) => p.Key == name).Value;
     }
 
     private static void EnrichHttpActivity(Activity activity, HttpResponseMessage response)


### PR DESCRIPTION
Remove `peer.service`, which is replaced by `service.peer.name`, which itself should be a service name not an arbitrary hostname.
