### PR TITLE
Refactor build-kit token broker profiles

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -486,8 +486,24 @@
               "build.yml"
             ]
           },
-          "write": {
+          "tag": {
             "TokenId": "costellobot-build-kit-write",
+            "Branches": [
+              "main"
+            ],
+            "Events": [
+              "workflow_dispatch"
+            ],
+            "Workflows": [
+              "release.yml"
+            ]
+          },
+          "write": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write",
+              "pull_requests": "write"
+            },
             "Branches": [
               "main"
             ],
@@ -502,8 +518,7 @@
               "*"
             ],
             "Workflows": [
-              "bump-version.yml",
-              "release.yml"
+              "bump-version.yml"
             ]
           }
         },


### PR DESCRIPTION
- Use GitHub app for `write`.
- Add `tag` profile.
