### PR TITLE
Add a cache of dynamic Regex patterns

### DIFF
--- a/src/Costellobot/GitCommitAnalyzer.cs
+++ b/src/Costellobot/GitCommitAnalyzer.cs
@@ -48,7 +48,7 @@ public sealed partial class GitCommitAnalyzer(
 
         foreach (var pattern in patterns)
         {
-            var match = Regex.Match(commitMessage, pattern, RegexOptions.Multiline);
+            var match = RegexCache.GetOrAdd(pattern, RegexOptions.Multiline, Regex.InfiniteMatchTimeout).Match(commitMessage);
             var group = match.Groups["to"];
 
             if (group.Success)
@@ -409,7 +409,7 @@ public sealed partial class GitCommitAnalyzer(
             {
                 try
                 {
-                    return pattern is "*" || Regex.IsMatch(input, pattern, RegexOptions.None, RegexTimeout);
+                    return pattern is "*" || RegexCache.GetOrAdd(pattern, RegexOptions.None, RegexTimeout).IsMatch(input);
                 }
                 catch (Exception ex) when (ex is RegexMatchTimeoutException or RegexParseException)
                 {
@@ -430,7 +430,7 @@ public sealed partial class GitCommitAnalyzer(
             }
 
             if (!ignored &&
-                trustedDependencies.Any((p) => Regex.IsMatch(dependency, p, RegexOptions.None, RegexTimeout)))
+                trustedDependencies.Any((p) => RegexCache.GetOrAdd(p, RegexOptions.None, RegexTimeout).IsMatch(dependency)))
             {
                 Log.TrustedDependencyNameUpdated(
                     logger,

--- a/src/Costellobot/GitCommitAnalyzer.cs
+++ b/src/Costellobot/GitCommitAnalyzer.cs
@@ -430,7 +430,7 @@ public sealed partial class GitCommitAnalyzer(
             }
 
             if (!ignored &&
-                trustedDependencies.Any((p) => RegexCache.GetOrAdd(p, RegexOptions.None, RegexTimeout).IsMatch(dependency)))
+                trustedDependencies.Any((p) => IsMatch(dependency, p, logger)))
             {
                 Log.TrustedDependencyNameUpdated(
                     logger,

--- a/src/Costellobot/GitCommitAnalyzer.cs
+++ b/src/Costellobot/GitCommitAnalyzer.cs
@@ -48,7 +48,7 @@ public sealed partial class GitCommitAnalyzer(
 
         foreach (var pattern in patterns)
         {
-            var match = RegexCache.GetOrAdd(pattern, RegexOptions.Multiline, Regex.InfiniteMatchTimeout).Match(commitMessage);
+            var match = RegexCache.GetOrAdd(pattern, RegexOptions.Multiline, RegexTimeout).Match(commitMessage);
             var group = match.Groups["to"];
 
             if (group.Success)

--- a/src/Costellobot/GitCommitAnalyzer.cs
+++ b/src/Costellobot/GitCommitAnalyzer.cs
@@ -405,7 +405,7 @@ public sealed partial class GitCommitAnalyzer(
 
         foreach ((string dependency, string? version, string? updateType, _) in dependencies)
         {
-            static bool IsMatch(string input, string pattern, ILogger logger)
+            static bool IsMatch(string input, string pattern, ILogger logger, bool resultOnError)
             {
                 try
                 {
@@ -414,14 +414,14 @@ public sealed partial class GitCommitAnalyzer(
                 catch (Exception ex) when (ex is RegexMatchTimeoutException or RegexParseException)
                 {
                     Log.FailedToEvaluateRegularExpression(logger, pattern, input, ex);
-                    return true;
+                    return resultOnError;
                 }
             }
 
             bool ignored = dependenciesToIgnore
                 .Any((p) =>
                     (p.UpdateType is null || string.Equals(updateType, p.UpdateType, StringComparison.Ordinal)) &&
-                    IsMatch(dependency, p.Name, logger));
+                    IsMatch(dependency, p.Name, logger, resultOnError: true));
 
             if (ignored)
             {
@@ -430,7 +430,7 @@ public sealed partial class GitCommitAnalyzer(
             }
 
             if (!ignored &&
-                trustedDependencies.Any((p) => IsMatch(dependency, p, logger)))
+                trustedDependencies.Any((p) => IsMatch(dependency, p, logger, resultOnError: false)))
             {
                 Log.TrustedDependencyNameUpdated(
                     logger,

--- a/src/Costellobot/Handlers/CheckSuiteHandler.cs
+++ b/src/Costellobot/Handlers/CheckSuiteHandler.cs
@@ -141,7 +141,7 @@ public sealed partial class CheckSuiteHandler(
         var options = context.WebhookOptions;
 
         var retryEligibleRuns = failedRuns
-            .Where((p) => options.RerunFailedChecks.Any((pattern) => Regex.IsMatch(p.Name, pattern, RegexOptions.None, RegexTimeout)))
+            .Where((p) => options.RerunFailedChecks.Any((pattern) => RegexCache.GetOrAdd(pattern, RegexOptions.None, RegexTimeout).IsMatch(p.Name)))
             .GroupBy((p) => p.Name)
             .Select((g) => (g.Key, Count: g.Count()))
             .ToList();

--- a/src/Costellobot/RegexCache.cs
+++ b/src/Costellobot/RegexCache.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+
+namespace MartinCostello.Costellobot;
+
+/// <summary>
+/// A helper that caches compiled <see cref="Regex"/> instances for patterns that are not known at compile-time.
+/// </summary>
+internal static class RegexCache
+{
+    /// <summary>
+    /// The maximum number of entries to retain in the cache.
+    /// </summary>
+    private const int MaximumSize = 512;
+
+    private static readonly ConcurrentDictionary<(string Pattern, RegexOptions Options, TimeSpan Timeout), Regex> Cache = new();
+
+    /// <summary>
+    /// Gets a compiled <see cref="Regex"/> for the specified pattern, options and timeout, reusing a
+    /// previously created instance for the same combination if one is already cached.
+    /// </summary>
+    /// <param name="pattern">The regular expression pattern.</param>
+    /// <param name="options">The <see cref="RegexOptions"/> to use to create the <see cref="Regex"/>.</param>
+    /// <param name="timeout">The timeout to use for the <see cref="Regex"/>.</param>
+    /// <returns>
+    /// The cached (or newly created) <see cref="Regex"/> instance for the specified pattern.
+    /// </returns>
+    public static Regex GetOrAdd(string pattern, RegexOptions options, TimeSpan timeout)
+    {
+        if (Cache.Count > MaximumSize)
+        {
+            Cache.Clear();
+        }
+
+        return Cache.GetOrAdd(
+            (pattern, options, timeout),
+            static (key) => new Regex(key.Pattern, key.Options | RegexOptions.Compiled, key.Timeout));
+    }
+}

--- a/src/Costellobot/RegexCache.cs
+++ b/src/Costellobot/RegexCache.cs
@@ -35,8 +35,10 @@ internal static class RegexCache
             Cache.Clear();
         }
 
+        options |= RegexOptions.Compiled;
+
         return Cache.GetOrAdd(
             (pattern, options, timeout),
-            static (key) => new Regex(key.Pattern, key.Options | RegexOptions.Compiled, key.Timeout));
+            static (key) => new Regex(key.Pattern, key.Options, key.Timeout));
     }
 }

--- a/src/Costellobot/RegexCache.cs
+++ b/src/Costellobot/RegexCache.cs
@@ -30,15 +30,44 @@ internal static class RegexCache
     /// </returns>
     public static Regex GetOrAdd(string pattern, RegexOptions options, TimeSpan timeout)
     {
-        if (Cache.Count > MaximumSize)
-        {
-            Cache.Clear();
-        }
-
         options |= RegexOptions.Compiled;
 
+        var key = (pattern, options, timeout);
+
+        if (Cache.TryGetValue(key, out var cached))
+        {
+            return cached;
+        }
+
+        TrimIfOverCapacity();
+
         return Cache.GetOrAdd(
-            (pattern, options, timeout),
-            static (key) => new Regex(key.Pattern, key.Options, key.Timeout));
+            key,
+            static (k) => new Regex(k.Pattern, k.Options, k.Timeout));
+    }
+
+    private static void TrimIfOverCapacity()
+    {
+        int excess = Cache.Count - MaximumSize;
+
+        if (excess <= 0)
+        {
+            return;
+        }
+
+        int toRemove = excess + (MaximumSize / 2);
+
+        foreach (var key in Cache.Keys)
+        {
+            if (toRemove <= 0)
+            {
+                break;
+            }
+
+            if (Cache.TryRemove(key, out _))
+            {
+                toRemove--;
+            }
+        }
     }
 }

--- a/src/Costellobot/RegexCache.cs
+++ b/src/Costellobot/RegexCache.cs
@@ -39,11 +39,13 @@ internal static class RegexCache
             return cached;
         }
 
-        TrimIfOverCapacity();
-
-        return Cache.GetOrAdd(
+        var regex = Cache.GetOrAdd(
             key,
             static (k) => new Regex(k.Pattern, k.Options, k.Timeout));
+
+        TrimIfOverCapacity();
+
+        return regex;
     }
 
     private static void TrimIfOverCapacity()


### PR DESCRIPTION
Avoid the built-in regex cache constantly being evicted due to its small size, and maintain a custom cache with up to 512 entries to avoid thrashing.
