### PR TITLE
Update NuGet profiles

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -261,8 +261,24 @@
               "build.yml"
             ]
           },
-          "write": {
+          "tag": {
             "TokenId": "costellobot-apple-fitness-workout-mapper-write",
+            "Branches": [
+              "main"
+            ],
+            "Events": [
+              "workflow_dispatch"
+            ],
+            "Workflows": [
+              "release.yml"
+            ]
+          },
+          "write": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write",
+              "pull_requests": "write"
+            },
             "Branches": [
               "main"
             ],
@@ -278,8 +294,7 @@
             ],
             "Workflows": [
               "bump-version.yml",
-              "npm-audit-fix.yml",
-              "release.yml"
+              "npm-audit-fix.yml"
             ]
           }
         },
@@ -442,8 +457,24 @@
               "build.yml"
             ]
           },
-          "write": {
+          "tag": {
             "TokenId": "costellobot-browserstack-automate-write",
+            "Branches": [
+              "main"
+            ],
+            "Events": [
+              "workflow_dispatch"
+            ],
+            "Workflows": [
+              "release.yml"
+            ]
+          },
+          "write": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write",
+              "pull_requests": "write"
+            },
             "Branches": [
               "main"
             ],
@@ -458,8 +489,7 @@
               "*"
             ],
             "Workflows": [
-              "bump-version.yml",
-              "release.yml"
+              "bump-version.yml"
             ]
           }
         },
@@ -660,8 +690,24 @@
               "build.yml"
             ]
           },
-          "write": {
+          "tag": {
             "TokenId": "costellobot-dotnet-bumper-write",
+            "Branches": [
+              "main"
+            ],
+            "Events": [
+              "workflow_dispatch"
+            ],
+            "Workflows": [
+              "release.yml"
+            ]
+          },
+          "write": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write",
+              "pull_requests": "write"
+            },
             "Branches": [
               "main"
             ],
@@ -676,8 +722,7 @@
               "*"
             ],
             "Workflows": [
-              "bump-version.yml",
-              "release.yml"
+              "bump-version.yml"
             ]
           }
         },
@@ -886,8 +931,24 @@
               "build.yml"
             ]
           },
-          "write": {
+          "tag": {
             "TokenId": "costellobot-lambda-test-server-write",
+            "Branches": [
+              "main"
+            ],
+            "Events": [
+              "workflow_dispatch"
+            ],
+            "Workflows": [
+              "release.yml"
+            ]
+          },
+          "write": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write",
+              "pull_requests": "write"
+            },
             "Branches": [
               "main"
             ],
@@ -902,8 +963,7 @@
               "*"
             ],
             "Workflows": [
-              "bump-version.yml",
-              "release.yml"
+              "bump-version.yml"
             ]
           }
         },
@@ -992,8 +1052,24 @@
               "build.yml"
             ]
           },
-          "write": {
+          "tag": {
             "TokenId": "costellobot-openapi-extensions-write",
+            "Branches": [
+              "main"
+            ],
+            "Events": [
+              "workflow_dispatch"
+            ],
+            "Workflows": [
+              "release.yml"
+            ]
+          },
+          "write": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write",
+              "pull_requests": "write"
+            },
             "Branches": [
               "main"
             ],
@@ -1008,8 +1084,7 @@
               "*"
             ],
             "Workflows": [
-              "bump-version.yml",
-              "release.yml"
+              "bump-version.yml"
             ]
           }
         },
@@ -1080,8 +1155,24 @@
               "build.yml"
             ]
           },
-          "write": {
+          "tag": {
             "TokenId": "costellobot-pseudolocalizer-write",
+            "Branches": [
+              "main"
+            ],
+            "Events": [
+              "workflow_dispatch"
+            ],
+            "Workflows": [
+              "release.yml"
+            ]
+          },
+          "write": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write",
+              "pull_requests": "write"
+            },
             "Branches": [
               "main"
             ],
@@ -1096,8 +1187,7 @@
               "*"
             ],
             "Workflows": [
-              "bump-version.yml",
-              "release.yml"
+              "bump-version.yml"
             ]
           }
         },
@@ -1190,8 +1280,24 @@
               "build.yml"
             ]
           },
-          "write": {
+          "tag": {
             "TokenId": "costellobot-sqllocaldb-write",
+            "Branches": [
+              "main"
+            ],
+            "Events": [
+              "workflow_dispatch"
+            ],
+            "Workflows": [
+              "release.yml"
+            ]
+          },
+          "write": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write",
+              "pull_requests": "write"
+            },
             "Branches": [
               "main"
             ],
@@ -1206,8 +1312,7 @@
               "*"
             ],
             "Workflows": [
-              "bump-version.yml",
-              "release.yml"
+              "bump-version.yml"
             ]
           }
         },
@@ -1364,8 +1469,24 @@
               "build.yml"
             ]
           },
-          "write": {
+          "tag": {
             "TokenId": "costellobot-wait-for-nuget-package-write",
+            "Branches": [
+              "main"
+            ],
+            "Events": [
+              "workflow_dispatch"
+            ],
+            "Workflows": [
+              "release.yml"
+            ]
+          },
+          "write": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write",
+              "pull_requests": "write"
+            },
             "Branches": [
               "main"
             ],
@@ -1380,8 +1501,7 @@
               "*"
             ],
             "Workflows": [
-              "bump-version.yml",
-              "release.yml"
+              "bump-version.yml"
             ]
           }
         },
@@ -1471,8 +1591,24 @@
               "build.yml"
             ]
           },
-          "write": {
+          "tag": {
             "TokenId": "costellobot-xunit-logging-write",
+            "Branches": [
+              "main"
+            ],
+            "Events": [
+              "workflow_dispatch"
+            ],
+            "Workflows": [
+              "release.yml"
+            ]
+          },
+          "write": {
+            "AppId": "183256",
+            "AppPermissions": {
+              "contents": "write",
+              "pull_requests": "write"
+            },
             "Branches": [
               "main"
             ],
@@ -1487,15 +1623,13 @@
               "*"
             ],
             "Workflows": [
-              "bump-version.yml",
-              "release.yml"
+              "bump-version.yml"
             ]
           }
         }
       },
       "Tokens": [
         "costellobot-apple-fitness-workout-mapper-write",
-        "costellobot-benchmarks-write",
         "costellobot-browserstack-automate-write",
         "costellobot-build-kit-write",
         "costellobot-dotnet-bumper-write",


### PR DESCRIPTION
Update profiles for NuGet-publishing repos to use `costellobot` to tag and `costellobot[bot]` for writes.
