### PR TITLE
Check user ID as well as login

### DIFF
--- a/src/Costellobot/Handlers/CheckSuiteHandler.cs
+++ b/src/Costellobot/Handlers/CheckSuiteHandler.cs
@@ -207,7 +207,7 @@ public sealed partial class CheckSuiteHandler(
 
         var options = context.WebhookOptions;
 
-        if (options.TrustedEntities.Users.Contains(author.User.Login, StringComparer.Ordinal))
+        if (options.TrustedEntities.Users.TryGetValue(author.User.Login, out var id) && author.User.Id == id)
         {
             return true;
         }

--- a/src/Costellobot/Handlers/CheckSuiteHandler.cs
+++ b/src/Costellobot/Handlers/CheckSuiteHandler.cs
@@ -221,7 +221,7 @@ public sealed partial class CheckSuiteHandler(
 
         if (!isTrusted)
         {
-            Log.IgnoringUntrustedUser(logger, checkSuiteId, repository, author.User.Login);
+            Log.IgnoringUntrustedUser(logger, checkSuiteId, repository, author.User.Login, author.User.Id);
         }
 
         return isTrusted;
@@ -404,12 +404,13 @@ public sealed partial class CheckSuiteHandler(
         [LoggerMessage(
             EventId = 15,
             Level = LogLevel.Debug,
-            Message = "Ignoring check suite ID {CheckSuiteId} for {Repository} as it is associated with a pull request from untrusted user {Login}.")]
+            Message = "Ignoring check suite ID {CheckSuiteId} for {Repository} as it is associated with a pull request from untrusted user {Login} ({UserId}).")]
         public static partial void IgnoringUntrustedUser(
             ILogger logger,
             long checkSuiteId,
             RepositoryId repository,
-            string login);
+            string login,
+            long userId);
 
         [LoggerMessage(
             EventId = 16,

--- a/src/Costellobot/Handlers/DeploymentStatusHandler.cs
+++ b/src/Costellobot/Handlers/DeploymentStatusHandler.cs
@@ -336,7 +336,8 @@ public sealed partial class DeploymentStatusHandler(
                 continue;
             }
 
-            if (!context.WebhookOptions.TrustedEntities.Users.Contains(commit.Author.Login))
+            if (!context.WebhookOptions.TrustedEntities.Users.TryGetValue(commit.Author.Login, out var id) ||
+                commit.Author.Id != id)
             {
                 Log.UntrustedCommitAuthorFound(logger, pendingDeployment.Id, repository, commit.Sha, commit.Author.Login);
                 return false;

--- a/src/Costellobot/Handlers/DeploymentStatusHandler.cs
+++ b/src/Costellobot/Handlers/DeploymentStatusHandler.cs
@@ -339,7 +339,14 @@ public sealed partial class DeploymentStatusHandler(
             if (!context.WebhookOptions.TrustedEntities.Users.TryGetValue(commit.Author.Login, out var id) ||
                 commit.Author.Id != id)
             {
-                Log.UntrustedCommitAuthorFound(logger, pendingDeployment.Id, repository, commit.Sha, commit.Author.Login);
+                Log.UntrustedCommitAuthorFound(
+                    logger,
+                    pendingDeployment.Id,
+                    repository,
+                    commit.Sha,
+                    commit.Author.Login,
+                    commit.Author.Id);
+
                 return false;
             }
 
@@ -457,13 +464,14 @@ public sealed partial class DeploymentStatusHandler(
         [LoggerMessage(
             EventId = 10,
             Level = LogLevel.Debug,
-            Message = "Deployment ID {DeploymentId} for {Repository} cannot be auto-deployed as it contains commit {Sha} from untrusted author {Login}.")]
+            Message = "Deployment ID {DeploymentId} for {Repository} cannot be auto-deployed as it contains commit {Sha} from untrusted author {Login} ({UserId}).")]
         public static partial void UntrustedCommitAuthorFound(
             ILogger logger,
             long deploymentId,
             RepositoryId repository,
             string sha,
-            string login);
+            string login,
+            long userId);
 
         [LoggerMessage(
             EventId = 11,

--- a/src/Costellobot/Handlers/PullRequestAnalyzer.cs
+++ b/src/Costellobot/Handlers/PullRequestAnalyzer.cs
@@ -51,7 +51,8 @@ public sealed partial class PullRequestAnalyzer(
         return reviews.Any((p) =>
             p.State is { Value: PullRequestReviewState.Approved } &&
             p.User.Login != authorLogin &&
-            options.TrustedEntities.Reviewers.Contains(p.User.Login, StringComparer.Ordinal));
+            options.TrustedEntities.Reviewers.TryGetValue(p.User.Login, out var id) &&
+            p.User.Id == id);
     }
 
     public async Task<bool> IsApprovedByAsync(IssueId id, string authorLogin)
@@ -73,11 +74,11 @@ public sealed partial class PullRequestAnalyzer(
     public bool IsFromTrustedUser(IssueId id, PullRequestEvent message)
     {
         var pr = message.PullRequest!;
-        return IsFromTrustedUser(id, pr.User.Login, pr.Draft);
+        return IsFromTrustedUser(id, pr.User.Login, pr.User.Id, pr.Draft);
     }
 
     public bool IsFromTrustedUser(IssueId id, SimplePullRequest pullRequest)
-        => IsFromTrustedUser(id, pullRequest.User.Login, pullRequest.Draft);
+        => IsFromTrustedUser(id, pullRequest.User.Login, pullRequest.User.Id, pullRequest.Draft);
 
     public async Task<bool> IsTrustedDependencyUpdateAsync(
         RepositoryId repository,
@@ -116,7 +117,7 @@ public sealed partial class PullRequestAnalyzer(
         }
     }
 
-    private bool IsFromTrustedUser(IssueId id, string authorLogin, bool isDraft)
+    private bool IsFromTrustedUser(IssueId id, string authorLogin, long authorId, bool isDraft)
     {
         var options = context.WebhookOptions;
 
@@ -132,9 +133,9 @@ public sealed partial class PullRequestAnalyzer(
             return false;
         }
 
-        bool isTrusted = options.TrustedEntities.Users.Contains(
-            authorLogin,
-            StringComparer.Ordinal);
+        bool isTrusted =
+            options.TrustedEntities.Users.TryGetValue(authorLogin, out var expectedId) &&
+            authorId == expectedId;
 
         if (!isTrusted)
         {

--- a/src/Costellobot/Handlers/PullRequestAnalyzer.cs
+++ b/src/Costellobot/Handlers/PullRequestAnalyzer.cs
@@ -51,8 +51,8 @@ public sealed partial class PullRequestAnalyzer(
         return reviews.Any((p) =>
             p.State is { Value: PullRequestReviewState.Approved } &&
             p.User.Login != authorLogin &&
-            options.TrustedEntities.Reviewers.TryGetValue(p.User.Login, out var id) &&
-            p.User.Id == id);
+            options.TrustedEntities.Reviewers.TryGetValue(p.User.Login, out var userId) &&
+            p.User.Id == userId);
     }
 
     public async Task<bool> IsApprovedByAsync(IssueId id, string authorLogin)
@@ -139,7 +139,7 @@ public sealed partial class PullRequestAnalyzer(
 
         if (!isTrusted)
         {
-            Log.IgnoringPullRequestFromUntrustedUser(logger, id, authorLogin);
+            Log.IgnoringPullRequestFromUntrustedUser(logger, id, authorLogin, authorId);
         }
 
         return isTrusted;
@@ -159,11 +159,12 @@ public sealed partial class PullRequestAnalyzer(
         [LoggerMessage(
             EventId = 2,
             Level = LogLevel.Debug,
-            Message = "Ignoring pull request {PullRequest} from {Login} as it is not from a trusted user.")]
+            Message = "Ignoring pull request {PullRequest} from {Login} ({UserId}) as it is not from a trusted user.")]
         public static partial void IgnoringPullRequestFromUntrustedUser(
             ILogger logger,
             IssueId pullRequest,
-            string? login);
+            string? login,
+            long userId);
 
         [LoggerMessage(
             EventId = 3,

--- a/src/Costellobot/Slices/Configuration.cshtml
+++ b/src/Costellobot/Slices/Configuration.cshtml
@@ -342,7 +342,7 @@
                                     </div>
                                     <div class="card-body">
                                         <ul id="trusted-reviewers">
-                                            @foreach (var user in Model.Webhook.TrustedEntities.Reviewers)
+                                            @foreach (var user in Model.Webhook.TrustedEntities.Reviewers.Keys)
                                             {
                                                 <li>
                                                     <a href="@(GitHubUserUrl(user))" target="_blank" rel="noopener" aria-label="View @(user)'s GitHub profile">
@@ -361,7 +361,7 @@
                                     </div>
                                     <div class="card-body">
                                         <ul id="trusted-users">
-                                            @foreach (var user in Model.Webhook.TrustedEntities.Users)
+                                            @foreach (var user in Model.Webhook.TrustedEntities.Users.Keys)
                                             {
                                                 <li>
                                                     <a href="@(GitHubUserUrl(user))" target="_blank" rel="noopener" aria-label="View @(user)'s GitHub profile">

--- a/src/Costellobot/TrustedEntitiesOptions.cs
+++ b/src/Costellobot/TrustedEntitiesOptions.cs
@@ -9,7 +9,7 @@ public sealed class TrustedEntitiesOptions
 
     public IDictionary<DependencyEcosystem, IList<string>> Publishers { get; set; } = new Dictionary<DependencyEcosystem, IList<string>>();
 
-    public IList<string> Reviewers { get; set; } = [];
+    public IDictionary<string, long> Reviewers { get; set; } = new Dictionary<string, long>();
 
-    public IList<string> Users { get; set; } = [];
+    public IDictionary<string, long> Users { get; set; } = new Dictionary<string, long>();
 }

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -273,17 +273,17 @@
           "aws"
         ]
       },
-      "Reviewers": [
-        "costellobot[bot]",
-        "costellorgbot[bot]"
-      ],
-      "Users": [
-        "costellobot",
-        "costellobot[bot]",
-        "costellorgbot[bot]",
-        "dependabot[bot]",
-        "renovate[bot]"
-      ]
+      "Reviewers": {
+        "costellobot[bot]": 102247573,
+        "costellorgbot[bot]": 208148282
+      },
+      "Users": {
+        "costellobot": 102549341,
+        "costellobot[bot]": 102247573,
+        "costellorgbot[bot]": 208148282,
+        "dependabot[bot]": 49699333,
+        "renovate[bot]": 29139614
+      }
     }
   }
 }

--- a/tests/Costellobot.Tests/Builders/GitHubFixtures.cs
+++ b/tests/Costellobot.Tests/Builders/GitHubFixtures.cs
@@ -16,6 +16,8 @@ public static class GitHubFixtures
 
     public const string DependabotCommitter = "dependabot[bot]";
 
+    public const int DependabotId = 49699333;
+
     public const string GitHubActionsBotName = "app/github-actions";
 
     public const string InstallationId = "24364748";
@@ -23,6 +25,8 @@ public static class GitHubFixtures
     public const string InstallationNodeId = "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uMjQzNjQ3NDg=";
 
     public const string RenovateCommitter = "renovate[bot]";
+
+    public const int RenovateId = 29139614;
 
     public static WebhookEvent CreatePingEvent() => new Octokit.Webhooks.Events.PingEvent()
     {
@@ -174,7 +178,7 @@ public static class GitHubFixtures
     }
 
     public static UserBuilder CreateUserForDependabot()
-        => CreateUser(DependabotCommitter);
+        => CreateUser(DependabotCommitter, DependabotId);
 
     public static UserBuilder CreateUser(
         string? login = null,

--- a/tests/Costellobot.Tests/Drivers/CheckSuiteDriver.cs
+++ b/tests/Costellobot.Tests/Drivers/CheckSuiteDriver.cs
@@ -9,9 +9,9 @@ namespace MartinCostello.Costellobot.Drivers;
 
 public sealed class CheckSuiteDriver
 {
-    public CheckSuiteDriver(string? login = null, string? conclusion = null)
+    public CheckSuiteDriver(string? login = null, int? id = null, string? conclusion = null)
     {
-        Owner = CreateUser(login);
+        Owner = CreateUser(login, id);
         Repository = Owner.CreateRepository();
         PullRequest = Repository.CreatePullRequest();
         WorkflowRun = Repository.CreateWorkflowRun();

--- a/tests/Costellobot.Tests/Drivers/PullRequestDriver.cs
+++ b/tests/Costellobot.Tests/Drivers/PullRequestDriver.cs
@@ -9,9 +9,9 @@ namespace MartinCostello.Costellobot.Drivers;
 
 public class PullRequestDriver
 {
-    public PullRequestDriver(string? login = null)
+    public PullRequestDriver(string? login = null, int? id = null)
     {
-        User = CreateUser(login);
+        User = CreateUser(login, id);
         Sender = User;
         Owner = CreateUser();
         Repository = Owner.CreateRepository();
@@ -34,10 +34,10 @@ public class PullRequestDriver
     public UserBuilder User { get; set; }
 
     public static PullRequestDriver ForDependabot()
-        => new(DependabotCommitter);
+        => new(DependabotCommitter, DependabotId);
 
     public static PullRequestDriver ForRenovate()
-        => new(RenovateCommitter);
+        => new(RenovateCommitter, RenovateId);
 
     public PullRequestDriver WithCommitMessage(string message)
     {

--- a/tests/Costellobot.Tests/Drivers/PullRequestReviewDriver.cs
+++ b/tests/Costellobot.Tests/Drivers/PullRequestReviewDriver.cs
@@ -19,7 +19,13 @@ public sealed class PullRequestReviewDriver : PullRequestDriver
     public PullRequestReviewBuilder Review { get; set; }
 
     public static PullRequestReviewDriver FromUserForDependabot(string login = "martincostello")
-        => new(login, DependabotCommitter);
+    {
+        var driver = new PullRequestReviewDriver(login, DependabotCommitter);
+
+        driver.PullRequest.User!.Id = DependabotId;
+
+        return driver;
+    }
 
     public PullRequestReviewDriver WithAuthorAssociation(string value)
     {

--- a/tests/Costellobot.Tests/Handlers/CheckSuiteHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/CheckSuiteHandlerTests.cs
@@ -369,18 +369,20 @@ public class CheckSuiteHandlerTests(AppFixture fixture, ITestOutputHelper output
     }
 
     [Theory]
-    [InlineData("rando-calrissian", "COLLABORATOR")]
-    [InlineData("rando-calrissian", "CONTRIBUTOR")]
-    [InlineData("rando-calrissian", "FIRST_TIMER")]
-    [InlineData("rando-calrissian", "FIRST_TIME_CONTRIBUTOR")]
+    [InlineData("costellobot", 123456, "COLLABORATOR")]
+    [InlineData("rando-calrissian", 1977, "COLLABORATOR")]
+    [InlineData("rando-calrissian", 1977, "CONTRIBUTOR")]
+    [InlineData("rando-calrissian", 1977, "FIRST_TIMER")]
+    [InlineData("rando-calrissian", 1977, "FIRST_TIME_CONTRIBUTOR")]
     public async Task Failed_Jobs_Are_Not_Rerun_If_Pull_Request_Is_Not_From_A_Trusted_User(
         string login,
+        int id,
         string authorAssociation)
     {
         // Arrange
         Fixture.FailedCheckRerunAttempts(1);
 
-        var driver = new CheckSuiteDriver(login);
+        var driver = new CheckSuiteDriver(login, id);
 
         driver.CheckSuite.PullRequests.Add(driver.PullRequest);
         driver.PullRequest.AuthorAssociation = authorAssociation;

--- a/tests/Costellobot.Tests/Handlers/CheckSuiteHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/CheckSuiteHandlerTests.cs
@@ -106,7 +106,7 @@ public class CheckSuiteHandlerTests(AppFixture fixture, ITestOutputHelper output
         // Arrange
         Fixture.FailedCheckRerunAttempts(2);
 
-        var driver = new CheckSuiteDriver(DependabotCommitter);
+        var driver = new CheckSuiteDriver(DependabotCommitter, DependabotId);
         driver.CheckSuite.PullRequests.Add(driver.PullRequest);
 
         for (int i = 0; i < 2; i++)
@@ -134,7 +134,7 @@ public class CheckSuiteHandlerTests(AppFixture fixture, ITestOutputHelper output
         // Arrange
         Fixture.FailedCheckRerunAttempts(2);
 
-        var driver = new CheckSuiteDriver(DependabotCommitter);
+        var driver = new CheckSuiteDriver(DependabotCommitter, DependabotId);
         driver.CheckSuite.PullRequests.Add(driver.PullRequest);
 
         driver.WithCheckRun((p) => CreateCheckRun(p, "ubuntu-latest", "completed", "failure"));

--- a/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
@@ -535,6 +535,48 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     }
 
     [Fact]
+    public async Task Deployment_Is_Not_Approved_For_Trusted_User_With_Wrong_UserId()
+    {
+        // Arrange
+        Fixture.ApproveDeployments();
+
+        var driver = new DeploymentStatusDriver(
+            (repo) => repo.CreateCommit(),
+            (repo) =>
+            {
+                var commit = CreateTrustedCommit(repo);
+                commit.Author = CreateUser(DependabotCommitter, 123456789);
+                return commit;
+            });
+
+        driver.WithPendingDeployment(CreateDeployment);
+
+        driver.WithActiveDeployment();
+        driver.WithInactiveDeployment();
+
+        RegisterGetAccessToken();
+
+        RegisterAllDeployments(driver);
+        RegisterCommitComparison(driver);
+        RegisterPullRequestForCommit(driver.HeadCommit);
+
+        var deploymentApproved = RegisterApprovePendingDeployment(driver);
+
+        RegisterGetAccessToken();
+
+        RegisterAllDeployments(driver);
+        RegisterCommitComparison(driver);
+
+        // Act
+        using var response = await PostWebhookAsync(driver);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        await AssertTaskNotRun(deploymentApproved);
+    }
+
+    [Fact]
     public async Task Deployment_Is_Not_Approved_For_Trusted_User_And_Untrusted_Dependency()
     {
         // Arrange

--- a/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
@@ -289,13 +289,15 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
         await AssertTaskNotRun(pullRequestApproved);
     }
 
-    [Fact]
-    public async Task Pull_Request_Is_Not_Approved_For_Untrusted_User()
+    [Theory]
+    [InlineData("costellobot", 123456)]
+    [InlineData("rando-calrissian", 1138)]
+    public async Task Pull_Request_Is_Not_Approved_For_Untrusted_User(string login, int id)
     {
         // Arrange
         Fixture.ApprovePullRequests();
 
-        var driver = new PullRequestDriver("rando-calrissian")
+        var driver = new PullRequestDriver(login, id)
             .WithCommitMessage(TrustedCommitMessage());
 
         RegisterGetAccessToken();

--- a/tests/Costellobot.Tests/Handlers/PullRequestReviewHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PullRequestReviewHandlerTests.cs
@@ -413,6 +413,7 @@ public class PullRequestReviewHandlerTests(AppFixture fixture, ITestOutputHelper
             user = new
             {
                 login = "costellobot[bot]",
+                id = 102247573,
                 type = "Bot",
             },
         };

--- a/tests/Costellobot.Tests/Handlers/PullRequestReviewHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PullRequestReviewHandlerTests.cs
@@ -279,16 +279,22 @@ public class PullRequestReviewHandlerTests(AppFixture fixture, ITestOutputHelper
         await AssertNotTrustedAsync(trustStoreUpdated);
     }
 
-    [Fact]
-    public async Task Trust_Store_Is_Not_Updated_For_Pull_Request_From_Untrusted_User()
+    [Theory]
+    [InlineData("costellobot", 123456, "COLLABORATOR")]
+    [InlineData("rando-calrissian", 1138, "NONE")]
+    public async Task Trust_Store_Is_Not_Updated_For_Pull_Request_From_Untrusted_User(
+        string login,
+        int id,
+        string authorAssociation)
     {
         // Arrange
         var dependency = ("foo", "1.2.3");
 
         var driver = await ConfigureAsync(
             dependency,
-            pullRequestAuthorAssociation: "NONE",
-            pullRequestAuthorLogin: "rando-calrissian");
+            pullRequestAuthorAssociation: authorAssociation,
+            pullRequestAuthorLogin: login,
+            pullRequestAuthorId: id);
 
         var trustStoreUpdated = RegisterTrusted(DependencyEcosystem.NuGet, dependency);
 
@@ -509,6 +515,7 @@ public class PullRequestReviewHandlerTests(AppFixture fixture, ITestOutputHelper
         string reviewState = "approved",
         string? pullRequestAuthorAssociation = null,
         string? pullRequestAuthorLogin = null,
+        int? pullRequestAuthorId = null,
         bool isCollaborator = true,
         bool isEnabled = true,
         IEnumerable<object>? reviews = null,
@@ -531,6 +538,11 @@ public class PullRequestReviewHandlerTests(AppFixture fixture, ITestOutputHelper
         {
             driver.PullRequest.User ??= CreateUser(pullRequestAuthorLogin);
             driver.PullRequest.User.Login = pullRequestAuthorLogin;
+
+            if (pullRequestAuthorId is { } userId)
+            {
+                driver.PullRequest.User.Id = userId;
+            }
         }
 
         RegisterGetAccessToken();


### PR DESCRIPTION
Add a verified user ID against each user login to check that the identity is exactly what is expected and apps cannot be renamed then an old name claimed by an untrusted party.
