### PR TITLE
Fix up icon markup

### DIFF
--- a/src/Costellobot/Slices/Home.cshtml
+++ b/src/Costellobot/Slices/Home.cshtml
@@ -4,7 +4,7 @@
   <div class="container-fluid">
     <h3>
       Application Logs
-      <span class="fa-solid fa-book" />
+      <span class="fa-solid fa-book" aria-hidden="true"></span>
     </h3>
     <div class="row">
       <div class="col-12">
@@ -23,7 +23,7 @@
     <h3>
       Webhook Deliveries
       <span id="webhooks-count"></span>
-      <span class="fa-solid fa-box-open" />
+      <span class="fa-solid fa-box-open" aria-hidden="true"></span>
     </h3>
     <div class="row">
       <div class="col-md-4">

--- a/src/Costellobot/Slices/SignIn.cshtml
+++ b/src/Costellobot/Slices/SignIn.cshtml
@@ -8,7 +8,7 @@
             <strong>
                 Access Denied
             </strong>
-            <span class="fa-solid fa-user-lock " aria-hidden="true"></span>
+            <span class="fa-solid fa-user-lock" aria-hidden="true"></span>
         </p>
         <p>
             To access costellobot, you must grant access to your GitHub account.


### PR DESCRIPTION
- Fix invalid `span` tags.
- Add missing `aria-hidden="true"`.
- Remove trailing space.
