### PR TITLE
Remove aquasecurity/trivy-action trust

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -206,7 +206,6 @@
         "^@typescript-eslint\/eslint-plugin$",
         "^@typescript-eslint\/parser$",
         "^anchore\/sbom-action$",
-        "^aquasecurity\/trivy-action$",
         "^AspNet\\.Security\\.OAuth\\..*$",
         "^BenchmarkDotNet$",
         "^dotnet-sdk$",


### PR DESCRIPTION
Removed aquasecurity/trivy-action from the trusted actions list.
