### PR TITLE
Add missing event

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -254,6 +254,7 @@
             ],
             "Events": [
               "push",
+              "schedule",
               "workflow_dispatch"
             ],
             "TargetRepository": "benchmarks",


### PR DESCRIPTION
Allow the `schedule` for the benchmarks in [martincostello/benchmarks-demo](https://github.com/martincostello/benchmarks-demo/blob/1c6030ca4dac9ebbeb82e5f7010abc6c7954485e/.github/workflows/benchmark.yml#L20).
