### PR TITLE
Migrate to actions/attest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
         dotnet publish ./src/Costellobot --arch x64 --os linux -p:PublishProfile=DefaultContainer
 
     - name: Attest container image
-      uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
       if: steps.publish-container.outputs.container-digest != ''
       with:
         create-storage-record: false


### PR DESCRIPTION
Migrate from now-deprecated attestation action to `actions/attest`.
