### PR TITLE
Performance optimisations

### DIFF
--- a/src/Costellobot/ApplicationTelemetry.cs
+++ b/src/Costellobot/ApplicationTelemetry.cs
@@ -12,7 +12,10 @@ public static class ApplicationTelemetry
 {
     public static readonly string ServiceName = "Costellobot";
     public static readonly string ServiceNamespace = "Costellobot";
-    public static readonly string ServiceVersion = GitMetadata.Version.Split('+')[0];
+    public static readonly string ServiceVersion = GitMetadata.Version.IndexOf('+', StringComparison.Ordinal) is >= 0 and var i
+        ? GitMetadata.Version[..i]
+        : GitMetadata.Version;
+
     public static readonly ActivitySource ActivitySource = new(ServiceName, ServiceVersion);
 
     public static ResourceBuilder ResourceBuilder { get; } = ResourceBuilder.CreateDefault()

--- a/src/Costellobot/GitCommitAnalyzer.cs
+++ b/src/Costellobot/GitCommitAnalyzer.cs
@@ -434,6 +434,10 @@ public sealed partial class GitCommitAnalyzer(
             }
         }
 
+        var registriesForEcosystem = _registries
+            .Where((p) => p.Ecosystem == ecosystem)
+            .ToList();
+
         // If a dependency is not trusted by name alone, determine whether it is trusted through its owner or implicitly
         foreach ((string dependency, var trust) in dependencyTrust.Where((p) => !p.Value.Trusted))
         {
@@ -470,7 +474,7 @@ public sealed partial class GitCommitAnalyzer(
 
         foreach ((string dependency, var trust) in dependencyTrust.Where((p) => p.Value.Trusted))
         {
-            var registry = _registries.FirstOrDefault((p) => p.Ecosystem == ecosystem);
+            var registry = registriesForEcosystem.FirstOrDefault();
 
             if (registry is null)
             {
@@ -570,9 +574,7 @@ public sealed partial class GitCommitAnalyzer(
                 return (false, version);
             }
 
-            var registries = _registries.Where((p) => p.Ecosystem == ecosystem).ToList();
-
-            if (registries.Count == 0)
+            if (registriesForEcosystem.Count == 0)
             {
                 return (false, version);
             }
@@ -584,7 +586,7 @@ public sealed partial class GitCommitAnalyzer(
                 return (false, version);
             }
 
-            foreach (var registry in registries)
+            foreach (var registry in registriesForEcosystem)
             {
                 if (await IsTrustedDependencyOwnerAsync(
                         repository,

--- a/src/Costellobot/GitHubTokenBroker.cs
+++ b/src/Costellobot/GitHubTokenBroker.cs
@@ -61,20 +61,20 @@ public sealed partial class GitHubTokenBroker(
                 return Results.Problem($"Profile '{profileName}' does not have a valid GitHub app configured.", statusCode: StatusCodes.Status404NotFound);
             }
 
-            var parts = repository.Split('/');
-            var owner = parts[0];
+            int slash = repository.IndexOf('/', StringComparison.Ordinal);
+            var owner = repository[..slash];
 
             string repo;
             IList<string>? targetRepositories;
 
             if (profile.TargetRepositories is not { Count: > 0 } targets)
             {
-                repo = parts[1];
+                repo = repository[(slash + 1)..];
                 targetRepositories = [repo];
             }
             else if (targets.SequenceEqual(AllRepositories, StringComparer.Ordinal))
             {
-                repo = parts[1];
+                repo = repository[(slash + 1)..];
                 targetRepositories = null;
             }
             else

--- a/src/Costellobot/Handlers/CheckSuiteHandler.cs
+++ b/src/Costellobot/Handlers/CheckSuiteHandler.cs
@@ -143,6 +143,7 @@ public sealed partial class CheckSuiteHandler(
         var retryEligibleRuns = failedRuns
             .Where((p) => options.RerunFailedChecks.Any((pattern) => Regex.IsMatch(p.Name, pattern, RegexOptions.None, RegexTimeout)))
             .GroupBy((p) => p.Name)
+            .Select((g) => (g.Key, Count: g.Count()))
             .ToList();
 
         if (retryEligibleRuns.Count < 1)
@@ -163,8 +164,10 @@ public sealed partial class CheckSuiteHandler(
         // is causing the check suite to fail is the "publish" check run.
         var latestCheckSuites = await context.InstallationClient.Check.Run.GetAllForCheckSuite(repository.Owner, repository.Name, checkSuiteId);
 
+        var eligibleNames = new HashSet<string>(retryEligibleRuns.Select((g) => g.Key), StringComparer.Ordinal);
+
         var latestFailingCheckRuns = latestCheckSuites.CheckRuns
-            .Where((p) => retryEligibleRuns.Any((group) => group.Key == p.Name))
+            .Where((p) => eligibleNames.Contains(p.Name))
             .Where((p) => p.Status.Value == CheckStatus.Completed)
             .Where((p) => p.Conclusion?.Value == CheckConclusion.Failure)
             .ToList();
@@ -187,7 +190,7 @@ public sealed partial class CheckSuiteHandler(
         }
 #pragma warning restore CA1873
 
-        if (retryEligibleRuns.Any((p) => p.Count() > options.RerunFailedChecksAttempts))
+        if (retryEligibleRuns.Any((p) => p.Count > options.RerunFailedChecksAttempts))
         {
             Log.TooManyRetries(logger, checkSuiteId, repository, options.RerunFailedChecksAttempts);
             return false;

--- a/src/Costellobot/Registries/GitSubmodulePackageRegistry.cs
+++ b/src/Costellobot/Registries/GitSubmodulePackageRegistry.cs
@@ -45,7 +45,7 @@ public sealed class GitSubmodulePackageRegistry(
             items[0] is { SubmoduleGitUrl: not null } item)
         {
             string url = item.SubmoduleGitUrl;
-            string urlWithoutRepoName = string.Join('/', url.Split('/').SkipLast(1));
+            string urlWithoutRepoName = url[..url.LastIndexOf('/')];
 
             return [urlWithoutRepoName];
         }

--- a/src/Costellobot/Registries/NuGetPackageRegistry.cs
+++ b/src/Costellobot/Registries/NuGetPackageRegistry.cs
@@ -123,21 +123,18 @@ public sealed partial class NuGetPackageRegistry : PackageRegistry
 
         var package = response.Data.FirstOrDefault((p) => string.Equals(p.Id, id, StringComparison.OrdinalIgnoreCase));
 
-        if (package is null ||
-            !string.Equals(package.Id, id, StringComparison.OrdinalIgnoreCase))
+        if (package is null)
         {
             return [];
         }
 
         var versionFound = package.Versions
-            .Where((p) => string.Equals(p.Version, version, StringComparison.OrdinalIgnoreCase))
-            .Select((p) => p.Version)
-            .FirstOrDefault();
+            .FirstOrDefault((p) => string.Equals(p.Version, version, StringComparison.OrdinalIgnoreCase))
+            ?.Version;
 
         versionFound ??= package.Versions
-            .Where((p) => p.Version.StartsWith(version, StringComparison.Ordinal))
-            .Where((p) => p.Version.Contains('+', StringComparison.Ordinal))
-            .Select((p) => p.Version.Split('+')[0])
+            .Where((p) => p.Version.StartsWith(version, StringComparison.Ordinal) && p.Version.Contains('+', StringComparison.Ordinal))
+            .Select((p) => p.Version[..p.Version.IndexOf('+', StringComparison.Ordinal)])
             .SingleOrDefault();
 
         versionFound ??= package.Version;
@@ -170,8 +167,7 @@ public sealed partial class NuGetPackageRegistry : PackageRegistry
         var index = await GetServiceIndexAsync(cancellationToken);
 
         var resource = index?.Resources?
-            .Where((p) => string.Equals(p.Type, type, StringComparison.Ordinal))
-            .FirstOrDefault();
+            .FirstOrDefault((p) => string.Equals(p.Type, type, StringComparison.Ordinal));
 
         string? baseAddress = null;
 


### PR DESCRIPTION
- Avoid allocating arrays to split strings.
- Avoid recomputing things in loops.
- Avoid `O(n*m)` lookup and replace with `O(1)`.
- Avoid counting group twice.
