### PR TITLE
Fix token permissions

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -941,6 +941,9 @@
               "schedule",
               "workflow_dispatch"
             ],
+            "TargetRepositories": [
+              "*"
+            ],
             "Workflows": [
               "update-static-assets.yml"
             ]


### PR DESCRIPTION
Allow access to all repositories for the `maintenance` profile for update-static-assets.
