### PR TITLE
Change README code block from PowerShell to console

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ to be installed.
 To build and test the application locally from a terminal/command-line, run the
 following set of commands:
 
-```powershell
+```console
 git clone https://github.com/martincostello/costellobot.git
 cd costellobot
 ./build.ps1


### PR DESCRIPTION
Change the README code snippet from using a `powershell` code block to a `console` code block for a more generic terminal example.

Closes #3151

Generated with [Claude Code](https://claude.ai/code)
