### PR TITLE
Fix renovate comment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PYROSCOPE_ARCH: 'x86_64'
         PYROSCOPE_VARIANT: 'glibc'
-        # renovate: datasource=github-releases depName=pyroscope-dotnet packageName=grafana/pyroscope-dotnet
+        # renovate: datasource=nuget depName=Pyroscope packageName=Pyroscope
         PYROSCOPE_VERSION: '0.10.0'
         SentryAuthToken: ${{ secrets.SENTRY_TOKEN }}
         UsePyroscope: 'true'


### PR DESCRIPTION
Tie to the NuGet package not GitHub releases as they aren't working due to the tag prefixes.
