### PR TITLE
Improve dependency highlighting

### DIFF
--- a/src/Costellobot/AdminEndpoints.cs
+++ b/src/Costellobot/AdminEndpoints.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
-using NuGet.Versioning;
 using Octokit;
 using Activity = System.Diagnostics.Activity;
 
@@ -359,35 +358,20 @@ public static class AdminEndpoints
                     DependencyEcosystem.Ruby,
                 ];
 
-                var comparer = Comparer<string>.Create(static (x, y) =>
-                {
-                    if (NuGetVersion.TryParse(x, out var versionX) &&
-                        NuGetVersion.TryParse(y, out var versionY))
-                    {
-                        return versionX.CompareTo(versionY);
-                    }
-
-                    return string.Compare(x, y, StringComparison.Ordinal);
-                });
-
-                var trusted = new Dictionary<DependencyEcosystem, IReadOnlyList<TrustedDependency>>();
-                var denied = new Dictionary<DependencyEcosystem, IReadOnlyList<DeniedDependency>>();
+                var trusted = new Dictionary<DependencyEcosystem, IReadOnlyList<OrderedDependency<TrustedDependency>>>();
+                var denied = new Dictionary<DependencyEcosystem, IReadOnlyList<OrderedDependency<DeniedDependency>>>();
 
                 foreach (var ecosystem in ecosystems)
                 {
                     var trustedDependencies = await store.GetTrustAsync(ecosystem, cancellationToken);
                     var deniedDependencies = await store.GetDeniedAsync(ecosystem, cancellationToken);
 
-                    trusted[ecosystem] = Sort(trustedDependencies, comparer);
-                    denied[ecosystem] = Sort(deniedDependencies, comparer);
+                    trusted[ecosystem] = DependencyHighlighter.Order(ecosystem, trustedDependencies, (p) => p.TrustedAt);
+                    denied[ecosystem] = DependencyHighlighter.Order(ecosystem, deniedDependencies, (p) => p.DeniedAt);
                 }
 
                 var model = new DependenciesModel(trusted, denied);
                 return Results.RazorSlice<Dependencies, DependenciesModel>(model);
-
-                static IReadOnlyList<T> Sort<T>(IEnumerable<T> collection, Comparer<string> comparer)
-                    where T : IDependency =>
-                    [.. collection.OrderBy((p) => p.Id).ThenByDescending((p) => p.Version, comparer)];
             })
             .AddEndpointFilter<SetAntiforgeryCookieFilter>()
             .WithName(DependenciesRoute)

--- a/src/Costellobot/DependencyHighlighter.cs
+++ b/src/Costellobot/DependencyHighlighter.cs
@@ -1,0 +1,191 @@
+// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using MartinCostello.Costellobot.Models;
+using NuGet.Versioning;
+
+namespace MartinCostello.Costellobot;
+
+/// <summary>
+/// A class that orders dependencies for display and marks the versions that are
+/// superseded by a more recent version of the same dependency as being outdated.
+/// </summary>
+public static class DependencyHighlighter
+{
+    private static readonly IComparer<string> VersionComparer = Comparer<string>.Create(Compare);
+
+    /// <summary>
+    /// Orders the specified dependencies for display and determines which are outdated.
+    /// </summary>
+    /// <typeparam name="T">The type of the dependency.</typeparam>
+    /// <param name="ecosystem">The ecosystem the dependencies belong to.</param>
+    /// <param name="dependencies">The dependencies to order.</param>
+    /// <param name="timestamp">A delegate to get the timestamp associated with a dependency.</param>
+    /// <returns>
+    /// The dependencies ordered for display, each paired with whether it is outdated.
+    /// </returns>
+    public static IReadOnlyList<OrderedDependency<T>> Order<T>(
+        DependencyEcosystem ecosystem,
+        IEnumerable<T> dependencies,
+        Func<T, DateTimeOffset?> timestamp)
+        where T : IDependency
+    {
+        var ordered = new List<OrderedDependency<T>>();
+
+        foreach (var group in dependencies.GroupBy((p) => p.Id, StringComparer.Ordinal))
+        {
+            ordered.AddRange(MarkOutdated(ecosystem, [.. group], timestamp));
+        }
+
+        return
+        [
+            .. ordered
+                .OrderBy((p) => p.Dependency.Id, StringComparer.Ordinal)
+                .ThenBy((p) => p.IsOutdated)
+                .ThenByDescending((p) => p.Dependency.Version, VersionComparer),
+        ];
+    }
+
+    private static IEnumerable<OrderedDependency<T>> MarkOutdated<T>(
+        DependencyEcosystem ecosystem,
+        IReadOnlyList<T> group,
+        Func<T, DateTimeOffset?> timestamp)
+        where T : IDependency
+    {
+        if (ecosystem is DependencyEcosystem.Docker)
+        {
+            return MarkDockerOutdated(group, timestamp);
+        }
+        else if (ecosystem is DependencyEcosystem.GitHubActions)
+        {
+            return MarkGitHubActionsOutdated(group);
+        }
+        else
+        {
+            return MarkOutdatedByVersion(group);
+        }
+    }
+
+    private static IEnumerable<OrderedDependency<T>> MarkOutdatedByVersion<T>(IReadOnlyList<T> group)
+        where T : IDependency
+    {
+        var latest = group.Select((p) => p.Version).Max(VersionComparer)!;
+        return group.Select((p) => new OrderedDependency<T>(p, Compare(p.Version, latest) < 0));
+    }
+
+    private static IEnumerable<OrderedDependency<T>> MarkDockerOutdated<T>(
+        IReadOnlyList<T> group,
+        Func<T, DateTimeOffset?> timestamp)
+        where T : IDependency
+    {
+        // A Docker version may be pinned to a specific image with a digest of the
+        // form "{tag}-{digest}" (e.g. "8.8.0-0a972..."). Such a version is treated
+        // as equivalent to the plain "{tag}" version for the purposes of determining
+        // which version is the most recent, so that the digest does not cause an
+        // otherwise current version to be highlighted as outdated.
+        var entries = group
+            .Select((p) => (Dependency: p, BaseVersion: DockerBaseVersion(p.Version), HasDigest: HasDockerDigest(p.Version)))
+            .ToArray();
+
+        var latestBaseVersion = entries.Select((p) => p.BaseVersion).Max(VersionComparer)!;
+
+        // When there are multiple digests for the latest version, the one with the
+        // newest timestamp is considered the most recent and the others are outdated.
+        var latestDigest = entries
+            .Where((p) => p.HasDigest && Compare(p.BaseVersion, latestBaseVersion) is 0)
+            .OrderByDescending((p) => timestamp(p.Dependency) ?? DateTimeOffset.MinValue)
+            .ThenByDescending((p) => p.Dependency.Version, VersionComparer)
+            .Select((p) => p.Dependency)
+            .FirstOrDefault();
+
+        return entries.Select((entry) =>
+        {
+            bool isLatestVersion = Compare(entry.BaseVersion, latestBaseVersion) is 0;
+
+            bool isOutdated = (isLatestVersion, entry.HasDigest) switch
+            {
+                (false, _) => true,
+                (true, false) => false,
+                (true, true) => !ReferenceEquals(entry.Dependency, latestDigest),
+            };
+
+            return new OrderedDependency<T>(entry.Dependency, isOutdated);
+        });
+    }
+
+    private static IEnumerable<OrderedDependency<T>> MarkGitHubActionsOutdated<T>(IReadOnlyList<T> group)
+        where T : IDependency
+    {
+        var latest = group.Select((p) => p.Version).Max(VersionComparer)!;
+        int? latestMajor = NuGetVersion.TryParse(latest, out var version) ? version.Major : null;
+
+        return group.Select((p) =>
+        {
+            // A major-version-only entry (e.g. "23") is treated as equivalent to a more
+            // specific version that shares the same major version (e.g. "23.2.0"), so that
+            // it is not highlighted as outdated when a more specific version is the latest.
+            bool isOutdated =
+                Compare(p.Version, latest) is not 0 &&
+                !(latestMajor is { } major && IsMajorOnly(p.Version, out int itemMajor) && itemMajor == major);
+
+            return new OrderedDependency<T>(p, isOutdated);
+        });
+    }
+
+    private static bool HasDockerDigest(string version)
+        => TrySplitDockerDigest(version, out _);
+
+    private static string DockerBaseVersion(string version)
+        => TrySplitDockerDigest(version, out var baseVersion) ? baseVersion : version;
+
+    private static bool TrySplitDockerDigest(string version, out string baseVersion)
+    {
+        // A Docker digest is the SHA-256 hash of the image (i.e. 64 hexadecimal characters).
+        int index = version.LastIndexOf('-');
+
+        if (index > 0 && IsDigest(version.AsSpan(index + 1)))
+        {
+            baseVersion = version[..index];
+            return true;
+        }
+
+        baseVersion = version;
+        return false;
+
+        static bool IsDigest(ReadOnlySpan<char> value)
+        {
+            if (value.Length is not 64)
+            {
+                return false;
+            }
+
+            foreach (char ch in value)
+            {
+                if (!char.IsAsciiHexDigit(ch))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+
+    private static bool IsMajorOnly(string version, out int major)
+    {
+        major = 0;
+        return !version.Contains('.', StringComparison.Ordinal) &&
+               int.TryParse(version, NumberStyles.None, CultureInfo.InvariantCulture, out major);
+    }
+
+    private static int Compare(string x, string y)
+    {
+        if (NuGetVersion.TryParse(x, out var versionX) &&
+            NuGetVersion.TryParse(y, out var versionY))
+        {
+            return versionX.CompareTo(versionY);
+        }
+
+        return string.Compare(x, y, StringComparison.Ordinal);
+    }
+}

--- a/src/Costellobot/Models/DependenciesModel.cs
+++ b/src/Costellobot/Models/DependenciesModel.cs
@@ -4,10 +4,10 @@
 namespace MartinCostello.Costellobot.Models;
 
 public sealed class DependenciesModel(
-    IReadOnlyDictionary<DependencyEcosystem, IReadOnlyList<TrustedDependency>> trusted,
-    IReadOnlyDictionary<DependencyEcosystem, IReadOnlyList<DeniedDependency>> denied)
+    IReadOnlyDictionary<DependencyEcosystem, IReadOnlyList<OrderedDependency<TrustedDependency>>> trusted,
+    IReadOnlyDictionary<DependencyEcosystem, IReadOnlyList<OrderedDependency<DeniedDependency>>> denied)
 {
-    public IReadOnlyDictionary<DependencyEcosystem, IReadOnlyList<TrustedDependency>> Trusted { get; } = trusted;
+    public IReadOnlyDictionary<DependencyEcosystem, IReadOnlyList<OrderedDependency<TrustedDependency>>> Trusted { get; } = trusted;
 
-    public IReadOnlyDictionary<DependencyEcosystem, IReadOnlyList<DeniedDependency>> Denied { get; } = denied;
+    public IReadOnlyDictionary<DependencyEcosystem, IReadOnlyList<OrderedDependency<DeniedDependency>>> Denied { get; } = denied;
 }

--- a/src/Costellobot/Models/OrderedDependency`1.cs
+++ b/src/Costellobot/Models/OrderedDependency`1.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Costellobot.Models;
+
+/// <summary>
+/// Represents a dependency ordered for display along with whether it has been
+/// superseded by a more recent version of the same dependency.
+/// </summary>
+/// <typeparam name="T">The type of the dependency.</typeparam>
+/// <param name="Dependency">The dependency.</param>
+/// <param name="IsOutdated">Whether the dependency is outdated.</param>
+public sealed record OrderedDependency<T>(T Dependency, bool IsOutdated)
+    where T : IDependency;

--- a/src/Costellobot/Slices/Dependencies.cshtml
+++ b/src/Costellobot/Slices/Dependencies.cshtml
@@ -34,51 +34,48 @@
                 <tbody>
                     @foreach ((var ecosystem, var dependencies) in Model.Trusted)
                     {
-                        foreach (var group in dependencies.GroupBy((p) => p.Id))
+                        foreach ((var dependency, var isOutdated) in dependencies)
                         {
-                            foreach ((var index, var dependency) in group.Index())
-                            {
-                                (var name, var url, var icon) = DependencyHelpers.GetPackageMetadata(ecosystem, dependency.Id, dependency.Version);
+                            (var name, var url, var icon) = DependencyHelpers.GetPackageMetadata(ecosystem, dependency.Id, dependency.Version);
 
-                                <tr class="trusted-dependency @(index is not 0 ? "table-light" : null)">
-                                    <td>
-                                        <span class="dependency-ecosystem @(icon)" title="@(name)" aria-hidden="true"></span>
-                                    </td>
-                                    <td>
-                                        <code class="dependency-id">
-                                            @if (url is { Length: > 0 })
-                                            {
-                                                <a href="@(url)" target="_blank" rel="noopener">@(dependency.Id)</a>
-                                            }
-                                            else
-                                            {
-                                                @(dependency.Id)
-                                            }
-                                        </code>
-                                    </td>
-                                    <td>
-                                        <code class="dependency-version">@(dependency.Version)</code>
-                                    </td>
-                                    <td>
-                                        <div class="dependency-timestamp" title="@(dependency.TrustedAt?.ToString("u", CultureInfo.InvariantCulture))">
-                                            @(dependency.TrustedAt?.Humanize())
+                            <tr class="trusted-dependency @(isOutdated ? "table-light" : null)">
+                                <td>
+                                    <span class="dependency-ecosystem @(icon)" title="@(name)" aria-hidden="true"></span>
+                                </td>
+                                <td>
+                                    <code class="dependency-id">
+                                        @if (url is { Length: > 0 })
+                                        {
+                                            <a href="@(url)" target="_blank" rel="noopener">@(dependency.Id)</a>
+                                        }
+                                        else
+                                        {
+                                            @(dependency.Id)
+                                        }
+                                    </code>
+                                </td>
+                                <td>
+                                    <code class="dependency-version">@(dependency.Version)</code>
+                                </td>
+                                <td>
+                                    <div class="dependency-timestamp" title="@(dependency.TrustedAt?.ToString("u", CultureInfo.InvariantCulture))">
+                                        @(dependency.TrustedAt?.Humanize())
+                                    </div>
+                                </td>
+                                <td>
+                                    <form action="dependencies/distrust" method="post">
+                                        <input type="hidden" name="@(tokens.FormFieldName)" value="@(tokens.RequestToken)">
+                                        <input type="hidden" name="ecosystem" value="@(ecosystem)">
+                                        <input type="hidden" name="id" value="@(dependency.Id)">
+                                        <input type="hidden" name="version" value="@(dependency.Version)">
+                                        <div class="d-grid">
+                                            <button class="btn btn-danger btn-sm distrust-dependency" title="Distrust @(dependency.Id) @(dependency.Version)" type="submit">
+                                                <span class="fa-solid fa-ban" aria-hidden="true"></span>
+                                            </button>
                                         </div>
-                                    </td>
-                                    <td>
-                                        <form action="dependencies/distrust" method="post">
-                                            <input type="hidden" name="@(tokens.FormFieldName)" value="@(tokens.RequestToken)">
-                                            <input type="hidden" name="ecosystem" value="@(ecosystem)">
-                                            <input type="hidden" name="id" value="@(dependency.Id)">
-                                            <input type="hidden" name="version" value="@(dependency.Version)">
-                                            <div class="d-grid">
-                                                <button class="btn btn-danger btn-sm distrust-dependency" title="Distrust @(dependency.Id) @(dependency.Version)" type="submit">
-                                                    <span class="fa-solid fa-ban" aria-hidden="true"></span>
-                                                </button>
-                                            </div>
-                                        </form>
-                                    </td>
-                                </tr>
-                            }
+                                    </form>
+                                </td>
+                            </tr>
                         }
                     }
                     <tr>
@@ -123,51 +120,48 @@
                 <tbody>
                     @foreach ((var ecosystem, var denied) in Model.Denied)
                     {
-                        foreach (var group in denied.GroupBy((p) => p.Id))
+                        foreach ((var dependency, var isOutdated) in denied)
                         {
-                            foreach ((var index, var dependency) in group.Index())
-                            {
-                                (var name, var url, var icon) = DependencyHelpers.GetPackageMetadata(ecosystem, dependency.Id, dependency.Version);
+                            (var name, var url, var icon) = DependencyHelpers.GetPackageMetadata(ecosystem, dependency.Id, dependency.Version);
 
-                                <tr class="denied-dependency @(index is not 0 ? "table-light" : null)">
-                                    <td>
-                                        <span class="dependency-ecosystem @(icon)" title="@(name)" aria-hidden="true"></span>
-                                    </td>
-                                    <td>
-                                        <code class="dependency-id">
-                                            @if (url is { Length: > 0 })
-                                            {
-                                                <a href="@(url)" target="_blank" rel="noopener">@(dependency.Id)</a>
-                                            }
-                                            else
-                                            {
-                                                @(dependency.Id)
-                                            }
-                                        </code>
-                                    </td>
-                                    <td>
-                                        <code class="dependency-version">@(dependency.Version)</code>
-                                    </td>
-                                    <td>
-                                        <div class="dependency-timestamp" title="@(dependency.DeniedAt?.ToString("u", CultureInfo.InvariantCulture))">
-                                            @(dependency.DeniedAt?.Humanize())
+                            <tr class="denied-dependency @(isOutdated ? "table-light" : null)">
+                                <td>
+                                    <span class="dependency-ecosystem @(icon)" title="@(name)" aria-hidden="true"></span>
+                                </td>
+                                <td>
+                                    <code class="dependency-id">
+                                        @if (url is { Length: > 0 })
+                                        {
+                                            <a href="@(url)" target="_blank" rel="noopener">@(dependency.Id)</a>
+                                        }
+                                        else
+                                        {
+                                            @(dependency.Id)
+                                        }
+                                    </code>
+                                </td>
+                                <td>
+                                    <code class="dependency-version">@(dependency.Version)</code>
+                                </td>
+                                <td>
+                                    <div class="dependency-timestamp" title="@(dependency.DeniedAt?.ToString("u", CultureInfo.InvariantCulture))">
+                                        @(dependency.DeniedAt?.Humanize())
+                                    </div>
+                                </td>
+                                <td>
+                                    <form action="dependencies/allow" method="post">
+                                        <input type="hidden" name="@(tokens.FormFieldName)" value="@(tokens.RequestToken)">
+                                        <input type="hidden" name="ecosystem" value="@(ecosystem)">
+                                        <input type="hidden" name="id" value="@(dependency.Id)">
+                                        <input type="hidden" name="version" value="@(dependency.Version)">
+                                        <div class="d-grid">
+                                            <button class="btn btn-danger btn-sm allow-dependency" title="Allow @(dependency.Id) @(dependency.Version)" type="submit">
+                                                <span class="fa-solid fa-trash-can" aria-hidden="true"></span>
+                                            </button>
                                         </div>
-                                    </td>
-                                    <td>
-                                        <form action="dependencies/allow" method="post">
-                                            <input type="hidden" name="@(tokens.FormFieldName)" value="@(tokens.RequestToken)">
-                                            <input type="hidden" name="ecosystem" value="@(ecosystem)">
-                                            <input type="hidden" name="id" value="@(dependency.Id)">
-                                            <input type="hidden" name="version" value="@(dependency.Version)">
-                                            <div class="d-grid">
-                                                <button class="btn btn-danger btn-sm allow-dependency" title="Allow @(dependency.Id) @(dependency.Version)" type="submit">
-                                                    <span class="fa-solid fa-trash-can" aria-hidden="true"></span>
-                                                </button>
-                                            </div>
-                                        </form>
-                                    </td>
-                                </tr>
-                            }
+                                    </form>
+                                </td>
+                            </tr>
                         }
                     }
                 </tbody>

--- a/tests/Costellobot.Tests/DependencyHighlighterTests.cs
+++ b/tests/Costellobot.Tests/DependencyHighlighterTests.cs
@@ -1,0 +1,193 @@
+// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using MartinCostello.Costellobot.Models;
+
+namespace MartinCostello.Costellobot;
+
+public static class DependencyHighlighterTests
+{
+    private const string DigestA = "0a972391db0b24ec336e35d1bc98b237237e26f82bf5120cf2f6b1688d1df973";
+    private const string DigestB = "1111111111111111111111111111111111111111111111111111111111111111";
+    private const string DigestC = "2222222222222222222222222222222222222222222222222222222222222222";
+
+    [Fact]
+    public static void Order_Marks_Older_Versions_As_Outdated_For_NuGet()
+    {
+        // Arrange
+        TrustedDependency[] dependencies =
+        [
+            Trusted("Verify.XunitV3", "28.10.1"),
+            Trusted("Verify.XunitV3", "28.11.0"),
+            Trusted("Verify.ImageMagick", "3.5.0"),
+        ];
+
+        // Act
+        var actual = Order(DependencyEcosystem.NuGet, dependencies);
+
+        // Assert
+        actual.ShouldSatisfyAllConditions(
+            () => Outdated(actual, "Verify.ImageMagick", "3.5.0").ShouldBeFalse(),
+            () => Outdated(actual, "Verify.XunitV3", "28.11.0").ShouldBeFalse(),
+            () => Outdated(actual, "Verify.XunitV3", "28.10.1").ShouldBeTrue());
+
+        // The newest version of each dependency is displayed first.
+        actual.Select((p) => p.Dependency.Version).ShouldBe(["3.5.0", "28.11.0", "28.10.1"]);
+    }
+
+    [Fact]
+    public static void Order_Treats_Docker_Tag_And_Its_Digest_As_Equivalent()
+    {
+        // Arrange
+        TrustedDependency[] dependencies =
+        [
+            Trusted("dotnet/runtime", "8.8.0"),
+            Trusted("dotnet/runtime", $"8.8.0-{DigestA}"),
+        ];
+
+        // Act
+        var actual = Order(DependencyEcosystem.Docker, dependencies);
+
+        // Assert - neither is highlighted as outdated as they are the same version
+        actual.ShouldAllBe((p) => !p.IsOutdated);
+    }
+
+    [Fact]
+    public static void Order_Marks_Equivalent_Docker_Versions_As_Outdated_When_Newer_Version_Exists()
+    {
+        // Arrange
+        TrustedDependency[] dependencies =
+        [
+            Trusted("dotnet/runtime", "8.8.0"),
+            Trusted("dotnet/runtime", $"8.8.0-{DigestA}"),
+            Trusted("dotnet/runtime", "8.8.1"),
+            Trusted("dotnet/runtime", $"8.8.1-{DigestB}"),
+        ];
+
+        // Act
+        var actual = Order(DependencyEcosystem.Docker, dependencies);
+
+        // Assert - the newer 8.8.1 pair makes both 8.8.0 versions outdated
+        actual.ShouldSatisfyAllConditions(
+            () => Outdated(actual, "dotnet/runtime", "8.8.1").ShouldBeFalse(),
+            () => Outdated(actual, "dotnet/runtime", $"8.8.1-{DigestB}").ShouldBeFalse(),
+            () => Outdated(actual, "dotnet/runtime", "8.8.0").ShouldBeTrue(),
+            () => Outdated(actual, "dotnet/runtime", $"8.8.0-{DigestA}").ShouldBeTrue());
+    }
+
+    [Fact]
+    public static void Order_Marks_Older_Docker_Digests_As_Outdated_By_Timestamp()
+    {
+        // Arrange
+        var baseline = new DateTimeOffset(2026, 06, 16, 12, 00, 00, TimeSpan.Zero);
+
+        TrustedDependency[] dependencies =
+        [
+            Trusted("dotnet/runtime", "8.8.0", baseline),
+            Trusted("dotnet/runtime", $"8.8.0-{DigestA}", baseline.AddHours(1)),
+            Trusted("dotnet/runtime", $"8.8.0-{DigestB}", baseline.AddHours(2)),
+        ];
+
+        // Act
+        var actual = Order(DependencyEcosystem.Docker, dependencies);
+
+        // Assert - the plain tag and the newest digest are current; the older digest is outdated
+        actual.ShouldSatisfyAllConditions(
+            () => Outdated(actual, "dotnet/runtime", "8.8.0").ShouldBeFalse(),
+            () => Outdated(actual, "dotnet/runtime", $"8.8.0-{DigestB}").ShouldBeFalse(),
+            () => Outdated(actual, "dotnet/runtime", $"8.8.0-{DigestA}").ShouldBeTrue());
+    }
+
+    [Fact]
+    public static void Order_Marks_Older_Docker_Digests_As_Outdated_By_Timestamp_With_No_Plain_Tag()
+    {
+        // Arrange
+        var baseline = new DateTimeOffset(2026, 06, 16, 12, 00, 00, TimeSpan.Zero);
+
+        TrustedDependency[] dependencies =
+        [
+            Trusted("dotnet/runtime", $"8.8.0-{DigestA}", baseline.AddHours(2)),
+            Trusted("dotnet/runtime", $"8.8.0-{DigestB}", baseline.AddHours(1)),
+            Trusted("dotnet/runtime", $"8.8.0-{DigestC}", baseline),
+        ];
+
+        // Act
+        var actual = Order(DependencyEcosystem.Docker, dependencies);
+
+        // Assert - only the digest with the newest timestamp is current
+        actual.ShouldSatisfyAllConditions(
+            () => Outdated(actual, "dotnet/runtime", $"8.8.0-{DigestA}").ShouldBeFalse(),
+            () => Outdated(actual, "dotnet/runtime", $"8.8.0-{DigestB}").ShouldBeTrue(),
+            () => Outdated(actual, "dotnet/runtime", $"8.8.0-{DigestC}").ShouldBeTrue());
+    }
+
+    [Fact]
+    public static void Order_Treats_Major_Version_Only_As_Equivalent_For_GitHub_Actions()
+    {
+        // Arrange
+        TrustedDependency[] dependencies =
+        [
+            Trusted("actions/checkout", "23"),
+            Trusted("actions/checkout", "23.2.0"),
+        ];
+
+        // Act
+        var actual = Order(DependencyEcosystem.GitHubActions, dependencies);
+
+        // Assert - the major-only entry is equivalent to the more specific version
+        actual.ShouldAllBe((p) => !p.IsOutdated);
+    }
+
+    [Fact]
+    public static void Order_Marks_Older_Specific_GitHub_Actions_Versions_As_Outdated()
+    {
+        // Arrange
+        TrustedDependency[] dependencies =
+        [
+            Trusted("actions/checkout", "23"),
+            Trusted("actions/checkout", "23.1.0"),
+            Trusted("actions/checkout", "23.2.0"),
+            Trusted("actions/checkout", "22.5.0"),
+        ];
+
+        // Act
+        var actual = Order(DependencyEcosystem.GitHubActions, dependencies);
+
+        // Assert
+        actual.ShouldSatisfyAllConditions(
+            () => Outdated(actual, "actions/checkout", "23").ShouldBeFalse(),
+            () => Outdated(actual, "actions/checkout", "23.2.0").ShouldBeFalse(),
+            () => Outdated(actual, "actions/checkout", "23.1.0").ShouldBeTrue(),
+            () => Outdated(actual, "actions/checkout", "22.5.0").ShouldBeTrue());
+    }
+
+    [Fact]
+    public static void Order_Marks_Major_Version_Only_As_Outdated_When_Newer_Major_Exists()
+    {
+        // Arrange
+        TrustedDependency[] dependencies =
+        [
+            Trusted("actions/checkout", "23"),
+            Trusted("actions/checkout", "24.0.0"),
+        ];
+
+        // Act
+        var actual = Order(DependencyEcosystem.GitHubActions, dependencies);
+
+        // Assert - a newer major version makes the major-only entry outdated
+        actual.ShouldSatisfyAllConditions(
+            () => Outdated(actual, "actions/checkout", "24.0.0").ShouldBeFalse(),
+            () => Outdated(actual, "actions/checkout", "23").ShouldBeTrue());
+    }
+
+    private static IReadOnlyList<OrderedDependency<TrustedDependency>> Order(
+        DependencyEcosystem ecosystem,
+        IEnumerable<TrustedDependency> dependencies)
+        => DependencyHighlighter.Order(ecosystem, dependencies, (p) => p.TrustedAt);
+
+    private static TrustedDependency Trusted(string id, string version, DateTimeOffset? trustedAt = null)
+        => new(id, version) { TrustedAt = trustedAt };
+
+    private static bool Outdated(IEnumerable<OrderedDependency<TrustedDependency>> dependencies, string id, string version)
+        => dependencies.Single((p) => p.Dependency.Id == id && p.Dependency.Version == version).IsOutdated;
+}


### PR DESCRIPTION
Make Docker versions with and without digests equivalent to each other and GitHub Actions floating tagss equivalent to the latest major.minor.patch version.
