### PR TITLE
Handle dependabot ignore regexes better

### DIFF
--- a/src/Costellobot/GitCommitAnalyzer.cs
+++ b/src/Costellobot/GitCommitAnalyzer.cs
@@ -401,10 +401,23 @@ public sealed partial class GitCommitAnalyzer(
 
         foreach ((string dependency, string? version, string? updateType, _) in dependencies)
         {
+            static bool IsMatch(string input, string pattern, ILogger logger)
+            {
+                try
+                {
+                    return pattern is "*" || Regex.IsMatch(input, pattern, RegexOptions.None, RegexTimeout);
+                }
+                catch (Exception ex) when (ex is RegexMatchTimeoutException or RegexParseException)
+                {
+                    Log.FailedToEvaluateRegularExpression(logger, pattern, input, ex);
+                    return false;
+                }
+            }
+
             bool ignored = dependenciesToIgnore
                 .Any((p) =>
-                    Regex.IsMatch(dependency, p.Name, RegexOptions.None, RegexTimeout) &&
-                    (p.UpdateType is null || string.Equals(updateType, p.UpdateType, StringComparison.Ordinal)));
+                    (p.UpdateType is null || string.Equals(updateType, p.UpdateType, StringComparison.Ordinal)) &&
+                    IsMatch(dependency, p.Name, logger));
 
             if (ignored)
             {
@@ -955,6 +968,16 @@ public sealed partial class GitCommitAnalyzer(
             string packageId,
             string packageVersion,
             DependencyEcosystem ecosystem,
+            Exception exception);
+
+        [LoggerMessage(
+            EventId = 17,
+            Level = LogLevel.Warning,
+            Message = "Failed to evaluate regular expression {Pattern} for input {Input}.")]
+        public static partial void FailedToEvaluateRegularExpression(
+            ILogger logger,
+            string pattern,
+            string input,
             Exception exception);
     }
 }

--- a/src/Costellobot/GitCommitAnalyzer.cs
+++ b/src/Costellobot/GitCommitAnalyzer.cs
@@ -410,7 +410,7 @@ public sealed partial class GitCommitAnalyzer(
                 catch (Exception ex) when (ex is RegexMatchTimeoutException or RegexParseException)
                 {
                     Log.FailedToEvaluateRegularExpression(logger, pattern, input, ex);
-                    return false;
+                    return true;
                 }
             }
 

--- a/tests/Costellobot.Tests/GitCommitAnalyzerTests.cs
+++ b/tests/Costellobot.Tests/GitCommitAnalyzerTests.cs
@@ -1848,8 +1848,6 @@ Signed-off-by: dependabot[bot] <support@github.com>";
               open-pull-requests-limit: 99
               ignore:
                 - dependency-name: "*"
-                  update-types: ["version-update:semver-major"]
-                - dependency-name: "Microsoft.IdentityModel.*"
             """;
 
         var target = CreateTarget(
@@ -1957,9 +1955,185 @@ Signed-off-by: dependabot[bot] <support@github.com>";
         // Assert
         actualEcosystem.ShouldBe(ecosystem);
 
-        trust.ShouldContainKeyAndValue("AspNet.Security.OAuth.Amazon", (true, null));
-        trust.ShouldContainKeyAndValue("AspNet.Security.OAuth.Apple", (true, null));
-        trust.ShouldContainKeyAndValue("AspNet.Security.OAuth.GitHub", (true, null));
+        trust.ShouldContainKeyAndValue("AspNet.Security.OAuth.Amazon", (false, null));
+        trust.ShouldContainKeyAndValue("AspNet.Security.OAuth.Apple", (false, null));
+        trust.ShouldContainKeyAndValue("AspNet.Security.OAuth.GitHub", (false, null));
+        trust.ShouldContainKeyAndValue("Microsoft.IdentityModel.JsonWebTokens", (false, null));
+        trust.Count.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task Commit_Is_Analyzed_Correctly_With_Invalid_Regex_For_Ignored_Packages_In_Dependabot_Configuration()
+    {
+        // Arrange
+        var ecosystem = DependencyEcosystem.NuGet;
+        var owner = CreateUser();
+        var repo = owner.CreateRepository();
+        var repository = new RepositoryId(repo.Owner.Login, repo.Name);
+        var reference = "dependabot/nuget/aspnet-security-oauth-b2c2f7560d";
+
+        var registry = Substitute.For<IPackageRegistry>();
+
+        registry.Ecosystem.Returns(ecosystem);
+
+        registry.GetPackageOwnersAsync(repository, "Microsoft.IdentityModel.JsonWebTokens", "8.0.0", CancellationToken)
+                .Returns(Task.FromResult<IReadOnlyList<string>>(["AzureAD", "Microsoft"]));
+
+        var options = new WebhookOptions()
+        {
+            TrustedEntities = new()
+            {
+                Dependencies = ["^AspNet.Security.OAuth\\..*$"],
+                Publishers = new Dictionary<DependencyEcosystem, IList<string>>()
+                {
+                    [ecosystem] = ["Microsoft"],
+                },
+            },
+        };
+
+        using var scope = Fixture.Services.CreateScope();
+
+        var dependabotConfiguration =
+            """
+            version: 2
+            updates:
+            - package-ecosystem: "github-actions"
+              directory: "/"
+              schedule:
+                interval: daily
+                time: "05:30"
+                timezone: Europe/London
+              reviewers:
+                - "octocat"
+            - package-ecosystem: nuget
+              directory: "/"
+              groups:
+                Microsoft.OpenApi:
+                  patterns:
+                    - Microsoft.OpenApi*
+                xunit:
+                  patterns:
+                    - Verify.Xunit
+                    - xunit*
+              schedule:
+                interval: daily
+                time: "05:30"
+                timezone: Europe/London
+              reviewers:
+                - "octocat"
+              open-pull-requests-limit: 99
+              ignore:
+                - dependency-name: "**"
+            """;
+
+        var target = CreateTarget(
+            scope.ServiceProvider,
+            options,
+            [registry],
+            (client) =>
+            {
+                client.GetRawContentByRef(
+                    repository.Owner,
+                    repository.Name,
+                    ".github/dependabot.yml",
+                    reference)
+                    .Returns(Task.FromResult(Encoding.UTF8.GetBytes(dependabotConfiguration)));
+            });
+
+        var sha = "815aad7927000ff23a2a61f2c640dad01a88658c";
+        var commitMessage = """
+                            Bump the aspnet-security-oauth group with 4 updates
+                            Bumps the aspnet-security-oauth group with 4 updates: [AspNet.Security.OAuth.Amazon](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers), [AspNet.Security.OAuth.Apple](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers), [Microsoft.IdentityModel.JsonWebTokens](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet) and [AspNet.Security.OAuth.GitHub](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers).
+
+
+                            Updates `AspNet.Security.OAuth.Amazon` from 9.0.0-rc.2.24554.41 to 9.0.0-rc.2.24557.45
+                            - [Release notes](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/releases)
+                            - [Commits](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/commits)
+
+                            Updates `AspNet.Security.OAuth.Apple` from 9.0.0-rc.2.24554.41 to 9.0.0-rc.2.24557.45
+                            - [Release notes](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/releases)
+                            - [Commits](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/commits)
+
+                            Updates `Microsoft.IdentityModel.JsonWebTokens` from 8.2.0 to 8.0.0
+                            - [Release notes](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/releases)
+                            - [Changelog](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/CHANGELOG.md)
+                            - [Commits](AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet@8.2.0...8.0.0)
+
+                            Updates `AspNet.Security.OAuth.GitHub` from 9.0.0-rc.2.24554.41 to 9.0.0-rc.2.24557.45
+                            - [Release notes](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/releases)
+                            - [Commits](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/commits)
+
+                            ---
+                            updated-dependencies:
+                            - dependency-name: AspNet.Security.OAuth.Amazon
+                              dependency-type: direct:production
+                              update-type: version-update:semver-patch
+                              dependency-group: aspnet-security-oauth
+                            - dependency-name: AspNet.Security.OAuth.Apple
+                              dependency-type: direct:production
+                              update-type: version-update:semver-patch
+                              dependency-group: aspnet-security-oauth
+                            - dependency-name: Microsoft.IdentityModel.JsonWebTokens
+                              dependency-type: direct:production
+                              update-type: version-update:semver-minor
+                              dependency-group: aspnet-security-oauth
+                            - dependency-name: AspNet.Security.OAuth.GitHub
+                              dependency-type: direct:production
+                              update-type: version-update:semver-patch
+                              dependency-group: aspnet-security-oauth
+                            ...
+
+                            Signed-off-by: dependabot[bot] <support@github.com>
+                            """;
+
+        var diff =
+            """
+            diff --git a/Directory.Packages.props b/Directory.Packages.props
+            index ead99a216..44207d0d1 100644
+            --- a/Directory.Packages.props
+            +++ b/Directory.Packages.props
+            @@ -11,9 +11,9 @@
+                 <PackageVersion Include="Aspire.Hosting.Azure.KeyVault" Version="9.0.0-rc.1.24511.1" />
+                 <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="9.0.0-rc.1.24511.1" />
+                 <PackageVersion Include="Aspire.Microsoft.Azure.Cosmos" Version="9.0.0-rc.1.24511.1" />
+            -    <PackageVersion Include="AspNet.Security.OAuth.Amazon" Version="9.0.0-rc.2.24554.41" />
+            -    <PackageVersion Include="AspNet.Security.OAuth.Apple" Version="9.0.0-rc.2.24554.41" />
+            -    <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="9.0.0-rc.2.24554.41" />
+            +    <PackageVersion Include="AspNet.Security.OAuth.Amazon" Version="9.0.0-rc.2.24557.45" />
+            +    <PackageVersion Include="AspNet.Security.OAuth.Apple" Version="9.0.0-rc.2.24557.45" />
+            +    <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="9.0.0-rc.2.24557.45" />
+                 <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
+                 <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.4" />
+                 <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.4" />
+            """;
+
+        // Act
+        var actual = await target.IsTrustedDependencyUpdateAsync(
+            repository,
+            reference,
+            sha,
+            commitMessage,
+            diff,
+            CancellationToken);
+
+        // Assert
+        actual.ShouldBeFalse();
+
+        // Act
+        (var actualEcosystem, var trust) = await target.GetDependencyTrustAsync(
+            repository,
+            reference,
+            sha,
+            commitMessage,
+            diff,
+            CancellationToken);
+
+        // Assert
+        actualEcosystem.ShouldBe(ecosystem);
+
+        trust.ShouldContainKeyAndValue("AspNet.Security.OAuth.Amazon", (false, null));
+        trust.ShouldContainKeyAndValue("AspNet.Security.OAuth.Apple", (false, null));
+        trust.ShouldContainKeyAndValue("AspNet.Security.OAuth.GitHub", (false, null));
         trust.ShouldContainKeyAndValue("Microsoft.IdentityModel.JsonWebTokens", (false, null));
         trust.Count.ShouldBe(4);
     }

--- a/tests/Costellobot.Tests/GitCommitAnalyzerTests.cs
+++ b/tests/Costellobot.Tests/GitCommitAnalyzerTests.cs
@@ -1787,6 +1787,184 @@ Signed-off-by: dependabot[bot] <support@github.com>";
     }
 
     [Fact]
+    public async Task Commit_Is_Analyzed_Correctly_With_Wildcard_Ignored_Packages_In_Dependabot_Configuration()
+    {
+        // Arrange
+        var ecosystem = DependencyEcosystem.NuGet;
+        var owner = CreateUser();
+        var repo = owner.CreateRepository();
+        var repository = new RepositoryId(repo.Owner.Login, repo.Name);
+        var reference = "dependabot/nuget/aspnet-security-oauth-b2c2f7560d";
+
+        var registry = Substitute.For<IPackageRegistry>();
+
+        registry.Ecosystem.Returns(ecosystem);
+
+        registry.GetPackageOwnersAsync(repository, "Microsoft.IdentityModel.JsonWebTokens", "8.0.0", CancellationToken)
+                .Returns(Task.FromResult<IReadOnlyList<string>>(["AzureAD", "Microsoft"]));
+
+        var options = new WebhookOptions()
+        {
+            TrustedEntities = new()
+            {
+                Dependencies = ["^AspNet.Security.OAuth\\..*$"],
+                Publishers = new Dictionary<DependencyEcosystem, IList<string>>()
+                {
+                    [ecosystem] = ["Microsoft"],
+                },
+            },
+        };
+
+        using var scope = Fixture.Services.CreateScope();
+
+        var dependabotConfiguration =
+            """
+            version: 2
+            updates:
+            - package-ecosystem: "github-actions"
+              directory: "/"
+              schedule:
+                interval: daily
+                time: "05:30"
+                timezone: Europe/London
+              reviewers:
+                - "octocat"
+            - package-ecosystem: nuget
+              directory: "/"
+              groups:
+                Microsoft.OpenApi:
+                  patterns:
+                    - Microsoft.OpenApi*
+                xunit:
+                  patterns:
+                    - Verify.Xunit
+                    - xunit*
+              schedule:
+                interval: daily
+                time: "05:30"
+                timezone: Europe/London
+              reviewers:
+                - "octocat"
+              open-pull-requests-limit: 99
+              ignore:
+                - dependency-name: "*"
+                  update-types: ["version-update:semver-major"]
+                - dependency-name: "Microsoft.IdentityModel.*"
+            """;
+
+        var target = CreateTarget(
+            scope.ServiceProvider,
+            options,
+            [registry],
+            (client) =>
+            {
+                client.GetRawContentByRef(
+                    repository.Owner,
+                    repository.Name,
+                    ".github/dependabot.yml",
+                    reference)
+                    .Returns(Task.FromResult(Encoding.UTF8.GetBytes(dependabotConfiguration)));
+            });
+
+        var sha = "815aad7927000ff23a2a61f2c640dad01a88658c";
+        var commitMessage = """
+                            Bump the aspnet-security-oauth group with 4 updates
+                            Bumps the aspnet-security-oauth group with 4 updates: [AspNet.Security.OAuth.Amazon](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers), [AspNet.Security.OAuth.Apple](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers), [Microsoft.IdentityModel.JsonWebTokens](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet) and [AspNet.Security.OAuth.GitHub](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers).
+
+
+                            Updates `AspNet.Security.OAuth.Amazon` from 9.0.0-rc.2.24554.41 to 9.0.0-rc.2.24557.45
+                            - [Release notes](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/releases)
+                            - [Commits](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/commits)
+
+                            Updates `AspNet.Security.OAuth.Apple` from 9.0.0-rc.2.24554.41 to 9.0.0-rc.2.24557.45
+                            - [Release notes](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/releases)
+                            - [Commits](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/commits)
+
+                            Updates `Microsoft.IdentityModel.JsonWebTokens` from 8.2.0 to 8.0.0
+                            - [Release notes](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/releases)
+                            - [Changelog](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/CHANGELOG.md)
+                            - [Commits](AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet@8.2.0...8.0.0)
+
+                            Updates `AspNet.Security.OAuth.GitHub` from 9.0.0-rc.2.24554.41 to 9.0.0-rc.2.24557.45
+                            - [Release notes](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/releases)
+                            - [Commits](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/commits)
+
+                            ---
+                            updated-dependencies:
+                            - dependency-name: AspNet.Security.OAuth.Amazon
+                              dependency-type: direct:production
+                              update-type: version-update:semver-patch
+                              dependency-group: aspnet-security-oauth
+                            - dependency-name: AspNet.Security.OAuth.Apple
+                              dependency-type: direct:production
+                              update-type: version-update:semver-patch
+                              dependency-group: aspnet-security-oauth
+                            - dependency-name: Microsoft.IdentityModel.JsonWebTokens
+                              dependency-type: direct:production
+                              update-type: version-update:semver-minor
+                              dependency-group: aspnet-security-oauth
+                            - dependency-name: AspNet.Security.OAuth.GitHub
+                              dependency-type: direct:production
+                              update-type: version-update:semver-patch
+                              dependency-group: aspnet-security-oauth
+                            ...
+
+                            Signed-off-by: dependabot[bot] <support@github.com>
+                            """;
+
+        var diff =
+            """
+            diff --git a/Directory.Packages.props b/Directory.Packages.props
+            index ead99a216..44207d0d1 100644
+            --- a/Directory.Packages.props
+            +++ b/Directory.Packages.props
+            @@ -11,9 +11,9 @@
+                 <PackageVersion Include="Aspire.Hosting.Azure.KeyVault" Version="9.0.0-rc.1.24511.1" />
+                 <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="9.0.0-rc.1.24511.1" />
+                 <PackageVersion Include="Aspire.Microsoft.Azure.Cosmos" Version="9.0.0-rc.1.24511.1" />
+            -    <PackageVersion Include="AspNet.Security.OAuth.Amazon" Version="9.0.0-rc.2.24554.41" />
+            -    <PackageVersion Include="AspNet.Security.OAuth.Apple" Version="9.0.0-rc.2.24554.41" />
+            -    <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="9.0.0-rc.2.24554.41" />
+            +    <PackageVersion Include="AspNet.Security.OAuth.Amazon" Version="9.0.0-rc.2.24557.45" />
+            +    <PackageVersion Include="AspNet.Security.OAuth.Apple" Version="9.0.0-rc.2.24557.45" />
+            +    <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="9.0.0-rc.2.24557.45" />
+                 <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
+                 <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.4" />
+                 <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.4" />
+            """;
+
+        // Act
+        var actual = await target.IsTrustedDependencyUpdateAsync(
+            repository,
+            reference,
+            sha,
+            commitMessage,
+            diff,
+            CancellationToken);
+
+        // Assert
+        actual.ShouldBeFalse();
+
+        // Act
+        (var actualEcosystem, var trust) = await target.GetDependencyTrustAsync(
+            repository,
+            reference,
+            sha,
+            commitMessage,
+            diff,
+            CancellationToken);
+
+        // Assert
+        actualEcosystem.ShouldBe(ecosystem);
+
+        trust.ShouldContainKeyAndValue("AspNet.Security.OAuth.Amazon", (true, null));
+        trust.ShouldContainKeyAndValue("AspNet.Security.OAuth.Apple", (true, null));
+        trust.ShouldContainKeyAndValue("AspNet.Security.OAuth.GitHub", (true, null));
+        trust.ShouldContainKeyAndValue("Microsoft.IdentityModel.JsonWebTokens", (false, null));
+        trust.Count.ShouldBe(4);
+    }
+
+    [Fact]
     public async Task Commit_Is_Analyzed_Correctly_With_Duplicated_Dependency_Names()
     {
         // Arrange


### PR DESCRIPTION
- Do not throw an exception if a dependabot ignore pattern is `*` ([example](https://github.com/dotnet/efcore/blob/a0344ff48d0c1fa7a9773ec7511efe1603956371/.github/dependabot.yml#L71-L72), cause by a dependabot PR to my fork).
- Handle `RegexMatchTimeoutException` and `RegexParseException` when evaluating dependabot ignore patterns.
- Evaluate the update type before evaluating the pattern.
