### PR TITLE
Remove redundant version override

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -72,7 +72,6 @@
     <PackageVersion Include="Sentry.AspNetCore" Version="6.10.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.12" />
     <PackageVersion Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="18.1.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
     <PackageVersion Include="xunit.v3.mtp-off" Version="4.0.0" />


### PR DESCRIPTION
Remove version override for System.Security.Cryptography.Xml that is now redundant.
