### PR TITLE
Add service.criticality resource attribute

### DIFF
--- a/src/Costellobot/ApplicationTelemetry.cs
+++ b/src/Costellobot/ApplicationTelemetry.cs
@@ -24,6 +24,7 @@ public static class ApplicationTelemetry
         .AddProcessRuntimeDetector()
         .AddAttributes(
             [
+                new("service.criticality", "high"),
                 new("vcs.owner.name", GitMetadata.RepositoryOwner),
                 new("vcs.provider.name", "github"),
                 new("vcs.ref.head.name", GitMetadata.Branch),


### PR DESCRIPTION
Add the `service.criticality` resource attribute to the service.
