### PR TITLE
Add missing workflow

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -832,6 +832,7 @@
               "workflow_dispatch"
             ],
             "Workflows": [
+              "dotnet-dependencies-updated.yml",
               "dotnet-release.yml",
               "dotnet-upgrade-report.yml",
               "dotnet-upgrade-report-for-nightly.yml",


### PR DESCRIPTION
Allow `dotnet-dependencies-updated` to use the `admin` profile.
