### PR TITLE
Enrich UI for debug errors

### DIFF
--- a/src/Costellobot/scripts/App.test.ts
+++ b/src/Costellobot/scripts/App.test.ts
@@ -435,7 +435,7 @@ describe('App', () => {
 
             const badge = document.querySelector('.webhook-status')!;
 
-            await vi.waitFor(() => expect(badge.textContent).toBe('400 - Bad Request'));
+            await vi.waitFor(() => expect(badge.textContent).toBe('400 - The webhook payload was invalid.'));
 
             expect(badge.classList.contains('bg-danger')).toBe(true);
             expect(badge.classList.contains('bg-success')).toBe(false);
@@ -463,6 +463,30 @@ describe('App', () => {
             await vi.waitFor(() => expect(badge.textContent).toBe('500'));
 
             expect(badge.classList.contains('bg-danger')).toBe(true);
+        });
+
+        test('displays a failure if the fetch request throws an exception', async () => {
+            setupDebugPage();
+            await initializeApp();
+
+            const fetch = vi.fn(() => Promise.reject(new Error('Failed to fetch.')));
+            vi.stubGlobal('fetch', fetch);
+
+            setPayload('{}');
+
+            document.getElementById('post-webhook')!.click();
+
+            const badge = document.querySelector('.webhook-status')!;
+
+            await vi.waitFor(() => expect(badge.textContent).toContain('0'));
+
+            expect(badge.classList.contains('bg-danger')).toBe(true);
+            expect(badge.classList.contains('bg-success')).toBe(false);
+
+            const submit = document.getElementById('post-webhook')!;
+
+            expect(submit.hasAttribute('disabled')).toBe(false);
+            expect(submit.querySelector('.spinner-border')!.classList.contains('d-none')).toBe(true);
         });
 
         test('omits the signature if there is no signature input', async () => {

--- a/src/Costellobot/scripts/App.test.ts
+++ b/src/Costellobot/scripts/App.test.ts
@@ -408,6 +408,63 @@ describe('App', () => {
             expect(badge.classList.contains('bg-success')).toBe(false);
         });
 
+        test('appends the problem details title to the badge if the response is not accepted', async () => {
+            setupDebugPage();
+            await initializeApp();
+
+            const problemDetails = {
+                type: 'https://tools.ietf.org/html/rfc9110#section-15.5.5',
+                title: 'Bad Request',
+                status: 400,
+                detail: 'The webhook payload was invalid.',
+                instance: '/github-webhook',
+            };
+
+            const fetch = vi.fn(() =>
+                Promise.resolve({
+                    ok: false,
+                    status: 400,
+                    json: () => Promise.resolve(problemDetails),
+                })
+            );
+            vi.stubGlobal('fetch', fetch);
+
+            setPayload('{}');
+
+            document.getElementById('post-webhook')!.click();
+
+            const badge = document.querySelector('.webhook-status')!;
+
+            await vi.waitFor(() => expect(badge.textContent).toBe('400 - Bad Request'));
+
+            expect(badge.classList.contains('bg-danger')).toBe(true);
+            expect(badge.classList.contains('bg-success')).toBe(false);
+        });
+
+        test('does not append a problem details title if the response body is not JSON', async () => {
+            setupDebugPage();
+            await initializeApp();
+
+            const fetch = vi.fn(() =>
+                Promise.resolve({
+                    ok: false,
+                    status: 500,
+                    json: () => Promise.reject(new Error('Not JSON.')),
+                })
+            );
+            vi.stubGlobal('fetch', fetch);
+
+            setPayload('{}');
+
+            document.getElementById('post-webhook')!.click();
+
+            const badge = document.querySelector('.webhook-status')!;
+
+            await vi.waitFor(() => expect(badge.textContent).toBe('500'));
+
+            expect(badge.classList.contains('bg-danger')).toBe(true);
+        });
+
         test('omits the signature if there is no signature input', async () => {
             setupDebugPage(false);
             await initializeApp();

--- a/src/Costellobot/scripts/App.test.ts
+++ b/src/Costellobot/scripts/App.test.ts
@@ -408,7 +408,7 @@ describe('App', () => {
             expect(badge.classList.contains('bg-success')).toBe(false);
         });
 
-        test('appends the problem details title to the badge if the response is not accepted', async () => {
+        test('appends the problem details detail to the badge if the response is not accepted', async () => {
             setupDebugPage();
             await initializeApp();
 
@@ -441,7 +441,7 @@ describe('App', () => {
             expect(badge.classList.contains('bg-success')).toBe(false);
         });
 
-        test('does not append a problem details title if the response body is not JSON', async () => {
+        test('does not append a problem details detail if the response body is not JSON', async () => {
             setupDebugPage();
             await initializeApp();
 
@@ -487,6 +487,25 @@ describe('App', () => {
 
             expect(submit.hasAttribute('disabled')).toBe(false);
             expect(submit.querySelector('.spinner-border')!.classList.contains('d-none')).toBe(true);
+        });
+
+        test('displays a failure if the fetch request rejects with a non-Error value', async () => {
+            setupDebugPage();
+            await initializeApp();
+
+            const fetch = vi.fn(() => Promise.reject('Network down.'));
+            vi.stubGlobal('fetch', fetch);
+
+            setPayload('{}');
+
+            document.getElementById('post-webhook')!.click();
+
+            const badge = document.querySelector('.webhook-status')!;
+
+            await vi.waitFor(() => expect(badge.textContent).toBe('0 - Network down.'));
+
+            expect(badge.classList.contains('bg-danger')).toBe(true);
+            expect(badge.classList.contains('bg-success')).toBe(false);
         });
 
         test('omits the signature if there is no signature input', async () => {

--- a/src/Costellobot/scripts/App.ts
+++ b/src/Costellobot/scripts/App.ts
@@ -119,8 +119,8 @@ export class App {
 
             let badgeContent = result.status.toString(10);
 
-            if (!result.isOK && result.error) {
-                badgeContent += ` - ${result.error.title}`;
+            if (!result.isOK && result.error && result.error.detail) {
+                badgeContent += ` - ${result.error.detail}`;
             }
 
             badge.textContent = badgeContent;
@@ -323,22 +323,32 @@ export class App {
             body: JSON.stringify(payload),
         };
 
-        const response = await fetch('/github-webhook', init);
+        try {
+            const response = await fetch('/github-webhook', init);
 
-        const result: WebhookResult = {
-            isOK: response.ok,
-            status: response.status,
-        };
+            const result: WebhookResult = {
+                isOK: response.ok,
+                status: response.status,
+            };
 
-        if (!response.ok) {
-            try {
-                result.error = await response.json();
-            } catch {
-                // Not JSON, ignore
+            if (!response.ok) {
+                try {
+                    result.error = await response.json();
+                } catch {
+                    // Not JSON, ignore
+                }
             }
-        }
 
-        return result;
+            return result;
+        } catch (err: any) {
+            return {
+                isOK: false,
+                status: 0,
+                error: {
+                    detail: err.message,
+                },
+            };
+        }
     }
 }
 
@@ -353,12 +363,12 @@ interface LogEntry {
 }
 
 interface ProblemDetails {
-    type: string;
-    title: string;
-    status: number;
+    type?: string;
+    title?: string;
+    status?: number;
     detail: string;
-    instance: string;
-    correlation: string;
+    instance?: string;
+    correlation?: string;
 }
 
 interface WebhookResult {

--- a/src/Costellobot/scripts/App.ts
+++ b/src/Costellobot/scripts/App.ts
@@ -117,7 +117,13 @@ export class App {
 
             const result = await this.postJson(event, payload, signature);
 
-            badge.textContent = result.status.toString(10);
+            let badgeContent = result.status.toString(10);
+
+            if (!result.isOK && result.error) {
+                badgeContent += ` - ${result.error.title}`;
+            }
+
+            badge.textContent = badgeContent;
             badge.classList.add(result.isOK ? 'bg-success' : 'bg-danger');
             badge.classList.remove(result.isOK ? 'bg-danger' : 'bg-success');
 
@@ -319,10 +325,20 @@ export class App {
 
         const response = await fetch('/github-webhook', init);
 
-        return {
+        const result: WebhookResult = {
             isOK: response.ok,
             status: response.status,
         };
+
+        if (!response.ok) {
+            try {
+                result.error = await response.json();
+            } catch {
+                // Not JSON, ignore
+            }
+        }
+
+        return result;
     }
 }
 
@@ -336,7 +352,17 @@ interface LogEntry {
     timestamp: string;
 }
 
+interface ProblemDetails {
+    type: string;
+    title: string;
+    status: number;
+    detail: string;
+    instance: string;
+    correlation: string;
+}
+
 interface WebhookResult {
     isOK: boolean;
     status: number;
+    error?: ProblemDetails | null;
 }

--- a/src/Costellobot/scripts/App.ts
+++ b/src/Costellobot/scripts/App.ts
@@ -340,12 +340,12 @@ export class App {
             }
 
             return result;
-        } catch (err: any) {
+        } catch (err: unknown) {
             return {
                 isOK: false,
                 status: 0,
                 error: {
-                    detail: err.message,
+                    detail: err instanceof Error ? err.message : String(err),
                 },
             };
         }
@@ -366,7 +366,7 @@ interface ProblemDetails {
     type?: string;
     title?: string;
     status?: number;
-    detail: string;
+    detail?: string;
     instance?: string;
     correlation?: string;
 }


### PR DESCRIPTION
- If the debug UI fails to deliver a webhook payload, show the detail from the returned problem details, if any.
- Handle non-HTTP errors (e.g. timeout). Previously the UI would be stuck in a state that required the page to be refreshed to retry.
