### PR TITLE
Fix typo

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -827,7 +827,7 @@
               "admin"
             ],
             "Events": [
-              "repository dispatch",
+              "repository_dispatch",
               "schedule",
               "workflow_dispatch"
             ],


### PR DESCRIPTION
Add missing underscore to event name.
