### PR TITLE
Fix links for child actions

### DIFF
--- a/src/Costellobot.AppHost/Costellobot.AppHost.csproj
+++ b/src/Costellobot.AppHost/Costellobot.AppHost.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Aspire.AppHost.Sdk" />
   <PropertyGroup>
+    <AspireUseCliBundle>true</AspireUseCliBundle>
     <IsAspireHost>true</IsAspireHost>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>

--- a/src/Costellobot/DependencyHelpers.cs
+++ b/src/Costellobot/DependencyHelpers.cs
@@ -3,7 +3,7 @@
 
 namespace MartinCostello.Costellobot;
 
-internal static class DependencyHelpers
+public static class DependencyHelpers
 {
     private const string DefaultStyles = "fa-solid fa-cube";
     private const string DockerStyles = "fa-brands fa-docker text-primary";
@@ -22,7 +22,7 @@ internal static class DependencyHelpers
         {
             DependencyEcosystem.Docker when id.StartsWith("dotnet/", StringComparison.Ordinal) => ("Docker", MicrosoftArtifactRegistryUrl($"/artifact/mar/{id}/tags"), MicrosoftStyles),
             DependencyEcosystem.Docker => ("Docker", DockerHubUrl($"/r/{id}/tags"), DockerStyles),
-            DependencyEcosystem.GitHubActions => ("GitHub Actions", GitHubUrl(id), GitHubStyles),
+            DependencyEcosystem.GitHubActions => ("GitHub Actions", GitHubActionUrl(id), GitHubStyles),
             DependencyEcosystem.GitHubRelease => ("GitHub", GitHubUrl(id), GitHubStyles),
             DependencyEcosystem.GoModules => ("Go Modules", GoPackageUrl($"/{id}@v{version.TrimStart('v')}"), GoStyles),
             DependencyEcosystem.Html => ("cdnjs", CdnjsUrl($"/libraries/{CdnjsLibraryName(id)}"), HtmlStyles),
@@ -63,6 +63,18 @@ internal static class DependencyHelpers
     {
         int index = id.IndexOf('/', StringComparison.Ordinal);
         return index > -1 ? id[..index] : id;
+    }
+
+    private static string GitHubActionUrl(string id)
+    {
+        var segments = id.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        if (segments.Length > 2)
+        {
+            return GitHubUrl($"/{segments[0]}/{segments[1]}/tree/HEAD/{string.Join('/', segments[2..])}");
+        }
+
+        return GitHubUrl(id);
     }
 
     private static string GitHubUrl(string path)

--- a/tests/Costellobot.Tests/DependencyHelpersTests.cs
+++ b/tests/Costellobot.Tests/DependencyHelpersTests.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.Costellobot;
+
+public static class DependencyHelpersTests
+{
+    [Theory]
+    [InlineData(DependencyEcosystem.GitHubActions, "martincostello/github-automation/actions/get-github-token", "4.3.3", "GitHub Actions", "https://github.com/martincostello/github-automation/tree/HEAD/actions/get-github-token", "fa-brands fa-square-github text-dark")]
+    public static void GetPackageMetadata_Returns_Expected_Values(
+        DependencyEcosystem ecosystem,
+        string id,
+        string version,
+        string expectedName,
+        string expectedUrl,
+        string expectedCssClasses)
+    {
+        // Act
+        var (actualName, actualUrl, actualCssClasses) = DependencyHelpers.GetPackageMetadata(ecosystem, id, version);
+
+        // Assert
+        Assert.Equal(expectedName, actualName);
+        Assert.Equal(expectedUrl, actualUrl);
+        Assert.Equal(expectedCssClasses, actualCssClasses);
+    }
+}


### PR DESCRIPTION
- Fix actions that are not defined in the root of a repository having UI links that 404'd.
- Set `AspireUseCliBundle=true` to resolve ASPIRE010 warning.
