### PR TITLE
Allow different repository targets

### DIFF
--- a/src/Costellobot/GitHubTokenBroker.cs
+++ b/src/Costellobot/GitHubTokenBroker.cs
@@ -55,7 +55,7 @@ public sealed partial class GitHubTokenBroker(
         {
             var parts = repository.Split('/');
             var owner = parts[0];
-            var repo = profile.TargetRepository ?? parts[1];
+            var repo = profile.TargetRepository is { Length: > 0 } ? profile.TargetRepository : parts[1];
 
             var client = clientFactory.CreateForApp(profile.AppId);
             var installation = await client.GitHubApps.GetRepositoryInstallationForCurrent(owner, repo);

--- a/src/Costellobot/GitHubTokenBroker.cs
+++ b/src/Costellobot/GitHubTokenBroker.cs
@@ -55,7 +55,7 @@ public sealed partial class GitHubTokenBroker(
         {
             var parts = repository.Split('/');
             var owner = parts[0];
-            var repo = parts[1];
+            var repo = profile.TargetRepository ?? parts[1];
 
             var client = clientFactory.CreateForApp(profile.AppId);
             var installation = await client.GitHubApps.GetRepositoryInstallationForCurrent(owner, repo);

--- a/src/Costellobot/GitHubTokenBroker.cs
+++ b/src/Costellobot/GitHubTokenBroker.cs
@@ -59,7 +59,7 @@ public sealed partial class GitHubTokenBroker(
 
             var client = clientFactory.CreateForApp(profile.AppId);
             var installation = await client.GitHubApps.GetRepositoryInstallationForCurrent(owner, repo);
-            var accessToken = await client.CreateInstallationTokenAsync(installation.Id, repo, profile.AppPermissions, cancellationToken);
+            var accessToken = await client.CreateInstallationTokenAsync(installation.Id, [repo], profile.AppPermissions, cancellationToken);
 
             token = accessToken.Token;
             tokenType = "app";

--- a/src/Costellobot/GitHubTokenProfileOptions.cs
+++ b/src/Costellobot/GitHubTokenProfileOptions.cs
@@ -15,6 +15,8 @@ public sealed class GitHubTokenProfileOptions
 
     public IList<string> Events { get; set; } = [];
 
+    public string? TargetRepository { get; set; }
+
     public IList<string> Workflows { get; set; } = [];
 
     public string? TokenId { get; set; }

--- a/src/Costellobot/Octokit/IGitHubClientExtensions.cs
+++ b/src/Costellobot/Octokit/IGitHubClientExtensions.cs
@@ -50,14 +50,14 @@ public static class IGitHubClientExtensions
     public static async Task<AccessToken> CreateInstallationTokenAsync(
         this IGitHubClient client,
         long installationId,
-        string repositoryName,
+        IList<string> targetRepositories,
         IDictionary<string, string> requiredPermissions,
         CancellationToken cancellationToken)
     {
         // See https://docs.github.com/rest/apps/apps?apiVersion=2026-03-10#create-an-installation-access-token-for-an-app
         var body = new
         {
-            repositories = new string[] { repositoryName },
+            repositories = targetRepositories,
             permissions = requiredPermissions,
         };
 

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -96,6 +96,7 @@
               "push",
               "workflow_dispatch"
             ],
+            "TargetRepository": "benchmarks",
             "Workflows": [
               "benchmark.yml"
             ]

--- a/tests/Costellobot.Tests/Bundles/github-oidc.json
+++ b/tests/Costellobot.Tests/Bundles/github-oidc.json
@@ -67,7 +67,7 @@
     },
     {
       "comment": "https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app",
-      "uri": "https://api.github.com/repos/martincostello/costellobot/installation",
+      "uri": "https://api.github.com/repos/martincostello/benchmarks/installation",
       "method": "GET",
       "contentFormat": "json",
       "contentJson": {


### PR DESCRIPTION
Allow generating a token for a different repository to the requesting repository's OIDC token.
