### PR TITLE
Refactor secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,6 @@ jobs:
       uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
       with:
         flags: ${{ matrix.os-name }}
-        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload test results to Codecov
       uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
@@ -110,7 +109,6 @@ jobs:
       with:
         flags: ${{ matrix.os-name }}
         report_type: test_results
-        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Docker log in
       uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -20,7 +20,12 @@ jobs:
       group: ${{ github.workflow }}
       cancel-in-progress: false
 
+    environment:
+      name: container-scan
+      deployment: false
+
     permissions:
+      actions: write
       contents: read
       security-events: write
 
@@ -136,5 +141,5 @@ jobs:
           github.event_name == 'schedule' &&
           steps.check-for-vulnerabilities.outputs.has-vulnerabilities == 'true'
         env:
-          GH_TOKEN: ${{ secrets.COSTELLOBOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run build.yml


### PR DESCRIPTION
- Remove `CODECOV_TOKEN`.
- Use `GITHUB_TOKEN` to trigger workflows.
- Use an environment for container scans.
