### PR TITLE
Fix native AoT warning

### DIFF
--- a/src/Costellobot/Costellobot.csproj
+++ b/src/Costellobot/Costellobot.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <ContainerFamily>resolute-chiseled-extra</ContainerFamily>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
     <InvariantGlobalization>false</InvariantGlobalization>
+    <PublishAot>false</PublishAot>
     <PublishSelfContained>true</PublishSelfContained>
     <PyroscopeApplicationName>costellobot-martincostello</PyroscopeApplicationName>
     <RootNamespace>MartinCostello.Costellobot</RootNamespace>

--- a/src/Costellobot/HealthCheckEndpoints.cs
+++ b/src/Costellobot/HealthCheckEndpoints.cs
@@ -60,19 +60,6 @@ public static class HealthCheckEndpoints
                     {
                         writer.WriteString("description", description);
                     }
-
-                    if (entry.Data is { Count: > 0 } data)
-                    {
-                        writer.WriteStartObject("data");
-
-                        foreach ((var key, var item) in data)
-                        {
-                            writer.WritePropertyName(key);
-                            writer.WriteStringValue(item?.ToString());
-                        }
-
-                        writer.WriteEndObject();
-                    }
                 }
 
                 writer.WriteEndObject();

--- a/src/Costellobot/HealthCheckEndpoints.cs
+++ b/src/Costellobot/HealthCheckEndpoints.cs
@@ -61,15 +61,18 @@ public static class HealthCheckEndpoints
                         writer.WriteString("description", description);
                     }
 
-                    writer.WriteStartObject("data");
-
-                    foreach ((var key, var item) in entry.Data)
+                    if (entry.Data is { Count: > 0 } data)
                     {
-                        writer.WritePropertyName(key);
-                        JsonSerializer.Serialize(writer, item, item?.GetType() ?? typeof(object));
-                    }
+                        writer.WriteStartObject("data");
 
-                    writer.WriteEndObject();
+                        foreach ((var key, var item) in data)
+                        {
+                            writer.WritePropertyName(key);
+                            writer.WriteStringValue(item?.ToString());
+                        }
+
+                        writer.WriteEndObject();
+                    }
                 }
 
                 writer.WriteEndObject();


### PR DESCRIPTION
- Remove `data` from health check responses - it's currently always empty anyway.
- Enable AoT analyzer to prevent future regressions - first-party code is now AoT compatible (as far as surfaced warnings are concerned).
- Explicitly disable AoT publishing as various dependencies are not AoT compatible (or are, but generate compiler errors, e.g. Aspire.Azure.Data.Tables, Google.Apis.Calendar.v3 (which itself depends on Newtonsoft.Json), Octokit, Octokit.GraphQL).
