### PR TITLE
Return GitHub App installation ID

### DIFF
--- a/src/Costellobot/GitHubTokenBroker.cs
+++ b/src/Costellobot/GitHubTokenBroker.cs
@@ -91,6 +91,7 @@ public sealed partial class GitHubTokenBroker(
             {
                 AppId = long.Parse(app.AppId, CultureInfo.InvariantCulture),
                 AppSlug = app.Name,
+                InstallationId = installation.Id,
                 Token = accessToken.Token,
                 TokenType = "app",
             };

--- a/src/Costellobot/Models/GitHubTokenResponse.cs
+++ b/src/Costellobot/Models/GitHubTokenResponse.cs
@@ -20,4 +20,8 @@ public sealed class GitHubTokenResponse
     [JsonPropertyName("appSlug")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? AppSlug { get; set; }
+
+    [JsonPropertyName("installationId")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? InstallationId { get; set; }
 }

--- a/tests/Costellobot.Tests/GitHubTokenTests.cs
+++ b/tests/Costellobot.Tests/GitHubTokenTests.cs
@@ -59,6 +59,10 @@ public sealed class GitHubTokenTests(HttpServerFixture fixture, ITestOutputHelpe
         response.TryGetProperty("appSlug", out var appSlug).ShouldBeTrue();
         appSlug.ValueKind.ShouldBe(JsonValueKind.String);
         appSlug.GetString().ShouldBe("costellobot");
+
+        response.TryGetProperty("installationId", out var installationId).ShouldBeTrue();
+        installationId.ValueKind.ShouldBe(JsonValueKind.Number);
+        installationId.GetInt64().ShouldBe(24364748);
     }
 
     [Fact]
@@ -99,6 +103,7 @@ public sealed class GitHubTokenTests(HttpServerFixture fixture, ITestOutputHelpe
 
         response.TryGetProperty("appId", out _).ShouldBeFalse();
         response.TryGetProperty("appSlug", out _).ShouldBeFalse();
+        response.TryGetProperty("installationId", out _).ShouldBeFalse();
     }
 
     [Fact]


### PR DESCRIPTION
When acquiring a GitHub app token, return the installation ID.
