### PR TITLE
Use native AoT for YamlDotNet

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -72,6 +72,7 @@
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.20.0" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
+    <PackageVersion Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="18.1.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3.mtp-off" Version="3.2.2" />
     <PackageVersion Include="YamlDotNet" Version="18.1.0" />

--- a/src/Costellobot/AppYamlSerializerContext.cs
+++ b/src/Costellobot/AppYamlSerializerContext.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using YamlDotNet.Serialization;
+
+namespace MartinCostello.Costellobot;
+
+[ExcludeFromCodeCoverage]
+[YamlSerializable(typeof(GitCommitAnalyzer.DependabotConfig))]
+[YamlSerializable(typeof(GitCommitAnalyzer.DependabotMetadata))]
+[YamlSerializable(typeof(GitCommitAnalyzer.Dependency))]
+[YamlSerializable(typeof(GitCommitAnalyzer.Ignore))]
+[YamlSerializable(typeof(GitCommitAnalyzer.Update))]
+[YamlStaticContext]
+public sealed partial class AppYamlSerializerContext;

--- a/src/Costellobot/Costellobot.csproj
+++ b/src/Costellobot/Costellobot.csproj
@@ -52,6 +52,7 @@
     <PackageReference Include="Pyroscope.OpenTelemetry" />
     <PackageReference Include="RazorSlices" />
     <PackageReference Include="Sentry.AspNetCore" />
+    <PackageReference Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" PrivateAssets="all" />
     <PackageReference Include="YamlDotNet" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Costellobot/GitCommitAnalyzer.cs
+++ b/src/Costellobot/GitCommitAnalyzer.cs
@@ -11,7 +11,6 @@ using MartinCostello.Costellobot.Registries;
 using NuGet.Versioning;
 using Octokit;
 using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 using DependencyUpdate = (string Name, string? Version, string? UpdateType, string? Previous);
 
 namespace MartinCostello.Costellobot;
@@ -23,9 +22,8 @@ public sealed partial class GitCommitAnalyzer(
     ILogger<GitCommitAnalyzer> logger)
 {
     private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
-    private static readonly IDeserializer YamlDeserializer = new StaticDeserializerBuilder(new DependabotYamlContext())
+    private static readonly IDeserializer YamlDeserializer = new StaticDeserializerBuilder(new AppYamlSerializerContext())
         .IgnoreUnmatchedProperties()
-        .WithNamingConvention(HyphenatedNamingConvention.Instance)
         .Build();
 
     private readonly ImmutableList<IPackageRegistry> _registries = [.. registries];
@@ -737,6 +735,57 @@ public sealed partial class GitCommitAnalyzer(
         return dependencies;
     }
 
+    internal sealed class DependabotConfig
+    {
+        [YamlMember(Alias = "version")]
+        public long Version { get; set; }
+
+        [YamlMember(Alias = "updates")]
+        public IList<Update> Updates { get; set; } = [];
+    }
+
+    internal sealed class Update
+    {
+        [YamlMember(Alias = "package-ecosystem")]
+        public string? PackageEcosystem { get; set; }
+
+        [YamlMember(Alias = "ignore")]
+        public IList<Ignore> Ignore { get; set; } = [];
+    }
+
+    internal sealed class Ignore
+    {
+        [YamlMember(Alias = "dependency-name")]
+        public string DependencyName { get; set; } = string.Empty;
+
+        [YamlMember(Alias = "update-types")]
+        public IList<string>? UpdateTypes { get; set; }
+    }
+
+    internal sealed class DependabotMetadata
+    {
+        [YamlMember(Alias = "updated-dependencies")]
+        public IList<Dependency> Dependencies { get; set; } = [];
+    }
+
+    internal sealed class Dependency
+    {
+        [YamlMember(Alias = "dependency-name")]
+        public string DependencyName { get; set; } = string.Empty;
+
+        [YamlMember(Alias = "dependency-version")]
+        public string? DependencyVersion { get; set; }
+
+        [YamlMember(Alias = "dependency-type")]
+        public string DependencyType { get; set; } = string.Empty;
+
+        [YamlMember(Alias = "update-type")]
+        public string UpdateType { get; set; } = string.Empty;
+
+        [YamlMember(Alias = "dependency-group")]
+        public string? DependencyGroup { get; set; }
+    }
+
     [ExcludeFromCodeCoverage]
     private static partial class Log
     {
@@ -907,60 +956,4 @@ public sealed partial class GitCommitAnalyzer(
             DependencyEcosystem ecosystem,
             Exception exception);
     }
-
-    private sealed class DependabotConfig
-    {
-        [YamlMember(Alias = "version")]
-        public long Version { get; set; }
-
-        [YamlMember(Alias = "updates")]
-        public IList<Update> Updates { get; set; } = [];
-    }
-
-    private sealed class Update
-    {
-        [YamlMember(Alias = "package-ecosystem")]
-        public string? PackageEcosystem { get; set; }
-
-        [YamlMember(Alias = "ignore")]
-        public IList<Ignore> Ignore { get; set; } = [];
-    }
-
-    private sealed class Ignore
-    {
-        [YamlMember(Alias = "dependency-name")]
-        public string DependencyName { get; set; } = string.Empty;
-
-        [YamlMember(Alias = "update-types")]
-        public IList<string>? UpdateTypes { get; set; }
-    }
-
-    private sealed class DependabotMetadata
-    {
-        [YamlMember(Alias = "updated-dependencies")]
-        public IList<Dependency> Dependencies { get; set; } = [];
-    }
-
-    private sealed class Dependency
-    {
-        [YamlMember(Alias = "dependency-name")]
-        public string DependencyName { get; set; } = string.Empty;
-
-        [YamlMember(Alias = "dependency-version")]
-        public string? DependencyVersion { get; set; }
-
-        [YamlMember(Alias = "dependency-type")]
-        public string DependencyType { get; set; } = string.Empty;
-
-        [YamlMember(Alias = "update-type")]
-        public string UpdateType { get; set; } = string.Empty;
-
-        [YamlMember(Alias = "dependency-group")]
-        public string? DependencyGroup { get; set; }
-    }
-
-    [YamlStaticContext]
-    [YamlSerializable(typeof(DependabotConfig))]
-    [YamlSerializable(typeof(DependabotMetadata))]
-    private sealed partial class DependabotYamlContext : StaticContext;
 }

--- a/src/Costellobot/GitCommitAnalyzer.cs
+++ b/src/Costellobot/GitCommitAnalyzer.cs
@@ -23,7 +23,7 @@ public sealed partial class GitCommitAnalyzer(
     ILogger<GitCommitAnalyzer> logger)
 {
     private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
-    private static readonly IDeserializer YamlDeserializer = new DeserializerBuilder()
+    private static readonly IDeserializer YamlDeserializer = new StaticDeserializerBuilder(new DependabotYamlContext())
         .IgnoreUnmatchedProperties()
         .WithNamingConvention(HyphenatedNamingConvention.Instance)
         .Build();
@@ -958,4 +958,9 @@ public sealed partial class GitCommitAnalyzer(
         [YamlMember(Alias = "dependency-group")]
         public string? DependencyGroup { get; set; }
     }
+
+    [YamlStaticContext]
+    [YamlSerializable(typeof(DependabotConfig))]
+    [YamlSerializable(typeof(DependabotMetadata))]
+    private sealed partial class DependabotYamlContext : StaticContext;
 }


### PR DESCRIPTION
Enable source-generation for YamlDotNet to prepare for native AoT publishing.
