### PR TITLE
Add new workflow to profile

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -1584,6 +1584,7 @@
               "*"
             ],
             "Workflows": [
+              "bump-sha.yml",
               "bump-version.yml"
             ]
           },


### PR DESCRIPTION
Allow the `bump-sha.yml` workflow to use the `version-bump` profile.
