### PR TITLE
Make owner claim configurable

### DIFF
--- a/src/Costellobot/AuthenticationEndpoints.cs
+++ b/src/Costellobot/AuthenticationEndpoints.cs
@@ -129,15 +129,17 @@ public static class AuthenticationEndpoints
         services
             .AddAuthorization()
             .AddOptions<AuthorizationOptions>()
-            .Configure((options) =>
+            .Configure<IOptionsMonitor<GitHubOptions>>((authorization, options) =>
             {
-                options.AddPolicy(GitHubOidcPolicyName, (policy) =>
+                var repositoryOwner = options.CurrentValue.TokenBroker.Owner;
+
+                authorization.AddPolicy(GitHubOidcPolicyName, (policy) =>
                 {
                     policy.RequireAuthenticatedUser()
-                          .RequireClaim(GitHubOidcClaims.RepositoryOwner, "martincostello");
+                          .RequireClaim(GitHubOidcClaims.RepositoryOwner, repositoryOwner);
                 });
 
-                options.AddPolicy(AdminPolicyName, (policy) =>
+                authorization.AddPolicy(AdminPolicyName, (policy) =>
                 {
                     policy.RequireAuthenticatedUser()
                           .AddRequirements(new AdministratorRequirement());

--- a/src/Costellobot/GitHubTokenBrokerOptions.cs
+++ b/src/Costellobot/GitHubTokenBrokerOptions.cs
@@ -7,6 +7,8 @@ public sealed class GitHubTokenBrokerOptions
 {
     public bool IsEnabled { get; set; }
 
+    public string Owner { get; set; } = string.Empty;
+
     public Dictionary<string, Dictionary<string, GitHubTokenProfileOptions>> Repositories { get; set; } = [];
 
     public IList<string> Tokens { get; set; } = [];

--- a/src/Costellobot/Slices/Configuration.cshtml
+++ b/src/Costellobot/Slices/Configuration.cshtml
@@ -413,6 +413,12 @@
                                 </td>
                             </tr>
                             <tr>
+                                <td>Owner</td>
+                                <td>
+                                    <code id="token-broker-repository-owner">@(Model.GitHub.TokenBroker.Owner)</code>
+                                </td>
+                            </tr>
+                            <tr>
                                 <td>Vault URI</td>
                                 <td>
                                     <a href="@(Model.GitHub.TokenBroker.VaultUri)" target="_blank" rel="noopener">

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -103,6 +103,7 @@
     "Scopes": [],
     "TokenBroker": {
       "IsEnabled": true,
+      "Owner": "martincostello",
       "Repositories": {
         "martincostello/adventofcode": {
           "benchmarks": {

--- a/src/Costellobot/appsettings.schema.json
+++ b/src/Costellobot/appsettings.schema.json
@@ -132,6 +132,10 @@
           "type": "boolean",
           "description": "Whether the token broker functionality is enabled."
         },
+        "Owner": {
+          "type": "string",
+          "description": "The owner of the GitHub repositories for which the token broker can issue tokens."
+        },
         "Repositories": {
           "type": "object",
           "description": "A dictionary of repositories (keyed by 'owner/name'), each mapping a named permission/policy to its configuration.",


### PR DESCRIPTION
Remove hard-coded owner for OIDC authorization and instead load from configuration.
