### PR TITLE
Remove github-actions from trusted users

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -282,7 +282,6 @@
         "costellobot[bot]",
         "costellorgbot[bot]",
         "dependabot[bot]",
-        "github-actions[bot]",
         "renovate[bot]"
       ]
     }


### PR DESCRIPTION
Remove `github-actions[bot]` from the list of trusted users given that it shouldn't be generating any PRs in repos I own anymore.
