### PR TITLE
Add GitHub token broker configuration

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -263,6 +263,132 @@
             ]
           }
         },
+        "martincostello/browserstack-automate": {
+          "publish": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write"
+            },
+            "Branches": [
+              "main"
+            ],
+            "Environments": [
+              "NuGet.org"
+            ],
+            "Events": [
+              "release",
+              "workflow_dispatch"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "TargetRepository": "github-automation",
+            "Workflows": [
+              "publish.yml"
+            ]
+          },
+          "release": {
+            "AppId": "3916475",
+            "AppPermissions": {
+              "contents": "write"
+            },
+            "Environments": [
+              "release"
+            ],
+            "Events": [
+              "push"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "build.yml"
+            ]
+          },
+          "write": {
+            "TokenId": "costellobot-browserstack-automate-write",
+            "Branches": [
+              "main"
+            ],
+            "Environments": [
+              "release"
+            ],
+            "Events": [
+              "release",
+              "workflow_dispatch"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "bump-version.yml",
+              "release.yml"
+            ]
+          }
+        },
+        "martincostello/build-kit": {
+          "publish": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write"
+            },
+            "Branches": [
+              "main"
+            ],
+            "Environments": [
+              "NuGet.org"
+            ],
+            "Events": [
+              "release",
+              "workflow_dispatch"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "TargetRepository": "github-automation",
+            "Workflows": [
+              "publish.yml"
+            ]
+          },
+          "release": {
+            "AppId": "3916475",
+            "AppPermissions": {
+              "contents": "write"
+            },
+            "Environments": [
+              "release"
+            ],
+            "Events": [
+              "push"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "build.yml"
+            ]
+          },
+          "write": {
+            "TokenId": "costellobot-build-kit-write",
+            "Branches": [
+              "main"
+            ],
+            "Environments": [
+              "release"
+            ],
+            "Events": [
+              "release",
+              "workflow_dispatch"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "bump-version.yml",
+              "release.yml"
+            ]
+          }
+        },
         "martincostello/costellobot": {
           "benchmarks": {
             "AppId": "3842668",
@@ -309,6 +435,69 @@
             ]
           }
         },
+        "martincostello/dotnet-bumper": {
+          "publish": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write"
+            },
+            "Branches": [
+              "main"
+            ],
+            "Environments": [
+              "NuGet.org"
+            ],
+            "Events": [
+              "release",
+              "workflow_dispatch"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "TargetRepository": "github-automation",
+            "Workflows": [
+              "publish.yml"
+            ]
+          },
+          "release": {
+            "AppId": "3916475",
+            "AppPermissions": {
+              "contents": "write"
+            },
+            "Environments": [
+              "release"
+            ],
+            "Events": [
+              "push"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "build.yml"
+            ]
+          },
+          "write": {
+            "TokenId": "costellobot-dotnet-bumper-write",
+            "Branches": [
+              "main"
+            ],
+            "Environments": [
+              "release"
+            ],
+            "Events": [
+              "release",
+              "workflow_dispatch"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "bump-version.yml",
+              "release.yml"
+            ]
+          }
+        },
         "martincostello/home": {
           "write": {
             "TokenId": "costellobot-home-write",
@@ -346,6 +535,69 @@
             "TokenId": "costellobot-immutable-releases-sandbox-write",
             "Branches": [
               "main"
+            ],
+            "Events": [
+              "release",
+              "workflow_dispatch"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "bump-version.yml",
+              "release.yml"
+            ]
+          }
+        },
+        "martincostello/lambda-test-server": {
+          "publish": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write"
+            },
+            "Branches": [
+              "main"
+            ],
+            "Environments": [
+              "NuGet.org"
+            ],
+            "Events": [
+              "release",
+              "workflow_dispatch"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "TargetRepository": "github-automation",
+            "Workflows": [
+              "publish.yml"
+            ]
+          },
+          "release": {
+            "AppId": "3916475",
+            "AppPermissions": {
+              "contents": "write"
+            },
+            "Environments": [
+              "release"
+            ],
+            "Events": [
+              "push"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "build.yml"
+            ]
+          },
+          "write": {
+            "TokenId": "costellobot-lambda-test-server-write",
+            "Branches": [
+              "main"
+            ],
+            "Environments": [
+              "release"
             ],
             "Events": [
               "release",
@@ -459,6 +711,195 @@
             ]
           }
         },
+        "martincostello/Pseudolocalizer": {
+          "publish": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write"
+            },
+            "Branches": [
+              "main"
+            ],
+            "Environments": [
+              "NuGet.org"
+            ],
+            "Events": [
+              "release",
+              "workflow_dispatch"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "TargetRepository": "github-automation",
+            "Workflows": [
+              "publish.yml"
+            ]
+          },
+          "release": {
+            "AppId": "3916475",
+            "AppPermissions": {
+              "contents": "write"
+            },
+            "Environments": [
+              "release"
+            ],
+            "Events": [
+              "push"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "build.yml"
+            ]
+          },
+          "write": {
+            "TokenId": "costellobot-pseudolocalizer-write",
+            "Branches": [
+              "main"
+            ],
+            "Environments": [
+              "release"
+            ],
+            "Events": [
+              "release",
+              "workflow_dispatch"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "bump-version.yml",
+              "release.yml"
+            ]
+          }
+        },
+        "martincostello/sqllocaldb": {
+          "publish": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write"
+            },
+            "Branches": [
+              "main"
+            ],
+            "Environments": [
+              "NuGet.org"
+            ],
+            "Events": [
+              "release",
+              "workflow_dispatch"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "TargetRepository": "github-automation",
+            "Workflows": [
+              "publish.yml"
+            ]
+          },
+          "release": {
+            "AppId": "3916475",
+            "AppPermissions": {
+              "contents": "write"
+            },
+            "Environments": [
+              "release"
+            ],
+            "Events": [
+              "push"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "build.yml"
+            ]
+          },
+          "write": {
+            "TokenId": "costellobot-sqllocaldb-write",
+            "Branches": [
+              "main"
+            ],
+            "Environments": [
+              "release"
+            ],
+            "Events": [
+              "release",
+              "workflow_dispatch"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "bump-version.yml",
+              "release.yml"
+            ]
+          }
+        },
+        "martincostello/wait-for-nuget-package": {
+          "publish": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write"
+            },
+            "Branches": [
+              "main"
+            ],
+            "Environments": [
+              "NuGet.org"
+            ],
+            "Events": [
+              "release",
+              "workflow_dispatch"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "TargetRepository": "github-automation",
+            "Workflows": [
+              "publish.yml"
+            ]
+          },
+          "release": {
+            "AppId": "3916475",
+            "AppPermissions": {
+              "contents": "write"
+            },
+            "Environments": [
+              "release"
+            ],
+            "Events": [
+              "push"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "build.yml"
+            ]
+          },
+          "write": {
+            "TokenId": "costellobot-wait-for-nuget-package-write",
+            "Branches": [
+              "main"
+            ],
+            "Environments": [
+              "release"
+            ],
+            "Events": [
+              "release",
+              "workflow_dispatch"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "bump-version.yml",
+              "release.yml"
+            ]
+          }
+        },
         "martincostello/website": {
           "benchmarks": {
             "AppId": "3842668",
@@ -489,6 +930,69 @@
               "npm-audit-fix.yml"
             ]
           }
+        },
+        "martincostello/xunit-logging": {
+          "publish": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write"
+            },
+            "Branches": [
+              "main"
+            ],
+            "Environments": [
+              "NuGet.org"
+            ],
+            "Events": [
+              "release",
+              "workflow_dispatch"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "TargetRepository": "github-automation",
+            "Workflows": [
+              "publish.yml"
+            ]
+          },
+          "release": {
+            "AppId": "3916475",
+            "AppPermissions": {
+              "contents": "write"
+            },
+            "Environments": [
+              "release"
+            ],
+            "Events": [
+              "push"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "build.yml"
+            ]
+          },
+          "write": {
+            "TokenId": "costellobot-xunit-logging-write",
+            "Branches": [
+              "main"
+            ],
+            "Environments": [
+              "release"
+            ],
+            "Events": [
+              "release",
+              "workflow_dispatch"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "bump-version.yml",
+              "release.yml"
+            ]
+          }
         }
       },
       "Tokens": [
@@ -496,12 +1000,20 @@
         "costellobot-alexa-london-travel-site-write",
         "costellobot-api-write",
         "costellobot-benchmarks-write",
+        "costellobot-browserstack-automate-write",
+        "costellobot-build-kit-write",
         "costellobot-costellobot-write",
+        "costellobot-dotnet-bumper-write",
         "costellobot-home-write",
         "costellobot-immutable-releases-sandbox-write",
+        "costellobot-lambda-test-server-write",
         "costellobot-openapi-extensions-write",
+        "costellobot-pseudolocalizer-write",
+        "costellobot-sqllocaldb-write",
         "costellobot-self-test",
-        "costellobot-website-write"
+        "costellobot-wait-for-nuget-package-write",
+        "costellobot-website-write",
+        "costellobot-xunit-logging-write"
       ],
       "VaultUri": ""
     },


### PR DESCRIPTION
Add profiles for browserstack-automate, build-kit, dotnet-bumper, lambda-test-server, Pseudolocalizer, sqllocaldb, wait-for-nuget-package and xunit-logging.
