### PR TITLE
Fix benchmarks permissions

### DIFF
--- a/src/Costellobot/GitHubTokenBroker.cs
+++ b/src/Costellobot/GitHubTokenBroker.cs
@@ -60,11 +60,12 @@ public sealed partial class GitHubTokenBroker(
 
             var parts = repository.Split('/');
             var owner = parts[0];
-            var repo = profile.TargetRepository is { Length: > 0 } ? profile.TargetRepository : parts[1];
+            var repo = profile.TargetRepositories is { Count: > 0 } ? profile.TargetRepositories[0] : parts[1];
+            var targetRepositories = profile.TargetRepositories is { Count: > 0 } ? profile.TargetRepositories : [repo];
 
             var client = clientFactory.CreateForApp(profile.AppId);
             var installation = await client.GitHubApps.GetRepositoryInstallationForCurrent(owner, repo);
-            var accessToken = await client.CreateInstallationTokenAsync(installation.Id, [repo], profile.AppPermissions, cancellationToken);
+            var accessToken = await client.CreateInstallationTokenAsync(installation.Id, targetRepositories, profile.AppPermissions, cancellationToken);
 
             response = new()
             {

--- a/src/Costellobot/GitHubTokenProfileOptions.cs
+++ b/src/Costellobot/GitHubTokenProfileOptions.cs
@@ -17,7 +17,7 @@ public sealed class GitHubTokenProfileOptions
 
     public IList<string> Tags { get; set; } = [];
 
-    public string? TargetRepository { get; set; }
+    public IList<string>? TargetRepositories { get; set; }
 
     public IList<string> Workflows { get; set; } = [];
 

--- a/src/Costellobot/Slices/Configuration.cshtml
+++ b/src/Costellobot/Slices/Configuration.cshtml
@@ -538,9 +538,9 @@
                                                                                 </tr>
                                                                             }
                                                                             <tr>
-                                                                                <td>Target Repository</td>
+                                                                                <td>Target Repositories</td>
                                                                                 <td>
-                                                                                    <code class="token-broker-target-repository">@(profile.TargetRepository ?? defaultRepository)</code>
+                                                                                    @(CodeList(profile.TargetRepositories ?? [], "token-broker-target-repository"))
                                                                                 </td>
                                                                             </tr>
                                                                         }

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -97,7 +97,8 @@
           "benchmarks": {
             "AppId": "3842668",
             "AppPermissions": {
-              "contents": "write"
+              "contents": "write",
+              "issues": "write"
             },
             "Branches": [
               "*"
@@ -106,7 +107,10 @@
               "push",
               "workflow_dispatch"
             ],
-            "TargetRepository": "benchmarks",
+            "TargetRepositories": [
+              "adventofcode",
+              "benchmarks"
+            ],
             "Workflows": [
               "benchmark-ci.yml"
             ]
@@ -128,7 +132,8 @@
           "benchmarks": {
             "AppId": "3842668",
             "AppPermissions": {
-              "contents": "write"
+              "contents": "write",
+              "issues": "write"
             },
             "Branches": [
               "*"
@@ -137,7 +142,10 @@
               "push",
               "workflow_dispatch"
             ],
-            "TargetRepository": "benchmarks",
+            "TargetRepositories": [
+              "alexa-london-travel",
+              "benchmarks"
+            ],
             "Workflows": [
               "benchmark.yml"
             ]
@@ -147,7 +155,8 @@
           "benchmarks": {
             "AppId": "3842668",
             "AppPermissions": {
-              "contents": "write"
+              "contents": "write",
+              "issues": "write"
             },
             "Branches": [
               "*"
@@ -156,7 +165,10 @@
               "push",
               "workflow_dispatch"
             ],
-            "TargetRepository": "benchmarks",
+            "TargetRepositories": [
+              "alexa-london-travel-site",
+              "benchmarks"
+            ],
             "Workflows": [
               "benchmark.yml"
             ]
@@ -178,7 +190,8 @@
           "benchmarks": {
             "AppId": "3842668",
             "AppPermissions": {
-              "contents": "write"
+              "contents": "write",
+              "issues": "write"
             },
             "Branches": [
               "*"
@@ -187,7 +200,10 @@
               "push",
               "workflow_dispatch"
             ],
-            "TargetRepository": "benchmarks",
+            "TargetRepositories": [
+              "api",
+              "benchmarks"
+            ],
             "Workflows": [
               "benchmark-ci.yml"
             ]
@@ -250,7 +266,8 @@
           "benchmarks": {
             "AppId": "3842668",
             "AppPermissions": {
-              "contents": "write"
+              "contents": "write",
+              "issues": "write"
             },
             "Branches": [
               "*"
@@ -259,7 +276,10 @@
               "push",
               "workflow_dispatch"
             ],
-            "TargetRepository": "benchmarks",
+            "TargetRepositories": [
+              "aspnetcore-openapi",
+              "benchmarks"
+            ],
             "Workflows": [
               "benchmark.yml"
             ]
@@ -269,7 +289,8 @@
           "benchmarks": {
             "AppId": "3842668",
             "AppPermissions": {
-              "contents": "write"
+              "contents": "write",
+              "issues": "write"
             },
             "Branches": [
               "*"
@@ -278,7 +299,10 @@
               "push",
               "workflow_dispatch"
             ],
-            "TargetRepository": "benchmarks",
+            "TargetRepositories": [
+              "aspnetcore-opentelemetry-benchmarks",
+              "benchmarks"
+            ],
             "Workflows": [
               "benchmark.yml"
             ]
@@ -288,7 +312,8 @@
           "benchmarks": {
             "AppId": "3842668",
             "AppPermissions": {
-              "contents": "write"
+              "contents": "write",
+              "issues": "write"
             },
             "Branches": [
               "*"
@@ -298,7 +323,10 @@
               "schedule",
               "workflow_dispatch"
             ],
-            "TargetRepository": "benchmarks",
+            "TargetRepositories": [
+              "benchmarks",
+              "benchmarks-demo"
+            ],
             "Workflows": [
               "benchmark.yml"
             ]
@@ -368,7 +396,9 @@
             "Tags": [
               "*"
             ],
-            "TargetRepository": "github-automation",
+            "TargetRepositories": [
+              "github-automation"
+            ],
             "Workflows": [
               "publish.yml"
             ]
@@ -431,7 +461,9 @@
             "Tags": [
               "*"
             ],
-            "TargetRepository": "github-automation",
+            "TargetRepositories": [
+              "github-automation"
+            ],
             "Workflows": [
               "publish.yml"
             ]
@@ -479,7 +511,8 @@
           "benchmarks": {
             "AppId": "3842668",
             "AppPermissions": {
-              "contents": "write"
+              "contents": "write",
+              "issues": "write"
             },
             "Branches": [
               "*"
@@ -488,7 +521,10 @@
               "push",
               "workflow_dispatch"
             ],
-            "TargetRepository": "benchmarks",
+            "TargetRepositories": [
+              "benchmarks",
+              "costellobot"
+            ],
             "Workflows": [
               "benchmark.yml"
             ]
@@ -556,7 +592,9 @@
             "Tags": [
               "*"
             ],
-            "TargetRepository": "github-automation",
+            "TargetRepositories": [
+              "github-automation"
+            ],
             "Workflows": [
               "publish.yml"
             ]
@@ -728,7 +766,9 @@
             "Tags": [
               "*"
             ],
-            "TargetRepository": "github-automation",
+            "TargetRepositories": [
+              "github-automation"
+            ],
             "Workflows": [
               "publish.yml"
             ]
@@ -796,7 +836,8 @@
           "benchmarks": {
             "AppId": "3842668",
             "AppPermissions": {
-              "contents": "write"
+              "contents": "write",
+              "issues": "write"
             },
             "Branches": [
               "*"
@@ -805,7 +846,10 @@
               "push",
               "workflow_dispatch"
             ],
-            "TargetRepository": "benchmarks",
+            "TargetRepositories": [
+              "benchmarks",
+              "openapi-extensions"
+            ],
             "Workflows": [
               "benchmark.yml"
             ]
@@ -828,7 +872,9 @@
             "Tags": [
               "*"
             ],
-            "TargetRepository": "github-automation",
+            "TargetRepositories": [
+              "github-automation"
+            ],
             "Workflows": [
               "publish.yml"
             ]
@@ -876,7 +922,8 @@
           "benchmarks": {
             "AppId": "3842668",
             "AppPermissions": {
-              "contents": "write"
+              "contents": "write",
+              "issues": "write"
             },
             "Branches": [
               "*"
@@ -885,7 +932,10 @@
               "push",
               "workflow_dispatch"
             ],
-            "TargetRepository": "benchmarks",
+            "TargetRepositories": [
+              "benchmarks",
+              "project-euler"
+            ],
             "Workflows": [
               "benchmark-ci.yml"
             ]
@@ -910,7 +960,9 @@
             "Tags": [
               "*"
             ],
-            "TargetRepository": "github-automation",
+            "TargetRepositories": [
+              "github-automation"
+            ],
             "Workflows": [
               "publish.yml"
             ]
@@ -1018,7 +1070,9 @@
             "Tags": [
               "*"
             ],
-            "TargetRepository": "github-automation",
+            "TargetRepositories": [
+              "github-automation"
+            ],
             "Workflows": [
               "publish.yml"
             ]
@@ -1190,7 +1244,9 @@
             "Tags": [
               "*"
             ],
-            "TargetRepository": "github-automation",
+            "TargetRepositories": [
+              "github-automation"
+            ],
             "Workflows": [
               "publish.yml"
             ]
@@ -1238,7 +1294,8 @@
           "benchmarks": {
             "AppId": "3842668",
             "AppPermissions": {
-              "contents": "write"
+              "contents": "write",
+              "issues": "write"
             },
             "Branches": [
               "*"
@@ -1247,7 +1304,10 @@
               "push",
               "workflow_dispatch"
             ],
-            "TargetRepository": "benchmarks",
+            "TargetRepositories": [
+              "benchmarks",
+              "website"
+            ],
             "Workflows": [
               "benchmark.yml"
             ]
@@ -1284,7 +1344,9 @@
             "Tags": [
               "*"
             ],
-            "TargetRepository": "github-automation",
+            "TargetRepositories": [
+              "github-automation"
+            ],
             "Workflows": [
               "publish.yml"
             ]


### PR DESCRIPTION
Benchmarks need access to comment on issues in the originating repository.

Add `issues: write` permissions to the profiles and extend functionality to allow multi-repository targets.
