### PR TITLE
Set Grafana HTTP timeout

### DIFF
--- a/src/Costellobot/GitHubExtensions.cs
+++ b/src/Costellobot/GitHubExtensions.cs
@@ -180,6 +180,7 @@ public static class GitHubExtensions
             client.BaseAddress = new(options.Url, UriKind.Absolute);
             client.DefaultRequestHeaders.Accept.Add(new("application/json"));
             client.DefaultRequestHeaders.Authorization = new("Bearer", options.Token);
+            client.Timeout = options.Timeout;
         });
 
         services.AddHostedService<GitHubWebhookService>();

--- a/src/Costellobot/GrafanaOptions.cs
+++ b/src/Costellobot/GrafanaOptions.cs
@@ -5,6 +5,8 @@ namespace MartinCostello.Costellobot;
 
 public sealed class GrafanaOptions
 {
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+
     public string Token { get; set; } = string.Empty;
 
     public string Url { get; set; } = string.Empty;

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -70,6 +70,7 @@
     "Scopes": ["https://www.googleapis.com/auth/calendar.readonly"]
   },
   "Grafana": {
+    "Timeout": "00:00:30",
     "Token": "",
     "Url": "https://grafana.martincostello.com"
   },


### PR DESCRIPTION
Set the HTTP timeout for adding deployment annotations in Grafana to 30 seconds to avoid HTTP request timeouts when the stack isn't running.
