### PR TITLE
Extend delivery page

### DIFF
--- a/src/Costellobot/AdminEndpoints.cs
+++ b/src/Costellobot/AdminEndpoints.cs
@@ -269,7 +269,7 @@ public static class AdminEndpoints
                 {
                     // Round deliveredAt to the previous minute
                     var deliveredAt = model.DeliveredAt.UtcDateTime;
-                    deliveredAt = deliveredAt.AddSeconds(-deliveredAt.Second).AddMilliseconds(-deliveredAt.Millisecond);
+                    deliveredAt = new(deliveredAt.Ticks - (deliveredAt.Ticks % TimeSpan.TicksPerMinute), deliveredAt.Kind);
 
                     // Query +/- 5 minutes around the rounded delivery time
                     const string GrafanaTimestampFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffK";

--- a/src/Costellobot/AdminEndpoints.cs
+++ b/src/Costellobot/AdminEndpoints.cs
@@ -227,9 +227,10 @@ public static class AdminEndpoints
                 string app,
                 long id,
                 IGitHubClientFactory factory,
-                IOptionsMonitor<GitHubOptions> options) =>
+                IOptionsMonitor<GitHubOptions> github,
+                IOptionsMonitor<GrafanaOptions> grafana) =>
             {
-                if (options.CurrentValue.TryGetAppId(app) is not { } appId)
+                if (github.CurrentValue.TryGetAppId(app) is not { } appId)
                 {
                     return Results.NotFound();
                 }
@@ -263,6 +264,44 @@ public static class AdminEndpoints
                 }
 
                 var model = new DeliveryModel(delivery);
+
+                if (!string.IsNullOrEmpty(grafana.CurrentValue.Url))
+                {
+                    // Round deliveredAt to the previous minute
+                    var deliveredAt = model.DeliveredAt.UtcDateTime;
+                    deliveredAt = deliveredAt.AddSeconds(-deliveredAt.Second).AddMilliseconds(-deliveredAt.Millisecond);
+
+                    // Query +/- 5 minutes around the rounded delivery time
+                    const string GrafanaTimestampFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffK";
+                    var window = TimeSpan.FromMinutes(5);
+                    var from = deliveredAt.Add(-window).ToString(GrafanaTimestampFormat, CultureInfo.InvariantCulture);
+                    var to = deliveredAt.Add(window).ToString(GrafanaTimestampFormat, CultureInfo.InvariantCulture);
+
+                    var urlBuilder = new UriBuilder(grafana.CurrentValue.Url)
+                    {
+                        Path = $"a/grafana-lokiexplore-app/explore/service/{ApplicationTelemetry.ServiceName}/logs",
+                    };
+
+                    const string FiltersParameter = "var-filters";
+
+                    var parameters = new Dictionary<string, string?>(5)
+                    {
+                        ["from"] = from,
+                        ["to"] = to,
+                        ["timezone"] = "browser",
+                        ["var-metadata"] = $"GitHub_Delivery|=|{model.DeliveryId}",
+                        [FiltersParameter] = $"service_name|=|{ApplicationTelemetry.ServiceName}",
+                    };
+
+                    model.LogsUrl = QueryHelpers.AddQueryString(urlBuilder.ToString(), parameters);
+
+                    urlBuilder.Path = "a/grafana-exploretraces-app/explore";
+
+                    parameters[FiltersParameter] = $"resource.service.name|=|{ApplicationTelemetry.ServiceName}";
+
+                    model.TracesUrl = QueryHelpers.AddQueryString(urlBuilder.ToString(), parameters);
+                    model.TracesUrl = QueryHelpers.AddQueryString(model.TracesUrl, FiltersParameter, $"span.github.webhook.delivery|=|{model.DeliveryId}");
+                }
 
                 var request = delivery.GetProperty("request");
 

--- a/src/Costellobot/Models/DeliveryModel.cs
+++ b/src/Costellobot/Models/DeliveryModel.cs
@@ -43,5 +43,9 @@ public sealed class DeliveryModel(JsonElement delivery)
 
     public int ResponseStatusCode => Delivery.GetProperty("status_code").GetInt32();
 
+    public string? LogsUrl { get; set; }
+
+    public string? TracesUrl { get; set; }
+
     private JsonElement Delivery { get; set; } = delivery;
 }

--- a/src/Costellobot/Slices/Delivery.cshtml
+++ b/src/Costellobot/Slices/Delivery.cshtml
@@ -30,7 +30,7 @@
         </td>
       </tr>
       <tr>
-        <td>Delivery</td>
+        <td>Delivery ID</td>
         <td>
           <code id="delivery-id">@(Model.Id)</code>
         </td>

--- a/src/Costellobot/Slices/Delivery.cshtml
+++ b/src/Costellobot/Slices/Delivery.cshtml
@@ -47,6 +47,30 @@
           <code id="url">@(Model.RequestUrl)</code>
         </td>
       </tr>
+      @if (!string.IsNullOrWhiteSpace(Model.LogsUrl))
+      {
+        <tr>
+          <td>Logs</td>
+          <td>
+            <a href="@(Model.LogsUrl)" target="_blank">
+              <span class="fa-solid fa-book fa-fw" aria-hidden="true"></span>
+              View logs for this delivery
+            </a>
+          </td>
+        </tr>
+      }
+      @if (!string.IsNullOrWhiteSpace(Model.TracesUrl))
+      {
+        <tr>
+          <td>Traces</td>
+          <td>
+            <a href="@(Model.TracesUrl)" target="_blank">
+              <span class="fa-solid fa-chart-gantt fa-fw" aria-hidden="true"></span>
+              View traces for this delivery
+            </a>
+          </td>
+        </tr>
+      }
     </tbody>
   </table>
   <hr/>

--- a/src/Costellobot/Slices/Delivery.cshtml
+++ b/src/Costellobot/Slices/Delivery.cshtml
@@ -52,7 +52,7 @@
         <tr>
           <td>Logs</td>
           <td>
-            <a href="@(Model.LogsUrl)" target="_blank">
+            <a href="@(Model.LogsUrl)" target="_blank" rel="noopener">
               <span class="fa-solid fa-book fa-fw" aria-hidden="true"></span>
               View logs for this delivery
             </a>
@@ -64,7 +64,7 @@
         <tr>
           <td>Traces</td>
           <td>
-            <a href="@(Model.TracesUrl)" target="_blank">
+            <a href="@(Model.TracesUrl)" target="_blank" rel="noopener">
               <span class="fa-solid fa-chart-gantt fa-fw" aria-hidden="true"></span>
               View traces for this delivery
             </a>

--- a/src/Costellobot/Slices/Delivery.cshtml
+++ b/src/Costellobot/Slices/Delivery.cshtml
@@ -30,6 +30,12 @@
         </td>
       </tr>
       <tr>
+        <td>Delivery</td>
+        <td>
+          <code id="delivery-id">@(Model.Id)</code>
+        </td>
+      </tr>
+      <tr>
         <td>Repository ID</td>
         <td>
           <code id="repository-id">@(Model.RepositoryId)</code>


### PR DESCRIPTION
- Add the numeric delivery ID to the delivery details page.
- Add a deep link to logs and traces 10 minutes around a delivery.
