### PR TITLE
Use OIDC to publish images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,10 @@ jobs:
     env:
       PUBLISH_CONTAINER: ${{ github.event.repository.fork == false && github.ref_name == github.event.repository.default_branch && matrix.os-name == 'linux' }}
 
+    environment:
+      name: build
+      deployment: false
+
     outputs:
       container-tag: ${{ steps.publish-container.outputs.container-tag }}
 
@@ -110,13 +114,18 @@ jobs:
         flags: ${{ matrix.os-name }}
         report_type: test_results
 
-    - name: Docker log in
-      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+    - name: Azure log in
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
       if: env.PUBLISH_CONTAINER == 'true'
       with:
-        registry: ${{ env.CONTAINER_REGISTRY }}
-        username: ${{ secrets.ACR_REGISTRY_USERNAME }}
-        password: ${{ secrets.ACR_REGISTRY_PASSWORD }}
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Log in to Azure Container Registry
+      shell: pwsh
+      if: env.PUBLISH_CONTAINER == 'true'
+      run: az acr login --name ${env:GITHUB_REPOSITORY_OWNER}
 
     - name: Publish container
       id: publish-container

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -5,7 +5,5 @@ rules:
     disable: true
   dependabot-cooldown:
     disable: true
-  secrets-outside-env:
-    disable: true
   undocumented-permissions:
     disable: true


### PR DESCRIPTION
Use OIDC to publish images to the Azure Container Registry.
