### PR TITLE
Update NuGet trusted publishers

### DIFF
--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -2100,7 +2100,6 @@
           "aspnet",
           "awsdotnet",
           "azure-sdk",
-          "dotnetfoundation",
           "dotnetframework",
           "EntityFramework",
           "GitHub",


### PR DESCRIPTION
Removed `dotnetfoundation` as a trusted publisher, as it's just a co-owner, rather than the real publishing entity.
