### PR TITLE
Native AoT preparation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,7 +45,6 @@
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.20.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.61.0" />
-    <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="7.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageVersion Include="NSubstitute" Version="6.0.0" />

--- a/src/Costellobot/AdminEndpoints.cs
+++ b/src/Costellobot/AdminEndpoints.cs
@@ -391,11 +391,11 @@ public static class AdminEndpoints
                 if (!await antiforgery.IsRequestValidAsync(context))
                 {
                     antiforgery.SetCookieTokenAndHeader(context);
-                    return Results.RedirectToRoute(DependenciesRoute);
+                    return Results.RedirectToRoute(DependenciesRoute, []);
                 }
 
                 await store.DistrustAsync(ecosystem, id, version, cancellationToken);
-                return Results.RedirectToRoute(DependenciesRoute);
+                return Results.RedirectToRoute(DependenciesRoute, []);
             })
             .WithName("DistrustDependencies")
             .WithMetadata(admin);
@@ -411,11 +411,11 @@ public static class AdminEndpoints
                 if (!await antiforgery.IsRequestValidAsync(context))
                 {
                     antiforgery.SetCookieTokenAndHeader(context);
-                    return Results.RedirectToRoute(DependenciesRoute);
+                    return Results.RedirectToRoute(DependenciesRoute, []);
                 }
 
                 await store.DistrustAllAsync(cancellationToken);
-                return Results.RedirectToRoute(DependenciesRoute);
+                return Results.RedirectToRoute(DependenciesRoute, []);
             })
             .WithName("DistrustAllDependencies")
             .WithMetadata(admin);
@@ -434,11 +434,11 @@ public static class AdminEndpoints
                 if (!await antiforgery.IsRequestValidAsync(context))
                 {
                     antiforgery.SetCookieTokenAndHeader(context);
-                    return Results.RedirectToRoute(DependenciesRoute);
+                    return Results.RedirectToRoute(DependenciesRoute, []);
                 }
 
                 await store.DenyAsync(ecosystem, id, version, cancellationToken);
-                return Results.RedirectToRoute(DependenciesRoute);
+                return Results.RedirectToRoute(DependenciesRoute, []);
             })
             .WithName("DenyDependency")
             .WithMetadata(admin);
@@ -457,11 +457,11 @@ public static class AdminEndpoints
                 if (!await antiforgery.IsRequestValidAsync(context))
                 {
                     antiforgery.SetCookieTokenAndHeader(context);
-                    return Results.RedirectToRoute(DependenciesRoute);
+                    return Results.RedirectToRoute(DependenciesRoute, []);
                 }
 
                 await store.AllowAsync(ecosystem, id, version, cancellationToken);
-                return Results.RedirectToRoute(DependenciesRoute);
+                return Results.RedirectToRoute(DependenciesRoute, []);
             })
             .WithName("AllowDependency")
             .WithMetadata(admin);

--- a/src/Costellobot/AppJsonSerializerContext.cs
+++ b/src/Costellobot/AppJsonSerializerContext.cs
@@ -2,13 +2,17 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using MartinCostello.Costellobot.Models;
 
 namespace MartinCostello.Costellobot;
 
 [ExcludeFromCodeCoverage]
+[JsonSerializable(typeof(ClientLogMessage))]
 [JsonSerializable(typeof(GitHubTokenRequest))]
 [JsonSerializable(typeof(GitHubTokenResponse))]
+[JsonSerializable(typeof(IDictionary<string, string>))]
+[JsonSerializable(typeof(JsonElement))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, WriteIndented = false)]
 internal sealed partial class AppJsonSerializerContext : JsonSerializerContext;

--- a/src/Costellobot/Costellobot.csproj
+++ b/src/Costellobot/Costellobot.csproj
@@ -8,8 +8,6 @@
     <PyroscopeApplicationName>costellobot-martincostello</PyroscopeApplicationName>
     <RootNamespace>MartinCostello.Costellobot</RootNamespace>
     <TargetFramework>net10.0</TargetFramework>
-    <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
-    <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>
     <UserSecretsId>Costellobot</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
@@ -34,7 +32,6 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
-    <PackageReference Include="Microsoft.TypeScript.MSBuild" PrivateAssets="all" />
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="Octokit" />
     <PackageReference Include="Octokit.GraphQL" />

--- a/src/Costellobot/Costellobot.csproj
+++ b/src/Costellobot/Costellobot.csproj
@@ -61,7 +61,6 @@
     <EmbeddedResource Include="bank-holidays.json" />
     <None Remove="scripts\ts\**\*.ts" />
     <PyroscopeLabels Include="costellobot" />
-    <TypeScriptCompile Include="scripts\ts\**\*.ts" />
   </ItemGroup>
   <Target Name="BundleAssets" BeforeTargets="BeforeBuild" DependsOnTargets="RestoreNpmPackages">
     <Exec Command="npm run build" Condition=" !Exists('$(MSBuildThisFileDirectory)\wwwroot\static\js\main.js') " />

--- a/src/Costellobot/CostellobotBuilder.cs
+++ b/src/Costellobot/CostellobotBuilder.cs
@@ -72,6 +72,11 @@ public static class CostellobotBuilder
         builder.Services.AddSingleton<ClientLogQueue>();
         builder.Services.AddHostedService<ClientLogBroadcastService>();
 
+        builder.Services.Configure<Microsoft.AspNetCore.SignalR.JsonHubProtocolOptions>((options) =>
+        {
+            options.PayloadSerializerOptions.TypeInfoResolverChain.Insert(0, AppJsonSerializerContext.Default);
+        });
+
         builder.Logging.AddTelemetry();
         builder.Logging.AddSignalR();
 

--- a/src/Costellobot/package-lock.json
+++ b/src/Costellobot/package-lock.json
@@ -2492,16 +2492,16 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
@@ -3773,16 +3773,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -4604,9 +4604,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
- Pass empty route dictionary to `Results.RedirectToRoute()`.
- Wire-up JSON serializer context to SignalR.
- Remove the Microsoft.TypeScript.MSBuild NuGet package as it's redundant and causes build errors in Visual Studio.
- Run `npm audit fix` to update brace-expansion.

Bits not working yet:

- Need to get source-generator for YamlDotNet working (generator appears to silently fail) - https://github.com/aaubry/YamlDotNet/issues/1124
- Need to get SignalR working with native AoT (messages seem to black-hole) - https://github.com/dotnet/aspnetcore/issues/68059
