### PR TITLE
Extend trust for third party NuGet feeds

### DIFF
--- a/src/Costellobot/GitCommitAnalyzer.cs
+++ b/src/Costellobot/GitCommitAnalyzer.cs
@@ -570,9 +570,9 @@ public sealed partial class GitCommitAnalyzer(
                 return (false, version);
             }
 
-            var registry = _registries.FirstOrDefault((p) => p.Ecosystem == ecosystem);
+            var registries = _registries.Where((p) => p.Ecosystem == ecosystem).ToList();
 
-            if (registry is null)
+            if (registries.Count == 0)
             {
                 return (false, version);
             }
@@ -584,15 +584,18 @@ public sealed partial class GitCommitAnalyzer(
                 return (false, version);
             }
 
-            if (await IsTrustedDependencyOwnerAsync(
-                    repository,
-                    dependency,
-                    version,
-                    publishers,
-                    registry,
-                    cancellationToken))
+            foreach (var registry in registries)
             {
-                return (true, version);
+                if (await IsTrustedDependencyOwnerAsync(
+                        repository,
+                        dependency,
+                        version,
+                        publishers,
+                        registry,
+                        cancellationToken))
+                {
+                    return (true, version);
+                }
             }
 
             return (await IsTrustedDependencyVersionAsync(repository, ecosystem, dependency, version, cancellationToken), version);

--- a/src/Costellobot/GitHubExtensions.cs
+++ b/src/Costellobot/GitHubExtensions.cs
@@ -153,6 +153,7 @@ public static class GitHubExtensions
         services.AddPackageRegistry<GitSubmodulePackageRegistry>();
         services.AddPackageRegistry<NpmPackageRegistry>("Npm");
         services.AddPackageRegistry<NuGetPackageRegistry>("NuGet");
+        services.AddPackageRegistry<NuGetPackageRegistry>("MyGet-OpenTelemetry");
         services.AddPackageRegistry<RubyGemsPackageRegistry>("RubyGems");
 
         services.AddSingleton<BadgeService>();

--- a/src/Costellobot/ILoggerExtensions.cs
+++ b/src/Costellobot/ILoggerExtensions.cs
@@ -27,7 +27,12 @@ public static class ILoggerExtensions
 
     public static IDisposable? BeginWebhookScope(this ILogger logger, WebhookEvent payload)
     {
-        var items = new Dictionary<string, object>(2);
+        var items = new Dictionary<string, object>(3);
+
+        if (payload.Action is { Length: > 0 } action)
+        {
+            items["GitHub.Action"] = action;
+        }
 
         if (payload.Repository is { } repository)
         {

--- a/src/Costellobot/Octokit/AppCredentialStore.cs
+++ b/src/Costellobot/Octokit/AppCredentialStore.cs
@@ -43,7 +43,7 @@ public sealed class AppCredentialStore(
 
         var tokenDescriptor = new SecurityTokenDescriptor()
         {
-            Expires = utcNow.Add(TokenLifetime),
+            Expires = utcNow.Add(TokenLifetime).Add(-TokenSkew),
             IssuedAt = utcNow.Add(-TokenSkew),
             Issuer = app.AppId,
             SigningCredentials = CreateSigningCredentials(algorithm),

--- a/src/Costellobot/Registries/IPackageRegistry.cs
+++ b/src/Costellobot/Registries/IPackageRegistry.cs
@@ -9,8 +9,7 @@ public interface IPackageRegistry
 
     DependencyEcosystem Ecosystem { get; }
 
-    Task<bool> AreOwnersTrustedAsync(IReadOnlyList<string> owners, CancellationToken cancellationToken)
-        => Task.FromResult(false);
+    Task<bool> AreOwnersTrustedAsync(IReadOnlyList<string> owners, CancellationToken cancellationToken);
 
     Task<bool?> GetPackageAttestationAsync(
         RepositoryId repository,

--- a/src/Costellobot/Registries/NuGetPackageRegistry.cs
+++ b/src/Costellobot/Registries/NuGetPackageRegistry.cs
@@ -54,7 +54,7 @@ public sealed partial class NuGetPackageRegistry : PackageRegistry
             var segments = client.BaseAddress.Segments;
             var owner = segments.Length switch
             {
-                5 when string.Equals(segments[1], "F/", StringComparison.Ordinal) => segments[2].TrimEnd('/'),
+                6 when string.Equals(segments[1], "F/", StringComparison.Ordinal) => segments[2].TrimEnd('/'),
                 _ => string.Empty,
             };
 
@@ -74,7 +74,7 @@ public sealed partial class NuGetPackageRegistry : PackageRegistry
 
         if (_private && owners.Count > 0)
         {
-            trusted = owners.SequenceEqual(_registryOwners);
+            trusted = owners.SequenceEqual(_registryOwners, StringComparer.Ordinal);
         }
 
         return Task.FromResult(trusted);

--- a/src/Costellobot/Registries/NuGetPackageRegistry.cs
+++ b/src/Costellobot/Registries/NuGetPackageRegistry.cs
@@ -9,17 +9,76 @@ using Microsoft.Extensions.Caching.Hybrid;
 
 namespace MartinCostello.Costellobot.Registries;
 
-public sealed partial class NuGetPackageRegistry(
-    HttpClient client,
-    HybridCache cache,
-    ILogger<NuGetPackageRegistry> logger) : PackageRegistry(client)
+public sealed partial class NuGetPackageRegistry : PackageRegistry
 {
     private static readonly HybridCacheEntryOptions CacheEntryOptions = new() { Expiration = TimeSpan.FromHours(1) };
     private static readonly string[] CacheTags = ["all", "nuget"];
 
-    private readonly string _cacheKeyPrefix = $"{client.BaseAddress!.Host}:{client.BaseAddress.PathAndQuery}";
+    private readonly HybridCache _cache;
+    private readonly string _cacheKeyPrefix;
+    private readonly ILogger _logger;
+    private readonly bool _private;
+    private readonly string[] _registryOwners;
+
+    public NuGetPackageRegistry(
+        HttpClient client,
+        HybridCache cache,
+        ILogger<NuGetPackageRegistry> logger)
+        : base(client)
+    {
+        _cache = cache;
+        _cacheKeyPrefix = $"{client.BaseAddress!.Host}:{client.BaseAddress.PathAndQuery}";
+        _logger = logger;
+        _private = false;
+        _registryOwners = [];
+
+        if (client.BaseAddress.Host is "f.feedz.io")
+        {
+            // Example: https://f.feedz.io/martincostello/costellobot/nuget/index.json
+            var segments = client.BaseAddress.Segments;
+            var owner = segments.Length switch
+            {
+                5 when string.Equals(segments[3], "nuget/", StringComparison.Ordinal) => segments[1].TrimEnd('/'),
+                _ => string.Empty,
+            };
+
+            if (!string.IsNullOrEmpty(owner))
+            {
+                _private = true;
+                _registryOwners = [owner];
+            }
+        }
+        else if (client.BaseAddress.Host is "www.myget.org")
+        {
+            // Example https://www.myget.org/F/opentelemetry/api/v3/index.json
+            var segments = client.BaseAddress.Segments;
+            var owner = segments.Length switch
+            {
+                5 when string.Equals(segments[1], "F/", StringComparison.Ordinal) => segments[2].TrimEnd('/'),
+                _ => string.Empty,
+            };
+
+            if (!string.IsNullOrEmpty(owner))
+            {
+                _private = true;
+                _registryOwners = [owner];
+            }
+        }
+    }
 
     public override DependencyEcosystem Ecosystem => DependencyEcosystem.NuGet;
+
+    public override Task<bool> AreOwnersTrustedAsync(IReadOnlyList<string> owners, CancellationToken cancellationToken)
+    {
+        bool trusted = false;
+
+        if (_private && owners.Count > 0)
+        {
+            trusted = owners.SequenceEqual(_registryOwners);
+        }
+
+        return Task.FromResult(trusted);
+    }
 
     public override async Task<IReadOnlyList<string>> GetPackageOwnersAsync(
         RepositoryId repository,
@@ -29,7 +88,7 @@ public sealed partial class NuGetPackageRegistry(
     {
         if (!NuGet.Versioning.NuGetVersion.TryParse(version, out var _))
         {
-            Log.InvalidNuGetPackageVersion(logger, version);
+            Log.InvalidNuGetPackageVersion(_logger, version);
             return [];
         }
 
@@ -93,7 +152,7 @@ public sealed partial class NuGetPackageRegistry(
         {
             JsonValueKind.Array => GetPackageOwners(package.Owners),
             JsonValueKind.String => GetPackageOwner(package.Owners),
-            _ => [],
+            _ => _private ? _registryOwners : [],
         };
 
         static IReadOnlyList<string> GetPackageOwner(JsonElement owner)
@@ -125,7 +184,7 @@ public sealed partial class NuGetPackageRegistry(
     }
 
     private async Task<ServiceIndex?> GetServiceIndexAsync(CancellationToken cancellationToken) =>
-        await cache.GetOrCreateAsync(
+        await _cache.GetOrCreateAsync(
             $"{_cacheKeyPrefix}:nuget-service-index",
             Client,
             static async (client, token) => await client.GetFromJsonAsync("index.json", NuGetJsonSerializerContext.Default.ServiceIndex, cancellationToken: token),

--- a/src/Costellobot/Registries/NuGetPackageRegistry.cs
+++ b/src/Costellobot/Registries/NuGetPackageRegistry.cs
@@ -27,12 +27,12 @@ public sealed partial class NuGetPackageRegistry : PackageRegistry
         : base(client)
     {
         _cache = cache;
-        _cacheKeyPrefix = $"{client.BaseAddress!.Host}:{client.BaseAddress.PathAndQuery}";
+        _cacheKeyPrefix = client.BaseAddress?.ToString() ?? string.Empty;
         _logger = logger;
         _private = false;
         _registryOwners = [];
 
-        if (client.BaseAddress.Host is "f.feedz.io")
+        if (client.BaseAddress?.Host is "f.feedz.io")
         {
             // Example: https://f.feedz.io/martincostello/costellobot/nuget/index.json
             var segments = client.BaseAddress.Segments;
@@ -48,7 +48,7 @@ public sealed partial class NuGetPackageRegistry : PackageRegistry
                 _registryOwners = [owner];
             }
         }
-        else if (client.BaseAddress.Host is "www.myget.org")
+        else if (client.BaseAddress?.Host is "www.myget.org")
         {
             // Example https://www.myget.org/F/opentelemetry/api/v3/index.json
             var segments = client.BaseAddress.Segments;

--- a/src/Costellobot/Registries/NuGetPackageRegistry.cs
+++ b/src/Costellobot/Registries/NuGetPackageRegistry.cs
@@ -17,6 +17,8 @@ public sealed partial class NuGetPackageRegistry(
     private static readonly HybridCacheEntryOptions CacheEntryOptions = new() { Expiration = TimeSpan.FromHours(1) };
     private static readonly string[] CacheTags = ["all", "nuget"];
 
+    private readonly string _cacheKeyPrefix = $"{client.BaseAddress!.Host}:{client.BaseAddress.PathAndQuery}";
+
     public override DependencyEcosystem Ecosystem => DependencyEcosystem.NuGet;
 
     public override async Task<IReadOnlyList<string>> GetPackageOwnersAsync(
@@ -32,7 +34,11 @@ public sealed partial class NuGetPackageRegistry(
         }
 
         // https://docs.microsoft.com/nuget/api/search-query-service-resource#versioning
+        // NuGet.org has multiple entries for fallback, so we could extend to support that in future
         var baseAddress = await GetBaseAddressAsync("SearchQueryService/3.5.0", cancellationToken);
+
+        // Fallback resource for other NuGet implementations such as feedz.io and MyGet.org
+        baseAddress ??= await GetBaseAddressAsync("SearchQueryService", cancellationToken);
 
         if (baseAddress is null)
         {
@@ -120,9 +126,9 @@ public sealed partial class NuGetPackageRegistry(
 
     private async Task<ServiceIndex?> GetServiceIndexAsync(CancellationToken cancellationToken) =>
         await cache.GetOrCreateAsync(
-            "nuget-service-index",
+            $"{_cacheKeyPrefix}:nuget-service-index",
             Client,
-            static async (client, token) => await client.GetFromJsonAsync("/v3/index.json", NuGetJsonSerializerContext.Default.ServiceIndex, cancellationToken: token),
+            static async (client, token) => await client.GetFromJsonAsync("index.json", NuGetJsonSerializerContext.Default.ServiceIndex, cancellationToken: token),
             CacheEntryOptions,
             CacheTags,
             cancellationToken);

--- a/src/Costellobot/Registries/PackageRegistry.cs
+++ b/src/Costellobot/Registries/PackageRegistry.cs
@@ -9,6 +9,9 @@ public abstract class PackageRegistry(HttpClient client) : IPackageRegistry
 
     protected HttpClient Client { get; } = client;
 
+    public virtual Task<bool> AreOwnersTrustedAsync(IReadOnlyList<string> owners, CancellationToken cancellationToken)
+        => Task.FromResult(false);
+
     public abstract Task<IReadOnlyList<string>> GetPackageOwnersAsync(
         RepositoryId repository,
         string id,

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -175,6 +175,9 @@
       "MicrosoftArtifactRegistry": {
         "BaseAddress": "https://mcr.microsoft.com"
       },
+      "MyGet-OpenTelemetry": {
+        "BaseAddress": "https://www.myget.org/F/opentelemetry/api/v3/"
+      },
       "Npm": {
         "BaseAddress": "https://registry.npmjs.org"
       },

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -179,7 +179,7 @@
         "BaseAddress": "https://registry.npmjs.org"
       },
       "NuGet": {
-        "BaseAddress": "https://api.nuget.org"
+        "BaseAddress": "https://api.nuget.org/v3/"
       },
       "PyPI": {
         "BaseAddress": "https://pypi.org"

--- a/tests/Costellobot.Tests/AuthenticationTests.cs
+++ b/tests/Costellobot.Tests/AuthenticationTests.cs
@@ -42,7 +42,7 @@ public sealed class AuthenticationTests(AppFixture fixture, ITestOutputHelper ou
 
         token1.IssuedAt.ShouldBe(utcNow.AddMinutes(-1), tolerance);
         token1.ValidFrom.ShouldBe(utcNow, tolerance);
-        token1.ValidTo.ShouldBe(utcNow.AddMinutes(10), tolerance);
+        token1.ValidTo.ShouldBe(utcNow.AddMinutes(9), tolerance);
 
         // Arrange
         await Task.Delay(TimeSpan.FromSeconds(1.1), CancellationToken);
@@ -70,7 +70,7 @@ public sealed class AuthenticationTests(AppFixture fixture, ITestOutputHelper ou
 
         token2.IssuedAt.ShouldBe(utcNow.AddMinutes(-1), tolerance);
         token2.ValidFrom.ShouldBe(utcNow, tolerance);
-        token2.ValidTo.ShouldBe(utcNow.AddMinutes(10), tolerance);
+        token2.ValidTo.ShouldBe(utcNow.AddMinutes(9), tolerance);
 
         token2.IssuedAt.ShouldBeGreaterThan(token1.IssuedAt);
         token2.ValidFrom.ShouldBeGreaterThan(token1.ValidFrom);

--- a/tests/Costellobot.Tests/Bundles/myget-search.json
+++ b/tests/Costellobot.Tests/Bundles/myget-search.json
@@ -1,0 +1,418 @@
+{
+  "$schema": "https://raw.githubusercontent.com/justeat/httpclient-interception/main/src/HttpClientInterception/Bundles/http-request-bundle-schema.json",
+  "id": "myget-search",
+  "version": 1,
+  "comment": "HTTP bundle for MyGet package search.",
+  "items": [
+    {
+      "comment": "MyGet service index",
+      "uri": "https://www.myget.org/F/opentelemetry/api/v3/index.json",
+      "method": "GET",
+      "contentFormat": "json",
+      "contentJson": {
+        "version": "3.0.0",
+        "resources": [
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/autocomplete",
+            "@type": "SearchAutocompleteService",
+            "comment": "Autocomplete endpoint of NuGet Search service."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/autocomplete",
+            "@type": "SearchAutocompleteService/3.0.0-beta",
+            "comment": "Autocomplete endpoint of NuGet Search service."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/autocomplete",
+            "@type": "SearchAutocompleteService/3.0.0-rc",
+            "comment": "Autocomplete endpoint of NuGet Search service."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/query",
+            "@type": "SearchQueryService",
+            "comment": "Query endpoint of NuGet Search service."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/query",
+            "@type": "SearchQueryService/3.0.0-beta",
+            "comment": "Query endpoint of NuGet Search service."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/query",
+            "@type": "SearchQueryService/3.0.0-rc",
+            "comment": "Query endpoint of NuGet Search service."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/",
+            "@type": "RegistrationsBaseUrl",
+            "comment": "Base URL of Azure storage where NuGet package registration info is stored."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/",
+            "@type": "RegistrationsBaseUrl/3.0.0-beta",
+            "comment": "Base URL of Azure storage where NuGet package registration info is stored."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/",
+            "@type": "RegistrationsBaseUrl/3.0.0-rc",
+            "comment": "Base URL of Azure storage where NuGet package registration info is stored."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/",
+            "@type": "RegistrationsBaseUrl/3.4.0",
+            "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/",
+            "@type": "RegistrationsBaseUrl/3.6.0",
+            "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL includes SemVer 2.0.0 packages."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/",
+            "@type": "RegistrationsBaseUrl/Versioned",
+            "clientVersion": "4.3.0-alpha",
+            "comment": "Base URL of Azure storage where NuGet package registration info is stored in GZIP format. This base URL includes SemVer 2.0.0 packages."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/{id-lower}/index.json",
+            "@type": "PackageDisplayMetadataUriTemplate",
+            "comment": "URI template used by NuGet Client to construct display metadata for Packages using ID."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/{id-lower}/index.json",
+            "@type": "PackageDisplayMetadataUriTemplate/3.0.0-beta",
+            "comment": "URI template used by NuGet Client to construct display metadata for Packages using ID."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/{id-lower}/index.json",
+            "@type": "PackageDisplayMetadataUriTemplate/3.0.0-rc",
+            "comment": "URI template used by NuGet Client to construct display metadata for Packages using ID."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/{id-lower}/{version-lower}.json",
+            "@type": "PackageVersionDisplayMetadataUriTemplate",
+            "comment": "URI template used by NuGet Client to construct display metadata for Packages using ID, Version."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/{id-lower}/{version-lower}.json",
+            "@type": "PackageVersionDisplayMetadataUriTemplate/3.0.0-beta",
+            "comment": "URI template used by NuGet Client to construct display metadata for Packages using ID, Version."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/{id-lower}/{version-lower}.json",
+            "@type": "PackageVersionDisplayMetadataUriTemplate/3.0.0-rc",
+            "comment": "URI template used by NuGet Client to construct display metadata for Packages using ID, Version."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/flatcontainer/",
+            "@type": "PackageBaseAddress/3.0.0",
+            "comment": "Base URL of Azure storage where NuGet package registration info for DNX is stored."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/repository-signatures/index.json",
+            "@type": "RepositorySignatures/4.7.0",
+            "comment": "The endpoint for discovering information about this package source's repository signatures."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v2/symbolpackage/",
+            "@type": "SymbolPackagePublish/4.9.0",
+            "comment": "URI template used by NuGet Client to push the symbol package."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v2",
+            "@type": "LegacyGallery",
+            "comment": "Legacy gallery using the V2 protocol."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v2",
+            "@type": "LegacyGallery/2.0.0",
+            "comment": "Legacy gallery using the V2 protocol."
+          },
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v2/package",
+            "@type": "PackagePublish/2.0.0",
+            "comment": "Legacy gallery publish endpoint using the V2 protocol."
+          }
+        ],
+        "@context": {
+          "@vocab": "http://schema.nuget.org/schema#",
+          "comment": "http://www.w3.org/2000/01/rdf-schema#comment"
+        }
+      }
+    },
+    {
+      "comment": "MyGet search result for OpenTelemetry.Instrumentation.AspNetCore",
+      "uri": "https://www.myget.org/F/opentelemetry/api/v3/query?prerelease=true&q=PackageId%3AOpenTelemetry.Instrumentation.AspNetCore&semVerLevel=2.0.0&take=1",
+      "contentFormat": "json",
+      "contentJson": {
+        "@context": { "@vocab": "http://schema.nuget.org/schema#" },
+        "totalHits": 10001,
+        "index": "opentelemetry",
+        "lastReopen": "2026-05-14T10:08:21.9934227Z",
+        "data": [
+          {
+            "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.3-alpha.0.171.json",
+            "@type": "Package",
+            "registration": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/index.json",
+            "id": "OpenTelemetry.Instrumentation.AspNetCore",
+            "description": "ASP.NET Core instrumentation for OpenTelemetry .NET",
+            "summary": "ASP.NET Core instrumentation for OpenTelemetry .NET",
+            "title": "OpenTelemetry.Instrumentation.AspNetCore",
+            "iconUrl": "",
+            "licenseUrl": null,
+            "projectUrl": "https://opentelemetry.io/",
+            "tags": [ "Observability", "OpenTelemetry", "Monitoring", "Telemetry", "distributed-tracing", "AspNetCore" ],
+            "authors": [ "OpenTelemetry", "Authors" ],
+            "totaldownloads": 26,
+            "verified": true,
+            "version": "1.15.3-alpha.0.171",
+            "versions": [
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.6.0.json",
+                "version": "1.6.0",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.7.0.json",
+                "version": "1.7.0",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.7.1.json",
+                "version": "1.7.1",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.8.0.json",
+                "version": "1.8.0",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.8.1.json",
+                "version": "1.8.1",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.9.0.json",
+                "version": "1.9.0",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.10.0.json",
+                "version": "1.10.0",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.10.1.json",
+                "version": "1.10.1",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.11.0.json",
+                "version": "1.11.0",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.11.1.json",
+                "version": "1.11.1",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.12.0.json",
+                "version": "1.12.0",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.13.0.json",
+                "version": "1.13.0",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.14.0.json",
+                "version": "1.14.0",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.0.json",
+                "version": "1.15.0",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.1-alpha.0.110.json",
+                "version": "1.15.1-alpha.0.110",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.1-alpha.0.111.json",
+                "version": "1.15.1-alpha.0.111",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.1-alpha.0.112.json",
+                "version": "1.15.1-alpha.0.112",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.1.json",
+                "version": "1.15.1",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.4.json",
+                "version": "1.15.2-alpha.0.4",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.14.json",
+                "version": "1.15.2-alpha.0.14",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.32.json",
+                "version": "1.15.2-alpha.0.32",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.39.json",
+                "version": "1.15.2-alpha.0.39",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.67.json",
+                "version": "1.15.2-alpha.0.67",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.77.json",
+                "version": "1.15.2-alpha.0.77",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.78.json",
+                "version": "1.15.2-alpha.0.78",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.86.json",
+                "version": "1.15.2-alpha.0.86",
+                "downloads": 1
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.102.json",
+                "version": "1.15.2-alpha.0.102",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.103.json",
+                "version": "1.15.2-alpha.0.103",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.106.json",
+                "version": "1.15.2-alpha.0.106",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.117.json",
+                "version": "1.15.2-alpha.0.117",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.118.json",
+                "version": "1.15.2-alpha.0.118",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.120.json",
+                "version": "1.15.2-alpha.0.120",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.143.json",
+                "version": "1.15.2-alpha.0.143",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.155.json",
+                "version": "1.15.2-alpha.0.155",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.162.json",
+                "version": "1.15.2-alpha.0.162",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2-alpha.0.174.json",
+                "version": "1.15.2-alpha.0.174",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.2.json",
+                "version": "1.15.2",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.3-alpha.0.47.json",
+                "version": "1.15.3-alpha.0.47",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.3-alpha.0.66.json",
+                "version": "1.15.3-alpha.0.66",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.3-alpha.0.71.json",
+                "version": "1.15.3-alpha.0.71",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.3-alpha.0.78.json",
+                "version": "1.15.3-alpha.0.78",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.3-alpha.0.90.json",
+                "version": "1.15.3-alpha.0.90",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.3-alpha.0.99.json",
+                "version": "1.15.3-alpha.0.99",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.3-alpha.0.118.json",
+                "version": "1.15.3-alpha.0.118",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.3-alpha.0.160.json",
+                "version": "1.15.3-alpha.0.160",
+                "downloads": 0
+              },
+              {
+                "@id": "https://www.myget.org/F/opentelemetry/api/v3/registration1/opentelemetry.instrumentation.aspnetcore/1.15.3-alpha.0.171.json",
+                "version": "1.15.3-alpha.0.171",
+                "downloads": 0
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "comment": "MyGet search result for foo",
+      "uri": "https://www.myget.org/F/opentelemetry/api/v3/query?prerelease=true&q=PackageId%3Afoo&semVerLevel=2.0.0&take=1",
+      "contentFormat": "json",
+      "contentJson": {
+        "@context": { "@vocab": "http://schema.nuget.org/schema#" },
+        "totalHits": 10000,
+        "index": "opentelemetry",
+        "lastReopen": "2026-05-14T10:07:28.5518592Z",
+        "data": []
+      }
+    }
+  ]
+}

--- a/tests/Costellobot.Tests/GitCommitAnalyzerTests.cs
+++ b/tests/Costellobot.Tests/GitCommitAnalyzerTests.cs
@@ -2422,6 +2422,84 @@ Signed-off-by: dependabot[bot] <support@github.com>";
     }
 
     [Fact]
+    public async Task Commit_Is_Analyzed_Correctly_With_Trusted_Publishers_For_Renovate_NuGet_Dependency_From_Private_Feed()
+    {
+        // Arrange
+        var ecosystem = DependencyEcosystem.NuGet;
+        var owner = CreateUser();
+        var repo = owner.CreateRepository();
+        var repository = new RepositoryId(repo.Owner.Login, repo.Name);
+        var reference = "renovate/nuget/opentelemetry.instrumentation.aspnetcore-1.x";
+
+        var registry = Substitute.For<IPackageRegistry>();
+
+        registry.Ecosystem.Returns(ecosystem);
+
+        string[] owners = ["opentelemetry"];
+
+        registry.AreOwnersTrustedAsync(owners, CancellationToken)
+                .Returns(Task.FromResult(true));
+
+        registry.GetPackageOwnersAsync(repository, "OpenTelemetry.Instrumentation.AspNetCore", "1.15.3-alpha.0.171", CancellationToken)
+                .Returns(Task.FromResult<IReadOnlyList<string>>(owners));
+
+        var options = new WebhookOptions()
+        {
+            TrustedEntities = new()
+            {
+                Publishers = new Dictionary<DependencyEcosystem, IList<string>>()
+                {
+                    [ecosystem] = ["aspnet", "Microsoft"],
+                },
+            },
+        };
+
+        using var scope = Fixture.Services.CreateScope();
+        var target = CreateTarget(scope.ServiceProvider, options, [registry]);
+
+        var diff = string.Empty;
+        var sha = "4d4a1c2c58b84bcb0cddbf28183d0b52e690ae6a";
+        var commitMessage = """
+                            Bump dependency OpenTelemetry.Instrumentation.AspNetCore to 1.15.3-al…
+                            …pha.0.171
+
+                            | datasource | package                                  | from               | to                 |
+                            | ---------- | ---------------------------------------- | ------------------ | ------------------ |
+                            | nuget      | OpenTelemetry.Instrumentation.AspNetCore | 1.15.3-alpha.0.160 | 1.15.3-alpha.0.171 |
+
+
+                            Signed-off-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>
+                            """;
+
+        // Act
+        var actual = await target.IsTrustedDependencyUpdateAsync(
+            repository,
+            reference,
+            sha,
+            commitMessage,
+            diff,
+            CancellationToken);
+
+        // Assert
+        actual.ShouldBeTrue();
+
+        // Act
+        (var actualEcosystem, var trust) = await target.GetDependencyTrustAsync(
+            repository,
+            reference,
+            sha,
+            commitMessage,
+            diff,
+            CancellationToken);
+
+        // Assert
+        actualEcosystem.ShouldBe(ecosystem);
+
+        trust.ShouldContainKeyAndValue("OpenTelemetry.Instrumentation.AspNetCore", (true, "1.15.3-alpha.0.171"));
+        trust.Count.ShouldBe(1);
+    }
+
+    [Fact]
     public async Task Commit_Is_Analyzed_Correctly_With_Trusted_Publishers_For_Renovate_Digest_Update_For_Dockerfile()
     {
         // Arrange

--- a/tests/Costellobot.Tests/Infrastructure/HttpRequestInterceptionBuilderExtensions.cs
+++ b/tests/Costellobot.Tests/Infrastructure/HttpRequestInterceptionBuilderExtensions.cs
@@ -12,6 +12,11 @@ public static class HttpRequestInterceptionBuilderExtensions
     public static HttpClientInterceptorOptions RegisterGoogleBundle(this HttpClientInterceptorOptions options) =>
         options.RegisterBundleFromResourceStream("google");
 
+    public static async Task<HttpClientInterceptorOptions> RegisterMyGetBundleAsync(
+        this HttpClientInterceptorOptions options,
+        CancellationToken cancellationToken = default) =>
+        await options.RegisterBundleFromResourceStreamAsync("myget-search", cancellationToken: cancellationToken);
+
     public static async Task<HttpClientInterceptorOptions> RegisterNuGetBundleAsync(
         this HttpClientInterceptorOptions options,
         CancellationToken cancellationToken = default) =>

--- a/tests/Costellobot.Tests/Registries/NuGetPackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/NuGetPackageRegistryTests.cs
@@ -18,7 +18,7 @@ public class NuGetPackageRegistryTests(ITestOutputHelper outputHelper)
     [InlineData("Octokit.Webhooks.AspNetCore", "1.4.0", new[] { "GitHub", "kfcampbell" })]
     [InlineData("foo", "1.0.0", new string[0])]
     [InlineData("System.Text.Json", "malformed", new string[0])]
-    public async Task Can_Get_Package_Owners(string id, string version, string[] expected)
+    public async Task Can_Get_Package_Owners_For_NuGet(string id, string version, string[] expected)
     {
         // Arrange
         var repository = new RepositoryId("some-org", "some-repo");
@@ -43,6 +43,73 @@ public class NuGetPackageRegistryTests(ITestOutputHelper outputHelper)
 
         // Assert
         actual.ShouldNotBeNull();
+        actual.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("foo", "1.0.0", new string[0])]
+    [InlineData("OpenTelemetry.Instrumentation.AspNetCore", "1.15.3-alpha.0.171", new[] { "opentelemetry" })]
+    public async Task Can_Get_Package_Owners_For_MyGet(string id, string version, string[] expected)
+    {
+        // Arrange
+        var repository = new RepositoryId("some-org", "some-repo");
+
+        var options = await new HttpClientInterceptorOptions()
+            .ThrowsOnMissingRegistration()
+            .RegisterMyGetBundleAsync(TestContext.Current.CancellationToken);
+
+        using var client = options.CreateHttpClient();
+        client.BaseAddress = new Uri("https://www.myget.org/F/opentelemetry/api/v3/");
+
+        using var cache = new ApplicationCache();
+
+        var target = new NuGetPackageRegistry(client, cache, outputHelper.ToLogger<NuGetPackageRegistry>());
+
+        // Act
+        var actual = await target.GetPackageOwnersAsync(
+            repository,
+            id,
+            version,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("https://api.nuget.org/v3/", new string[0], false)]
+    [InlineData("https://api.nuget.org/v3/", new string[] { "foo" }, false)]
+    [InlineData("https://api.nuget.org/v3/", new string[] { "martin_costello" }, false)]
+    [InlineData("https://api.nuget.org/v3/", new string[] { "microsoft" }, false)]
+    [InlineData("https://f.feedz.io", new string[] { "foo" }, false)]
+    [InlineData("https://f.feedz.io", new string[] { "martincostello" }, false)]
+    [InlineData("https://f.feedz.io/martincostello/costellobot/nuget/index.json", new string[0], false)]
+    [InlineData("https://f.feedz.io/martincostello/costellobot/nuget/index.json", new string[] { "foo" }, false)]
+    [InlineData("https://f.feedz.io/martincostello/costellobot/nuget/index.json", new string[] { "martincostello" }, true)]
+    [InlineData("https://www.myget.org", new string[] { "foo" }, false)]
+    [InlineData("https://www.myget.org", new string[] { "opentelemetry" }, false)]
+    [InlineData("https://www.myget.org/F/opentelemetry/api/v3/index.json", new string[0], false)]
+    [InlineData("https://www.myget.org/F/opentelemetry/api/v3/index.json", new string[] { "foo" }, false)]
+    [InlineData("https://www.myget.org/F/opentelemetry/api/v3/index.json", new string[] { "opentelemetry" }, true)]
+    public async Task Owners_Trusted_For_Private_Feeds(string baseAddress, string[] owners, bool expected)
+    {
+        // Arrange
+        var options = await new HttpClientInterceptorOptions()
+            .ThrowsOnMissingRegistration()
+            .RegisterNuGetBundleAsync(TestContext.Current.CancellationToken);
+
+        using var client = options.CreateHttpClient();
+        client.BaseAddress = new Uri(baseAddress);
+
+        using var cache = new ApplicationCache();
+
+        var target = new NuGetPackageRegistry(client, cache, outputHelper.ToLogger<NuGetPackageRegistry>());
+
+        // Act
+        var actual = await target.AreOwnersTrustedAsync(owners, TestContext.Current.CancellationToken);
+
+        // Assert
         actual.ShouldBe(expected);
     }
 }

--- a/tests/Costellobot.Tests/Registries/NuGetPackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/NuGetPackageRegistryTests.cs
@@ -59,7 +59,7 @@ public class NuGetPackageRegistryTests(ITestOutputHelper outputHelper)
             .RegisterMyGetBundleAsync(TestContext.Current.CancellationToken);
 
         using var client = options.CreateHttpClient();
-        client.BaseAddress = new Uri("https://www.myget.org/F/opentelemetry/api/v3/");
+        client.BaseAddress = new Uri("https://www.myget.org/F/opentelemetry/api/v3/index.json");
 
         using var cache = new ApplicationCache();
 

--- a/tests/Costellobot.Tests/Registries/NuGetPackageRegistryTests.cs
+++ b/tests/Costellobot.Tests/Registries/NuGetPackageRegistryTests.cs
@@ -28,7 +28,7 @@ public class NuGetPackageRegistryTests(ITestOutputHelper outputHelper)
             .RegisterNuGetBundleAsync(TestContext.Current.CancellationToken);
 
         using var client = options.CreateHttpClient();
-        client.BaseAddress = new Uri("https://api.nuget.org");
+        client.BaseAddress = new Uri("https://api.nuget.org/v3/");
 
         using var cache = new ApplicationCache();
 


### PR DESCRIPTION
- Add support for multiple registries of the same type, for example using MyGet or feedz.io.
- Support NuGet package registries other than NuGet.org, such as MyGet and feedz.io, that are explicitly configured, as private if the registry URL matches a well-known format. This then marks any packages found as implicitly trusted as having the same ownership as the feed.
- Deduct token skew when setting the expiry for JWTs to avoid requests being rejected as too far into the future.
- Add an attribute to logs and traces for GitHub webhook payloads' action.
