### PR TITLE
Handle invalid JSON payloads

### DIFF
--- a/src/Costellobot/GitHubEventProcessor.cs
+++ b/src/Costellobot/GitHubEventProcessor.cs
@@ -131,6 +131,6 @@ public sealed partial class GitHubEventProcessor(
             EventId = 3,
             Level = LogLevel.Warning,
             Message = "Failed to deserialize webhook with ID {HookId}.")]
-        public static partial void WebhookDeserializationFailed(ILogger logger, string? hookId, Exception ex);
+        public static partial void WebhookDeserializationFailed(ILogger logger, string? hookId, Exception exception);
     }
 }

--- a/src/Costellobot/GitHubEventProcessor.cs
+++ b/src/Costellobot/GitHubEventProcessor.cs
@@ -66,6 +66,19 @@ public sealed partial class GitHubEventProcessor(
         }
     }
 
+    public override WebhookEvent DeserializeWebhookEvent(WebhookHeaders headers, string body)
+    {
+        try
+        {
+            return base.DeserializeWebhookEvent(headers, body);
+        }
+        catch (JsonException ex)
+        {
+            Log.WebhookDeserializationFailed(logger, headers.Delivery, ex);
+            throw;
+        }
+    }
+
     private async Task<(IDictionary<string, string> Headers, JsonElement Payload)> BroadcastLogAsync(
         IDictionary<string, StringValues> headers,
         string body,
@@ -113,5 +126,11 @@ public sealed partial class GitHubEventProcessor(
             Level = LogLevel.Debug,
             Message = "Processed webhook with ID {HookId}.")]
         public static partial void ProcessedWebhook(ILogger logger, string? hookId);
+
+        [LoggerMessage(
+            EventId = 3,
+            Level = LogLevel.Warning,
+            Message = "Failed to deserialize webhook with ID {HookId}.")]
+        public static partial void WebhookDeserializationFailed(ILogger logger, string? hookId, Exception ex);
     }
 }

--- a/src/Costellobot/GitHubExtensions.cs
+++ b/src/Costellobot/GitHubExtensions.cs
@@ -69,12 +69,28 @@ public static class GitHubExtensions
         services.AddHybridCache((p) => p.ReportTagMetrics = true);
         services.AddOptions();
 
-        services.Configure<GitHubOptions>(configuration.GetSection("GitHub"));
-        services.Configure<GitHubWebhookOptions>((p) => p.Secret = configuration["GitHub:WebhookSecret"]);
         services.Configure<GoogleOptions>(configuration.GetSection("Google"));
         services.Configure<GrafanaOptions>(configuration.GetSection("Grafana"));
         services.Configure<SiteOptions>(configuration.GetSection("Site"));
         services.Configure<WebhookOptions>(configuration.GetSection("Webhook"));
+
+        services.Configure<GitHubOptions>(configuration.GetSection("GitHub"));
+        services.Configure<GitHubWebhookOptions>((options) =>
+        {
+            options.Secret = configuration["GitHub:WebhookSecret"];
+            options.ExceptionHandler = (ex, context) =>
+            {
+                bool handled = false;
+
+                if (ex is System.Text.Json.JsonException)
+                {
+                    context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    handled = true;
+                }
+
+                return ValueTask.FromResult(handled);
+            };
+        });
 
         services.TryAddSingleton(TimeProvider.System);
 

--- a/tests/Costellobot.Tests/ApiTests.cs
+++ b/tests/Costellobot.Tests/ApiTests.cs
@@ -172,4 +172,24 @@ public sealed class ApiTests(HttpServerFixture fixture, ITestOutputHelper output
         response.ShouldNotBeNull();
         response.Status.ShouldBe(StatusCodes.Status404NotFound);
     }
+
+    [Fact]
+    public async Task Invalid_Payload_Responds_With_Json()
+    {
+        // Arrange
+        var options = Fixture.Services.GetRequiredService<IOptions<GitHubOptions>>().Value;
+
+        // Act
+        using var actual = await PostWebhookAsync("ping", new { }, options.WebhookSecret);
+
+        // Assert
+        actual.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+        actual.Content.Headers.ContentType.ShouldNotBeNull();
+        actual.Content.Headers.ContentType.MediaType.ShouldBe("application/problem+json");
+
+        var response = await actual.Content.ReadFromJsonAsync<ProblemDetails>(CancellationToken);
+        response.ShouldNotBeNull();
+        response.Status.ShouldBe(StatusCodes.Status400BadRequest);
+    }
 }


### PR DESCRIPTION
Handle invalid webhook payloads as HTTP 400 errors.

~~Depends on octokit/webhooks.net#963.~~
