### PR TITLE
Update pyroscope to 0.14.0-rc.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
         PYROSCOPE_ARCH: 'x86_64'
         PYROSCOPE_VARIANT: 'glibc'
         # renovate: datasource=nuget depName=Pyroscope packageName=Pyroscope
-        PYROSCOPE_VERSION: '0.14.0-rc.1'
+        PYROSCOPE_VERSION: '0.14.0-rc.2'
         SentryAuthToken: ${{ secrets.SENTRY_TOKEN }}
         UsePyroscope: 'true'
       run: |


### PR DESCRIPTION
Update to 0.14.0-rc.2 to continue investigating where profiles broke compared to 0.14.1.
