### PR TITLE
Add benchmarks timeout

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,6 +25,7 @@ jobs:
   benchmark:
     name: benchmark
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.event.repository.fork == false
 
     permissions:


### PR DESCRIPTION
Cancel the job if it takes longer than 30 minutes.
