### PR TITLE
Fix workflow permissions

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -1009,7 +1009,8 @@
               "workflow_dispatch"
             ],
             "Workflows": [
-              "update-dotnet-sdks.yml"
+              "update-dotnet-sdks.yml",
+              "update-dotnet-sdks-for-nightly.yml"
             ]
           },
           "write": {


### PR DESCRIPTION
Allow `update-dotnet-sdks-for-nightly.yml` to use the `update-dotnet-sdks` profile.
