### PR TITLE
Fix OATS application service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,19 +19,9 @@ services:
       - Webhook__QueueName=queue.1
       - WEBSITE_AUTH_ENCRYPTION_KEY=1d02ee45-791c-4f23-b448-11f80accfd5c
       - WEBSITE_SITE_NAME=Costellobot
-  ready:
+  oats-input:
     image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
-    command: ["sh", "-c", "sleep infinity"]
-    depends_on:
-      - costellobot
-      - servicebus-emulator
-      - sql-server
-    healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://servicebus-emulator:5300/health > /dev/null && curl -fsS -H 'x-health-probe-token:43SBjvAs3HwI+lXWSzfoV2bh5hSbEK2TRxiK2SZN2qA=' http://costellobot:8080/health/readiness > /dev/null || exit 1"]
-      interval: 5s
-      retries: 20
-      start_period: 5s
-      timeout: 3s
+    profiles: [oats-input]
   servicebus-emulator:
     image: mcr.microsoft.com/azure-messaging/servicebus-emulator:2.0.1@sha256:5a96d893b245031740f7d46e0fe5ff282d24b78c4b7d761dd57590f3f010a9b3
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - servicebus-emulator
       - sql-server
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS -H 'x-health-probe-token:43SBjvAs3HwI+lXWSzfoV2bh5hSbEK2TRxiK2SZN2qA=' http://costellobot:8080/health/readiness > /dev/null || exit 1"]
+      test: ["CMD-SHELL", "curl -fsS http://servicebus-emulator:5300/health > /dev/null && curl -fsS -H 'x-health-probe-token:43SBjvAs3HwI+lXWSzfoV2bh5hSbEK2TRxiK2SZN2qA=' http://costellobot:8080/health/readiness > /dev/null || exit 1"]
       interval: 5s
       retries: 20
       start_period: 5s

--- a/tests/Costellobot.Oats/oats.yml
+++ b/tests/Costellobot.Oats/oats.yml
@@ -3,51 +3,67 @@ interval: 500ms
 fixture:
   compose:
     file: ./../../docker-compose.yml
-    app_service: costellobot
-    app_port: 8080
 seed:
   type: app
 input:
-  - path: /version
-  - path: /github-webhook
-    method: POST
-    headers:
-      Accept: '*/*'
-      Content-Type: application/json; charset=utf-8
-      User-Agent: GitHub-Hookshot/f05835d
-      X-GitHub-Delivery: 09e27db8-e74c-4a28-a951-50552382af03
-      X-GitHub-Event: ping
-      X-GitHub-Hook-ID: "109948940"
-      X-GitHub-Hook-Installation-Target-ID: "183256"
-      X-GitHub-Hook-Installation-Target-Type: integration
-    body: |-
-      {
-        "zen": "Responsive is better than fast.",
-        "hook_id": 109948940,
-        "hook": {
-          "type": "App",
-          "id": 109948940,
-          "name": "web",
-          "active": true,
-          "config": {
-            "content_type": "json",
-            "insecure_ssl": "0",
-            "secret": "my-secret",
-            "url": "https://costellobot.martincostello.local/github-webhook"
-          },
-          "deliveries_url": "https://api.github.com/app/hook/deliveries",
-          "events": ["*"],
-          "ping_url": "https://api.github.com/app/hook/109948940/pings",
-          "url": "https://api.github.com/app/hook/109948940"
-        },
-        "updated_at": "2022-03-23T23:13:43Z",
-        "created_at": "2022-03-23T23:13:43Z",
-        "app_id": 349596565,
-        "installation": {
-          "id": 183256,
-          "node_id": "c0dctApWjo2ooEXO0RATfhWfiQrE2og7axfcZRs6gEk="
-        }
-      }
+  - compose:
+      service: oats-input
+      command:
+        - sh
+        - -c
+        - |
+          until curl -fsS http://servicebus-emulator:5300/health > /dev/null &&
+            curl -fsS -H 'x-health-probe-token:43SBjvAs3HwI+lXWSzfoV2bh5hSbEK2TRxiK2SZN2qA=' http://costellobot:8080/health/readiness > /dev/null
+          do
+            sleep 2
+          done
+          curl -fsS http://costellobot:8080/version > /dev/null
+  - compose:
+      service: oats-input
+      command:
+        - sh
+        - -c
+        - |
+          curl -fsS \
+            --request POST \
+            --header 'Accept: */*' \
+            --header 'Content-Type: application/json; charset=utf-8' \
+            --header 'User-Agent: GitHub-Hookshot/f05835d' \
+            --header 'X-GitHub-Delivery: 09e27db8-e74c-4a28-a951-50552382af03' \
+            --header 'X-GitHub-Event: ping' \
+            --header 'X-GitHub-Hook-ID: 109948940' \
+            --header 'X-GitHub-Hook-Installation-Target-ID: 183256' \
+            --header 'X-GitHub-Hook-Installation-Target-Type: integration' \
+            --data-binary @- \
+            http://costellobot:8080/github-webhook <<'JSON'
+          {
+            "zen": "Responsive is better than fast.",
+            "hook_id": 109948940,
+            "hook": {
+              "type": "App",
+              "id": 109948940,
+              "name": "web",
+              "active": true,
+              "config": {
+                "content_type": "json",
+                "insecure_ssl": "0",
+                "secret": "my-secret",
+                "url": "https://costellobot.martincostello.local/github-webhook"
+              },
+              "deliveries_url": "https://api.github.com/app/hook/deliveries",
+              "events": ["*"],
+              "ping_url": "https://api.github.com/app/hook/109948940/pings",
+              "url": "https://api.github.com/app/hook/109948940"
+            },
+            "updated_at": "2022-03-23T23:13:43Z",
+            "created_at": "2022-03-23T23:13:43Z",
+            "app_id": 349596565,
+            "installation": {
+              "id": 183256,
+              "node_id": "c0dctApWjo2ooEXO0RATfhWfiQrE2og7axfcZRs6gEk="
+            }
+          }
+          JSON
 expected:
   logs:
     - logql: '{ service_name="Costellobot" } |~ `Application started.`'

--- a/tests/Costellobot.Oats/oats.yml
+++ b/tests/Costellobot.Oats/oats.yml
@@ -12,7 +12,7 @@ input:
         - sh
         - -c
         - |
-          until curl -fsS http://servicebus-emulator:5300/health > /dev/null &&
+          until curl -fsS -H 'Host: localhost:5300' http://servicebus-emulator:5300/health > /dev/null &&
             curl -fsS -H 'x-health-probe-token:43SBjvAs3HwI+lXWSzfoV2bh5hSbEK2TRxiK2SZN2qA=' http://costellobot:8080/health/readiness > /dev/null
           do
             sleep 2

--- a/tests/Costellobot.Oats/oats.yml
+++ b/tests/Costellobot.Oats/oats.yml
@@ -3,7 +3,7 @@ interval: 500ms
 fixture:
   compose:
     file: ./../../docker-compose.yml
-    app_service: ready
+    app_service: costellobot
     app_port: 8080
 seed:
   type: app


### PR DESCRIPTION
Use the Costellobot service for OATS application input routing while retaining the readiness sidecar for Compose startup synchronization.

This fixes the failing OATS check in #3745, where OATS could not resolve a published port for the `ready` sidecar.