### PR TITLE
Add resource monitoring

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,6 +37,7 @@
     <PackageVersion Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.6.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.ResourceMonitoring" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />

--- a/src/Costellobot/Costellobot.csproj
+++ b/src/Costellobot/Costellobot.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" NoWarn="RT0003" />
     <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.ResourceMonitoring" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
     <PackageReference Include="NuGet.Versioning" />

--- a/src/Costellobot/CostellobotBuilder.cs
+++ b/src/Costellobot/CostellobotBuilder.cs
@@ -57,6 +57,7 @@ public static class CostellobotBuilder
         builder.Services.AddApplicationHealthChecks();
         builder.Services.AddGitHub(builder.Configuration);
         builder.Services.AddHsts((options) => options.MaxAge = TimeSpan.FromDays(180));
+        builder.Services.AddResourceMonitoring();
         builder.Services.AddResponseCaching();
         builder.Services.AddTelemetry(builder.Environment);
 

--- a/src/Costellobot/CostellobotBuilder.cs
+++ b/src/Costellobot/CostellobotBuilder.cs
@@ -57,7 +57,6 @@ public static class CostellobotBuilder
         builder.Services.AddApplicationHealthChecks();
         builder.Services.AddGitHub(builder.Configuration);
         builder.Services.AddHsts((options) => options.MaxAge = TimeSpan.FromDays(180));
-        builder.Services.AddResourceMonitoring();
         builder.Services.AddResponseCaching();
         builder.Services.AddTelemetry(builder.Environment);
 
@@ -78,6 +77,12 @@ public static class CostellobotBuilder
         {
             options.PayloadSerializerOptions.TypeInfoResolverChain.Insert(0, AppJsonSerializerContext.Default);
         });
+
+        // Workaround for https://github.com/dotnet/extensions/issues/5962
+        if (OperatingSystem.IsLinux() || OperatingSystem.IsWindows())
+        {
+            builder.Services.AddResourceMonitoring();
+        }
 
         builder.Logging.AddTelemetry();
         builder.Logging.AddSignalR();

--- a/src/Costellobot/TelemetryExtensions.cs
+++ b/src/Costellobot/TelemetryExtensions.cs
@@ -30,6 +30,7 @@ public static class TelemetryExtensions
                           .AddHttpClientInstrumentation()
                           .AddProcessInstrumentation()
                           .AddMeter(ApplicationTelemetry.ServiceName)
+                          .AddMeter("Microsoft.Extensions.Diagnostics.ResourceMonitoring")
                           .AddMeter("Polly")
                           .AddMeter("System.Runtime")
                           .SetExemplarFilter(ExemplarFilterType.TraceBased);


### PR DESCRIPTION
Add [`Microsoft.Extensions.Diagnostics.ResourceMonitoring`](https://learn.microsoft.com/dotnet/core/diagnostics/diagnostic-resource-monitoring#use-net-metrics-of-resource-monitoring) to enable container-level [resource metrics](https://learn.microsoft.com/dotnet/core/diagnostics/built-in-metrics-diagnostics#microsoftextensionsdiagnosticsresourcemonitoring).
