### PR TITLE
Configure metrics and tracing from config

### DIFF
--- a/src/Costellobot/CostellobotBuilder.cs
+++ b/src/Costellobot/CostellobotBuilder.cs
@@ -10,6 +10,8 @@ using Azure.Identity;
 using Microsoft.AspNetCore.HostFiltering;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.Extensions.Diagnostics.Metrics;
+using Microsoft.Extensions.Diagnostics.Tracing;
 using Microsoft.Extensions.Options;
 
 namespace MartinCostello.Costellobot;
@@ -66,8 +68,10 @@ public static class CostellobotBuilder
             options.Providers.Add<GzipCompressionProvider>();
         });
 
-        builder.Services.AddMetrics();
+        builder.Services.AddMetrics((p) => p.AddConfiguration(builder.Configuration));
         builder.Services.AddSingleton<CostellobotMetrics>();
+
+        builder.Services.AddTracing((p) => p.AddConfiguration(builder.Configuration));
 
         builder.Services.AddSignalR();
         builder.Services.AddSingleton<ClientLogQueue>();

--- a/src/Costellobot/TelemetryExtensions.cs
+++ b/src/Costellobot/TelemetryExtensions.cs
@@ -29,21 +29,12 @@ public static class TelemetryExtensions
                           .AddAspNetCoreInstrumentation()
                           .AddHttpClientInstrumentation()
                           .AddProcessInstrumentation()
-                          .AddMeter(ApplicationTelemetry.ServiceName)
-                          .AddMeter("Microsoft.Extensions.Caching.Memory.MemoryCache")
-                          .AddMeter("Microsoft.Extensions.Diagnostics.ResourceMonitoring")
-                          .AddMeter("Polly")
-                          .AddMeter("System.Runtime")
                           .SetExemplarFilter(ExemplarFilterType.TraceBased);
                })
                .WithTracing((builder) =>
                {
                    builder.SetResourceBuilder(ApplicationTelemetry.ResourceBuilder)
-                          .AddHttpClientInstrumentation()
-                          .AddSource(ApplicationTelemetry.ServiceName)
-                          .AddSource("Azure.*")
-                          .AddSource("Microsoft.AspNetCore")
-                          .AddSource("Microsoft.AspNetCore.SignalR.Server");
+                          .AddHttpClientInstrumentation();
 
                    if (environment.IsDevelopment())
                    {

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -1911,6 +1911,27 @@
       "System": "Warning"
     }
   },
+  "Metrics": {
+    "OpenTelemetry": {
+      "EnabledMetrics": {
+        "Default": false,
+        "Costellobot": true,
+        "Microsoft.Extensions.Caching.Memory.MemoryCache": true,
+        "Microsoft.Extensions.Diagnostics.ResourceMonitoring": true,
+        "Polly": true,
+        "System.Runtime": true
+      }
+    }
+  },
+  "Tracing": {
+    "EnabledTracing": {
+      "Default": false,
+      "Costellobot": true,
+      "Azure.*": true,
+      "Microsoft.AspNetCore": true,
+      "Microsoft.AspNetCore.SignalR.Server": true
+    }
+  },
   "Site": {
     "AdminRoles": [],
     "AdminUsers": [],

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -1912,15 +1912,13 @@
     }
   },
   "Metrics": {
-    "OpenTelemetry": {
-      "EnabledMetrics": {
-        "Default": false,
-        "Costellobot": true,
-        "Microsoft.Extensions.Caching.Memory.MemoryCache": true,
-        "Microsoft.Extensions.Diagnostics.ResourceMonitoring": true,
-        "Polly": true,
-        "System.Runtime": true
-      }
+    "EnabledMetrics": {
+      "Default": false,
+      "Costellobot": true,
+      "Microsoft.Extensions.Caching.Memory.MemoryCache": true,
+      "Microsoft.Extensions.Diagnostics.ResourceMonitoring": true,
+      "Polly": true,
+      "System.Runtime": true
     }
   },
   "Tracing": {


### PR DESCRIPTION
Try using the functionality from Microsoft.Extensions.Diagnostics to enable meters and traces from JSON configuration instead of with code.
