### PR TITLE
Increase MyGet timeout

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -1997,7 +1997,8 @@
         "BaseAddress": "https://mcr.microsoft.com"
       },
       "MyGet-OpenTelemetry": {
-        "BaseAddress": "https://www.myget.org/F/opentelemetry/api/v3/"
+        "BaseAddress": "https://www.myget.org/F/opentelemetry/api/v3/",
+        "Timeout": "00:00:10"
       },
       "Npm": {
         "BaseAddress": "https://registry.npmjs.org"


### PR DESCRIPTION
Allow up to 10 seconds to query MyGet for packages.
