### PR TITLE
Disable secrets-outside-env audit

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -5,5 +5,7 @@ rules:
     disable: true
   dependabot-cooldown:
     disable: true
+  secrets-outside-env:
+    disable: true
   undocumented-permissions:
     disable: true


### PR DESCRIPTION
This isn't appropriate in most cases as there's no logical environment, and environments are already used in cases where they are.
