### PR TITLE
Rename dependency

### DIFF
--- a/.github/workflows/oats.yml
+++ b/.github/workflows/oats.yml
@@ -111,6 +111,6 @@ jobs:
         env:
           # renovate: datasource=github-releases depName=gcx packageName=grafana/gcx
           GCX_VERSION: '1.0.0'
-          # renovate: datasource=github-releases depName=LGTM packageName=grafana/docker-otel-lgtm
+          # renovate: datasource=github-releases depName=docker-otel-lgtm packageName=grafana/docker-otel-lgtm
           LGTM_VERSION: '0.30.1'
         run: oats --gcx-version="${GCX_VERSION}" --lgtm-version="${LGTM_VERSION}" --timeout=5m ./tests/Costellobot.Oats

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -2047,6 +2047,7 @@
         "^Microsoft\\.NET\\.Test\\.Sdk$",
         "^NodaTime$",
         "^NodaTime\\.Testing$",
+        "^redis$",
         "^Swashbuckle\\.AspNetCore",
         "^Swashbuckle\\.AspNetCore\\..*$"
       ],


### PR DESCRIPTION
- Use `docker-otel-lgtm` as the name for renovate updates instead of `LGTM`.
- Trust updates to redis container images.
