### PR TITLE
Upgrade to OATS v0.8.0

### DIFF
--- a/.github/workflows/oats.yml
+++ b/.github/workflows/oats.yml
@@ -103,12 +103,14 @@ jobs:
       - name: Install OATS
         env:
           # renovate: datasource=github-releases depName=oats packageName=grafana/oats
-          OATS_VERSION: v0.7.0
+          OATS_VERSION: 122f93ad134b9cee0314e33b165ce567dfd7e280
         run: |
           go install "github.com/grafana/oats@${OATS_VERSION}"
 
       - name: Run OATS
         env:
+          # renovate: datasource=github-releases depName=gcx packageName=grafana/gcx
+          GCX_VERSION: '0.5.0'
           # renovate: datasource=github-releases depName=LGTM packageName=grafana/docker-otel-lgtm
           LGTM_VERSION: '0.29.1'
-        run: oats --lgtm-version="${LGTM_VERSION}" --timeout=5m ./tests/Costellobot.Oats
+        run: oats --gcx-version="${GCX_VERSION}" --lgtm-version="${LGTM_VERSION}" --timeout=5m ./tests/Costellobot.Oats

--- a/.github/workflows/oats.yml
+++ b/.github/workflows/oats.yml
@@ -113,4 +113,4 @@ jobs:
           GCX_VERSION: '0.5.0'
           # renovate: datasource=github-releases depName=LGTM packageName=grafana/docker-otel-lgtm
           LGTM_VERSION: '0.29.1'
-        run: oats --gcx-version="${GCX_VERSION}" --lgtm-version="${LGTM_VERSION}" --timeout=5m ./tests/Costellobot.Oats/oats-config.yaml
+        run: oats --gcx-version="${GCX_VERSION}" --lgtm-version="${LGTM_VERSION}" --timeout=5m --config ./tests/Costellobot.Oats/oats-config.yaml

--- a/.github/workflows/oats.yml
+++ b/.github/workflows/oats.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Install OATS
         env:
           # renovate: datasource=github-releases depName=oats packageName=grafana/oats
-          OATS_VERSION: 122f93ad134b9cee0314e33b165ce567dfd7e280
+          OATS_VERSION: 6682d85491e83e5ad3276c6d72ae863f47d0727f
         run: |
           go install "github.com/grafana/oats@${OATS_VERSION}"
 

--- a/.github/workflows/oats.yml
+++ b/.github/workflows/oats.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Install OATS
         env:
           # renovate: datasource=github-releases depName=oats packageName=grafana/oats
-          OATS_VERSION: 6682d85491e83e5ad3276c6d72ae863f47d0727f
+          OATS_VERSION: 3b4477ab15b842ffb0b7c71357412c5cacfbf7d6
         run: |
           go install "github.com/grafana/oats@${OATS_VERSION}"
 
@@ -113,4 +113,4 @@ jobs:
           GCX_VERSION: '0.5.0'
           # renovate: datasource=github-releases depName=LGTM packageName=grafana/docker-otel-lgtm
           LGTM_VERSION: '0.29.1'
-        run: oats --gcx-version="${GCX_VERSION}" --lgtm-version="${LGTM_VERSION}" --timeout=5m --config ./tests/Costellobot.Oats/oats-config.yaml
+        run: oats --gcx-version="${GCX_VERSION}" --lgtm-version="${LGTM_VERSION}" --timeout=5m ./tests/Costellobot.Oats

--- a/.github/workflows/oats.yml
+++ b/.github/workflows/oats.yml
@@ -113,4 +113,4 @@ jobs:
           GCX_VERSION: '0.5.0'
           # renovate: datasource=github-releases depName=LGTM packageName=grafana/docker-otel-lgtm
           LGTM_VERSION: '0.29.1'
-        run: oats --gcx-version="${GCX_VERSION}" --lgtm-version="${LGTM_VERSION}" --timeout=5m ./tests/Costellobot.Oats
+        run: oats --gcx-version="${GCX_VERSION}" --lgtm-version="${LGTM_VERSION}" --timeout=5m ./tests/Costellobot.Oats/oats-config.yaml

--- a/.github/workflows/oats.yml
+++ b/.github/workflows/oats.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Install OATS
         env:
           # renovate: datasource=github-releases depName=oats packageName=grafana/oats
-          OATS_VERSION: 3b4477ab15b842ffb0b7c71357412c5cacfbf7d6
+          OATS_VERSION: v0.8.0
         run: |
           go install "github.com/grafana/oats@${OATS_VERSION}"
 

--- a/tests/Costellobot.Oats/oats-config.yaml
+++ b/tests/Costellobot.Oats/oats-config.yaml
@@ -1,0 +1,4 @@
+meta:
+  version: 3
+cases:
+  - oats.yml

--- a/tests/Costellobot.Oats/oats.yml
+++ b/tests/Costellobot.Oats/oats.yml
@@ -68,8 +68,8 @@ expected:
           match_type: regexp
     - query: memory:alloc_size:bytes:space:bytes{ service_name="Costellobot" }
       match:
-        - match_type: regexp
-          name: MartinCostello.Costellobot!
+        - name: MartinCostello.Costellobot!
+          match_type: regexp
   traces:
     - traceql: '{ span.messaging.operation = "receive" }'
       match_spans:

--- a/tests/Costellobot.Oats/oats.yml
+++ b/tests/Costellobot.Oats/oats.yml
@@ -1,7 +1,10 @@
-oats-schema-version: 2
-docker-compose:
-  files:
-    - ./../../docker-compose.yml
+name: oats
+interval: 500ms
+fixture:
+  compose:
+    file: ./../../docker-compose.yml
+seed:
+  type: app
 input:
   - path: /version
   - path: /github-webhook
@@ -12,8 +15,8 @@ input:
       User-Agent: GitHub-Hookshot/f05835d
       X-GitHub-Delivery: 09e27db8-e74c-4a28-a951-50552382af03
       X-GitHub-Event: ping
-      X-GitHub-Hook-ID: 109948940
-      X-GitHub-Hook-Installation-Target-ID: 183256
+      X-GitHub-Hook-ID: "109948940"
+      X-GitHub-Hook-Installation-Target-ID: "183256"
       X-GitHub-Hook-Installation-Target-Type: integration
     body: |-
       {
@@ -43,11 +46,12 @@ input:
           "node_id": "c0dctApWjo2ooEXO0RATfhWfiQrE2og7axfcZRs6gEk="
         }
       }
-interval: 500ms
 expected:
   logs:
     - logql: '{ service_name="Costellobot" } |~ `Application started.`'
-      regexp: 'Application started'
+      match:
+        - match_type: regexp
+          name: Application started
   metrics:
     - promql: costellobot_github_webhook_delivery_total{ github_webhook_event="ping" }
       value: '>= 1'
@@ -59,72 +63,125 @@ expected:
       value: '>= 1'
   profiles:
     - query: process_cpu:cpu:nanoseconds:cpu:nanoseconds{ service_name="Costellobot" }
-      flamebearers:
-        regexp: MartinCostello.Costellobot!
+      match:
+        - match_type: regexp
+          name: MartinCostello.Costellobot!
     - query: memory:alloc_size:bytes:space:bytes{ service_name="Costellobot" }
-      flamebearers:
-        regexp: MartinCostello.Costellobot!
+      match:
+        - match_type: regexp
+          name: MartinCostello.Costellobot!
   traces:
     - traceql: '{ span.messaging.operation = "receive" }'
-      equals: 'ServiceBusReceiver.Receive'
-      attributes:
-        az.namespace: Microsoft.ServiceBus
-        messaging.destination.name: queue.1
-        messaging.operation: receive
-        messaging.system: servicebus
+      match_spans:
+        - name: ServiceBusReceiver.Receive
+          attributes:
+            - key: az.namespace
+              value: Microsoft.ServiceBus
+            - key: messaging.destination.name
+              value: queue.1
+            - key: messaging.operation
+              value: receive
+            - key: messaging.system
+              value: servicebus
     - traceql: '{ span.http.route =~ "/github-webhook" }'
-      equals: 'POST /github-webhook'
-      attributes:
-        github.webhook.delivery: 09e27db8-e74c-4a28-a951-50552382af03
-        github.webhook.event: ping
-        github.webhook.hook.id: 109948940
-        github.webhook.hook.installation.target.id: 183256
-        http.request.method: POST
-        http.response.status_code: 200
-      attribute-regexp:
-        messaging.message.id: .+
+      match_spans:
+        - name: POST /github-webhook
+          attributes:
+            - key: github.webhook.delivery
+              value: 09e27db8-e74c-4a28-a951-50552382af03
+            - key: github.webhook.event
+              value: ping
+            - key: github.webhook.hook.id
+              value: "109948940"
+            - key: github.webhook.hook.installation.target.id
+              value: "183256"
+            - key: http.request.method
+              value: POST
+            - key: http.response.status_code
+              value: "200"
+        - match_type: regexp
+          attributes:
+            - key: messaging.message.id
+              value: .+
     - traceql: '{ span.http.route =~ "/github-webhook" }'
-      equals: 'ServiceBusProcessor.ProcessMessage'
-      attributes:
-        az.namespace: Microsoft.ServiceBus
-        messaging.destination.name: queue.1
-        messaging.operation: process
-        messaging.system: servicebus
+      match_spans:
+        - name: ServiceBusProcessor.ProcessMessage
+          attributes:
+            - key: az.namespace
+              value: Microsoft.ServiceBus
+            - key: messaging.destination.name
+              value: queue.1
+            - key: messaging.operation
+              value: process
+            - key: messaging.system
+              value: servicebus
     - traceql: '{ span.http.route =~ "/github-webhook" }'
-      equals: 'ServiceBusReceiver.Complete'
-      attributes:
-        az.namespace: Microsoft.ServiceBus
-        messaging.destination.name: queue.1
-        messaging.operation: settle
-        messaging.system: servicebus
+      match_spans:
+        - name: ServiceBusReceiver.Complete
+          attributes:
+            - key: az.namespace
+              value: Microsoft.ServiceBus
+            - key: messaging.destination.name
+              value: queue.1
+            - key: messaging.operation
+              value: settle
+            - key: messaging.system
+              value: servicebus
     - traceql: '{ span.http.route =~ "/github-webhook" }'
-      equals: 'ServiceBusSender.Send'
-      attributes:
-        az.namespace: Microsoft.ServiceBus
-        messaging.destination.name: queue.1
-        messaging.operation: publish
-        messaging.system: servicebus
+      match_spans:
+        - name: ServiceBusSender.Send
+          attributes:
+            - key: az.namespace
+              value: Microsoft.ServiceBus
+            - key: messaging.destination.name
+              value: queue.1
+            - key: messaging.operation
+              value: publish
+            - key: messaging.system
+              value: servicebus
     - traceql: '{ span.http.route =~ "/version" }'
-      equals: 'GET /version'
-      attributes:
-        cloud.provider: azure
-        http.request.method: GET
-        http.response.status_code: 200
-        os.name: Ubuntu
-        os.type: linux
-        process.runtime.name: .NET
-        service.name: Costellobot
-        service.namespace: Costellobot
-        telemetry.sdk.language: dotnet
-        telemetry.sdk.name: opentelemetry
-      attribute-regexp:
-        container.id: .+
-        host.name: .+
-        os.build_id: .+
-        os.description: .+
-        os.version: .+
-        process.runtime.description: .NET.+
-        process.runtime.version: .+
-        service.instance.id: .+
-        service.version: 1.0.\d+
-        telemetry.sdk.version: .+
+      match_spans:
+        - name: GET /version
+          attributes:
+            - key: cloud.provider
+              value: azure
+            - key: http.request.method
+              value: GET
+            - key: http.response.status_code
+              value: "200"
+            - key: os.name
+              value: Ubuntu
+            - key: os.type
+              value: linux
+            - key: process.runtime.name
+              value: .NET
+            - key: service.name
+              value: Costellobot
+            - key: service.namespace
+              value: Costellobot
+            - key: telemetry.sdk.language
+              value: dotnet
+            - key: telemetry.sdk.name
+              value: opentelemetry
+        - match_type: regexp
+          attributes:
+            - key: container.id
+              value: .+
+            - key: host.name
+              value: .+
+            - key: os.build_id
+              value: .+
+            - key: os.description
+              value: .+
+            - key: os.version
+              value: .+
+            - key: process.runtime.description
+              value: .NET.+
+            - key: process.runtime.version
+              value: .+
+            - key: service.instance.id
+              value: .+
+            - key: service.version
+              value: 1.0.\d+
+            - key: telemetry.sdk.version
+              value: .+

--- a/tests/Costellobot.Oats/oats.yml
+++ b/tests/Costellobot.Oats/oats.yml
@@ -50,8 +50,8 @@ expected:
   logs:
     - logql: '{ service_name="Costellobot" } |~ `Application started.`'
       match:
-        - match_type: regexp
-          name: Application started
+        - name: Application started
+          match_type: regexp
   metrics:
     - promql: costellobot_github_webhook_delivery_total{ github_webhook_event="ping" }
       value: '>= 1'
@@ -64,8 +64,8 @@ expected:
   profiles:
     - query: process_cpu:cpu:nanoseconds:cpu:nanoseconds{ service_name="Costellobot" }
       match:
-        - match_type: regexp
-          name: MartinCostello.Costellobot!
+        - name: MartinCostello.Costellobot!
+          match_type: regexp
     - query: memory:alloc_size:bytes:space:bytes{ service_name="Costellobot" }
       match:
         - match_type: regexp
@@ -74,6 +74,7 @@ expected:
     - traceql: '{ span.messaging.operation = "receive" }'
       match_spans:
         - name: ServiceBusReceiver.Receive
+          match_type: strict
           attributes:
             - key: az.namespace
               value: Microsoft.ServiceBus
@@ -86,6 +87,7 @@ expected:
     - traceql: '{ span.http.route =~ "/github-webhook" }'
       match_spans:
         - name: POST /github-webhook
+          match_type: strict
           attributes:
             - key: github.webhook.delivery
               value: 09e27db8-e74c-4a28-a951-50552382af03
@@ -99,13 +101,15 @@ expected:
               value: POST
             - key: http.response.status_code
               value: "200"
-        - match_type: regexp
+        - name: POST /github-webhook
+          match_type: regexp
           attributes:
             - key: messaging.message.id
               value: .+
     - traceql: '{ span.http.route =~ "/github-webhook" }'
       match_spans:
         - name: ServiceBusProcessor.ProcessMessage
+          match_type: strict
           attributes:
             - key: az.namespace
               value: Microsoft.ServiceBus
@@ -118,6 +122,7 @@ expected:
     - traceql: '{ span.http.route =~ "/github-webhook" }'
       match_spans:
         - name: ServiceBusReceiver.Complete
+          match_type: strict
           attributes:
             - key: az.namespace
               value: Microsoft.ServiceBus
@@ -130,6 +135,7 @@ expected:
     - traceql: '{ span.http.route =~ "/github-webhook" }'
       match_spans:
         - name: ServiceBusSender.Send
+          match_type: strict
           attributes:
             - key: az.namespace
               value: Microsoft.ServiceBus
@@ -142,6 +148,7 @@ expected:
     - traceql: '{ span.http.route =~ "/version" }'
       match_spans:
         - name: GET /version
+          match_type: strict
           attributes:
             - key: cloud.provider
               value: azure
@@ -163,7 +170,8 @@ expected:
               value: dotnet
             - key: telemetry.sdk.name
               value: opentelemetry
-        - match_type: regexp
+        - name: GET /version
+          match_type: regexp
           attributes:
             - key: container.id
               value: .+


### PR DESCRIPTION
Upgrade to OATS [v0.8.0](https://github.com/grafana/oats/releases/tag/v0.8.0).
