### PR TITLE
Remove rate property from HTTP test stub

### DIFF
--- a/tests/Costellobot.Tests/ConfigurationTests.cs
+++ b/tests/Costellobot.Tests/ConfigurationTests.cs
@@ -40,13 +40,6 @@ public class ConfigurationTests(HttpServerFixture fixture, ITestOutputHelper out
                     reset = inOneHour,
                 },
             },
-            rate = new
-            {
-                limit = 12_500,
-                used = 1,
-                remaining = 12_499,
-                reset = inOneHour,
-            },
         };
 
         CreateDefaultBuilder()


### PR DESCRIPTION
Remove the `rate` property which is deprecated in future API versions. See [Version 2026-03-10](https://docs.github.com/en/rest/about-the-rest-api/breaking-changes?apiVersion=2026-03-10#version-2026-03-10).
