### PR TITLE
Handle PRs marked ready for review

### DIFF
--- a/src/Costellobot/Handlers/PullRequestHandler.cs
+++ b/src/Costellobot/Handlers/PullRequestHandler.cs
@@ -28,10 +28,11 @@ public sealed partial class PullRequestHandler(
 
         bool isManualApproval = false;
 
-        if (!IsNewPullRequestFromTrustedUser(body, out var pull))
+        if (!IsPullRequestFromTrustedUser(body, out var pull))
         {
             if (!await IsManuallyApprovedAsync(pull, body))
             {
+                Log.IgnoringPullRequestAction(logger, pull, message.Action);
                 return;
             }
 
@@ -57,17 +58,19 @@ public sealed partial class PullRequestHandler(
         }
     }
 
-    private bool IsNewPullRequestFromTrustedUser(PullRequestEvent message, out IssueId pull)
+    private bool IsPullRequestFromTrustedUser(PullRequestEvent message, out IssueId pull)
     {
         pull = IssueId.Create(message.Repository!, message.PullRequest!.Number);
 
-        if (!string.Equals(message.Action, PullRequestActionValue.Opened, StringComparison.Ordinal))
+        var isReleventAction = message.Action switch
         {
-            if (!string.Equals(message.Action, PullRequestActionValue.Labeled, StringComparison.Ordinal))
-            {
-                Log.IgnoringPullRequestAction(logger, pull, message.Action);
-            }
+            PullRequestActionValue.Opened => true,
+            PullRequestActionValue.ReadyForReview => true,
+            _ => false,
+        };
 
+        if (!isReleventAction)
+        {
             return false;
         }
 

--- a/src/Costellobot/WellKnownGitHubEvents.cs
+++ b/src/Costellobot/WellKnownGitHubEvents.cs
@@ -26,6 +26,7 @@ public static class WellKnownGitHubEvents
         (WebhookEventType.Push, null),
         (WebhookEventType.PullRequest, PullRequestActionValue.Labeled),
         (WebhookEventType.PullRequest, PullRequestActionValue.Opened),
+        (WebhookEventType.PullRequest, PullRequestActionValue.ReadyForReview),
         (WebhookEventType.PullRequestReview, PullRequestReviewActionValue.Submitted),
         (WebhookEventType.RepositoryDispatch, RepositoryDispatchActionValue.DeploymentCompleted),
         (WebhookEventType.RepositoryDispatch, RepositoryDispatchActionValue.DeploymentStarted),

--- a/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/PullRequestHandlerTests.cs
@@ -15,8 +15,10 @@ namespace MartinCostello.Costellobot.Handlers;
 [Collection<AppCollection>]
 public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outputHelper) : IntegrationTests<AppFixture>(fixture, outputHelper)
 {
-    [Fact]
-    public async Task Pull_Request_Is_Approved_For_Trusted_User_And_Dependency_Name()
+    [Theory]
+    [InlineData("opened")]
+    [InlineData("ready_for_review")]
+    public async Task Pull_Request_Is_Approved_For_Trusted_User_And_Dependency_Name(string action)
     {
         // Arrange
         Fixture.ApprovePullRequests();
@@ -31,7 +33,7 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
         var pullRequestApproved = RegisterReview(driver);
 
         // Act
-        using var response = await PostWebhookAsync(driver);
+        using var response = await PostWebhookAsync(driver, action);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
@@ -345,7 +347,6 @@ public class PullRequestHandlerTests(AppFixture fixture, ITestOutputHelper outpu
     [InlineData("converted_to_draft")]
     [InlineData("edited")]
     [InlineData("locked")]
-    [InlineData("ready_for_review")]
     [InlineData("reopened")]
     [InlineData("review_request_removed")]
     [InlineData("review_requested")]


### PR DESCRIPTION
Auto-approve PRs created after the changes made in https://github.com/martincostello/update-dotnet-sdk/pull/1933 by looking for webhook payloads when a PR is marled as ready-for-review.
