### PR TITLE
Add profile for apple-fitness-workout-mapper

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -205,6 +205,47 @@
             ]
           }
         },
+        "martincostello/apple-fitness-workout-mapper": {
+          "release": {
+            "AppId": "3916475",
+            "AppPermissions": {
+              "contents": "write"
+            },
+            "Environments": [
+              "release"
+            ],
+            "Events": [
+              "push"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "build.yml"
+            ]
+          },
+          "write": {
+            "TokenId": "costellobot-apple-fitness-workout-mapper-write",
+            "Branches": [
+              "main"
+            ],
+            "Environments": [
+              "write"
+            ],
+            "Events": [
+              "release",
+              "workflow_dispatch"
+            ],
+            "Tags": [
+              "*"
+            ],
+            "Workflows": [
+              "bump-version.yml",
+              "npm-audit-fix.yml",
+              "release.yml"
+            ]
+          }
+        },
         "martincostello/aspnetcore-openapi": {
           "benchmarks": {
             "AppId": "3842668",
@@ -1206,6 +1247,7 @@
         "costellobot-adventofcode-write",
         "costellobot-alexa-london-travel-site-write",
         "costellobot-api-write",
+        "costellobot-apple-fitness-workout-mapper-write",
         "costellobot-benchmarks-write",
         "costellobot-browserstack-automate-write",
         "costellobot-build-kit-write",


### PR DESCRIPTION
Add GitHub token broker profiles for the apple-fitness-workout-mapper repository.
