### PR TITLE
Use OIDC to access ACR for Trivy

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      id-token: write
       security-events: write
 
     steps:
@@ -43,6 +44,17 @@ jobs:
           persist-credentials: false
           show-progress: false
 
+      - name: Azure log in
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Log in to Azure Container Registry
+        shell: pwsh
+        run: az acr login --name ${env:GITHUB_REPOSITORY_OWNER}
+
       - name: Configure Trivy
         id: configure
         shell: pwsh
@@ -55,8 +67,6 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
-          TRIVY_USERNAME: ${{ secrets.TRIVY_USERNAME }}
-          TRIVY_PASSWORD: ${{ secrets.TRIVY_PASSWORD }}
         with:
           image-ref: ${{ steps.configure.outputs.container-image }}
           format: 'sarif'
@@ -75,8 +85,6 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
-          TRIVY_USERNAME: ${{ secrets.TRIVY_USERNAME }}
-          TRIVY_PASSWORD: ${{ secrets.TRIVY_PASSWORD }}
         with:
           image-ref: ${{ steps.configure.outputs.container-image }}
           format: 'json'


### PR DESCRIPTION
Use OIDC to access ACR for Trivy scans instead of credentials.
