### PR TITLE
Fix calendar time zone handling

### DIFF
--- a/src/Costellobot/DeploymentRules/CalendarDeploymentRule.cs
+++ b/src/Costellobot/DeploymentRules/CalendarDeploymentRule.cs
@@ -18,7 +18,6 @@ public sealed partial class CalendarDeploymentRule(
 {
     private static readonly HybridCacheEntryOptions CacheEntryOptions = new() { Expiration = TimeSpan.FromHours(3) };
     private static readonly string[] CacheTags = ["all", "calendar"];
-    private static readonly TimeSpan OneDay = TimeSpan.FromDays(1);
 
     /// <inheritdoc/>
     public override string Name => "Not-Busy-Calendar";
@@ -28,19 +27,21 @@ public sealed partial class CalendarDeploymentRule(
     {
         if (options.CurrentValue.CalendarIds is { Count: > 0 } calendarIds)
         {
-            var today = DateTime.SpecifyKind(timeProvider.GetUtcNow().Date, DateTimeKind.Utc);
+            var timeZoneId = options.CurrentValue.CalendarTimeZoneId;
+            var timeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+            var today = TimeZoneInfo.ConvertTime(timeProvider.GetUtcNow(), timeZone).Date;
 
             foreach (var calendarId in calendarIds.Where((p) => !string.IsNullOrEmpty(p)))
             {
                 var events = await cache.GetOrCreateAsync(
                     CacheKey(today, calendarId),
-                    (calendar, today, calendarId),
+                    (calendar, today, timeZone, timeZoneId, calendarId),
                     static async (state, cancellationToken) =>
                     {
-                        var (calendar, today, calendarId) = state;
+                        var (calendar, today, timeZone, timeZoneId, calendarId) = state;
 
-                        var minTime = new DateTimeOffset(today, TimeSpan.Zero);
-                        var maxTime = minTime.AddDays(1);
+                        var minTime = new DateTimeOffset(TimeZoneInfo.ConvertTimeToUtc(today, timeZone), TimeSpan.Zero);
+                        var maxTime = new DateTimeOffset(TimeZoneInfo.ConvertTimeToUtc(today.AddDays(1), timeZone), TimeSpan.Zero);
 
                         var request = calendar.Events.List(calendarId);
 
@@ -48,7 +49,7 @@ public sealed partial class CalendarDeploymentRule(
                         request.SingleEvents = true;
                         request.TimeMinDateTimeOffset = minTime;
                         request.TimeMaxDateTimeOffset = maxTime;
-                        request.TimeZone = "UTC";
+                        request.TimeZone = timeZoneId;
 
                         return await request.ExecuteAsync(cancellationToken);
                     },
@@ -56,7 +57,7 @@ public sealed partial class CalendarDeploymentRule(
                     CacheTags,
                     cancellationToken);
 
-                var @event = events.Items.FirstOrDefault(IsBusy);
+                var @event = events.Items.FirstOrDefault((item) => IsBusy(item, timeZone));
 
                 if (@event is not null)
                 {
@@ -74,11 +75,11 @@ public sealed partial class CalendarDeploymentRule(
             return FormattableString.Invariant($"calendar:{date:d}:{hash}");
         }
 
-        static bool IsBusy(Event @event)
+        static bool IsBusy(Event @event, TimeZoneInfo timeZone)
         {
             var isAllDayEvent =
                 (@event.Start.Date is not null && @event.End.Date is not null) ||
-                ((@event.End.DateTimeDateTimeOffset - @event.Start.DateTimeDateTimeOffset) == OneDay);
+                IsFullLocalDay(@event.Start.DateTimeDateTimeOffset, @event.End.DateTimeDateTimeOffset, timeZone);
 
             if (!isAllDayEvent)
             {
@@ -87,6 +88,21 @@ public sealed partial class CalendarDeploymentRule(
 
             return @event.Transparency is not "transparent" ||
                    @event.EventType is "outOfOffice";
+        }
+
+        static bool IsFullLocalDay(DateTimeOffset? start, DateTimeOffset? end, TimeZoneInfo timeZone)
+        {
+            if (start is not { } startValue || end is not { } endValue)
+            {
+                return false;
+            }
+
+            var startLocal = TimeZoneInfo.ConvertTime(startValue, timeZone);
+            var endLocal = TimeZoneInfo.ConvertTime(endValue, timeZone);
+
+            return startLocal.TimeOfDay == TimeSpan.Zero &&
+                   endLocal.TimeOfDay == TimeSpan.Zero &&
+                   endLocal.Date == startLocal.Date.AddDays(1);
         }
     }
 

--- a/src/Costellobot/GoogleOptions.cs
+++ b/src/Costellobot/GoogleOptions.cs
@@ -7,6 +7,8 @@ public sealed class GoogleOptions
 {
     public IList<string> CalendarIds { get; set; } = [];
 
+    public string CalendarTimeZoneId { get; set; } = "UTC";
+
     public string ClientEmail { get; set; } = string.Empty;
 
     public string PrivateKeyId { get; set; } = string.Empty;

--- a/src/Costellobot/appsettings.json
+++ b/src/Costellobot/appsettings.json
@@ -1884,6 +1884,7 @@
   },
   "Google": {
     "CalendarIds": [],
+    "CalendarTimeZoneId": "Europe/London",
     "ClientEmail": "",
     "PrivateKey": "",
     "PrivateKeyId": "",

--- a/tests/Costellobot.Tests/Bundles/google.json
+++ b/tests/Costellobot.Tests/Bundles/google.json
@@ -19,7 +19,7 @@
     },
     {
       "comment": "https://developers.google.com/workspace/calendar/api/v3/reference/events/list",
-      "uri": "https://www.googleapis.com/calendar/v3/calendars/google-calendar-id/events?singleEvents=true&timeMax=2023-09-02T00%3A00%3A00Z&timeMin=2023-09-01T00%3A00%3A00Z&timeZone=UTC&fields=items%28start%2Cend%2Csummary%2Ctransparency%2CeventType%29",
+      "uri": "https://www.googleapis.com/calendar/v3/calendars/google-calendar-id/events?singleEvents=true&timeMax=2023-09-01T23%3A00%3A00Z&timeMin=2023-08-31T23%3A00%3A00Z&timeZone=Europe%2FLondon&fields=items%28start%2Cend%2Csummary%2Ctransparency%2CeventType%29",
       "method": "GET",
       "contentFormat": "json",
       "contentJson": {
@@ -37,7 +37,7 @@
     },
     {
       "comment": "https://developers.google.com/workspace/calendar/api/v3/reference/events/list",
-      "uri": "https://www.googleapis.com/calendar/v3/calendars/24-hour-event/events?singleEvents=true&timeMax=2023-09-02T00%3A00%3A00Z&timeMin=2023-09-01T00%3A00%3A00Z&timeZone=UTC&fields=items%28start%2Cend%2Csummary%2Ctransparency%2CeventType%29",
+      "uri": "https://www.googleapis.com/calendar/v3/calendars/24-hour-event/events?singleEvents=true&timeMax=2023-09-01T23%3A00%3A00Z&timeMin=2023-08-31T23%3A00%3A00Z&timeZone=Europe%2FLondon&fields=items%28start%2Cend%2Csummary%2Ctransparency%2CeventType%29",
       "method": "GET",
       "contentFormat": "json",
       "contentJson": {
@@ -122,7 +122,7 @@
     },
     {
       "comment": "https://developers.google.com/workspace/calendar/api/v3/reference/events/list",
-      "uri": "https://www.googleapis.com/calendar/v3/calendars/all-day-event/events?singleEvents=true&timeMax=2023-09-02T00%3A00%3A00Z&timeMin=2023-09-01T00%3A00%3A00Z&timeZone=UTC&fields=items%28start%2Cend%2Csummary%2Ctransparency%2CeventType%29",
+      "uri": "https://www.googleapis.com/calendar/v3/calendars/all-day-event/events?singleEvents=true&timeMax=2023-09-01T23%3A00%3A00Z&timeMin=2023-08-31T23%3A00%3A00Z&timeZone=Europe%2FLondon&fields=items%28start%2Cend%2Csummary%2Ctransparency%2CeventType%29",
       "method": "GET",
       "contentFormat": "json",
       "contentJson": {
@@ -207,7 +207,92 @@
     },
     {
       "comment": "https://developers.google.com/workspace/calendar/api/v3/reference/events/list",
-      "uri": "https://www.googleapis.com/calendar/v3/calendars/google-calendar-id/events?singleEvents=true&timeMax=2023-12-26T00%3A00%3A00Z&timeMin=2023-12-25T00%3A00%3A00Z&timeZone=UTC&fields=items%28start%2Cend%2Csummary%2Ctransparency%2CeventType%29",
+      "uri": "https://www.googleapis.com/calendar/v3/calendars/dst-transition-event/events?singleEvents=true&timeMax=2023-10-30T00%3A00%3A00Z&timeMin=2023-10-28T23%3A00%3A00Z&timeZone=Europe%2FLondon&fields=items%28start%2Cend%2Csummary%2Ctransparency%2CeventType%29",
+      "method": "GET",
+      "contentFormat": "json",
+      "contentJson": {
+        "kind": "calendar#events",
+        "etag": "dst-transition-event",
+        "summary": "A calendar",
+        "description": "The calendar for a busy Google user on the day UK clocks go back",
+        "updated": "2023-10-29T09:00:00Z",
+        "timeZone": "Europe/London",
+        "accessRole": "reader",
+        "defaultReminders": [],
+        "nextSyncToken": "next-sync-token",
+        "items": [
+          {
+            "kind": "calendar#event",
+            "etag": "etag",
+            "id": "string",
+            "status": "confirmed",
+            "htmlLink": "https://calendar.google.com/calendar/event/event-id",
+            "created": "2023-10-29T09:30:00Z",
+            "updated": "2023-10-29T09:00:00Z",
+            "summary": "Busy",
+            "description": "Doing things",
+            "location": "Somewhere fun",
+            "creator": {
+              "id": "user-id",
+              "email": "someone@google.local",
+              "displayName": "Organizer",
+              "self": true
+            },
+            "organizer": {
+              "id": "user-id",
+              "email": "someone@google.local",
+              "displayName": "Organizer",
+              "self": true
+            },
+            "start": {
+              "dateTime": "2023-10-29T00:00:00+01:00",
+              "timeZone": "Europe/London"
+            },
+            "end": {
+              "dateTime": "2023-10-30T00:00:00Z",
+              "timeZone": "Europe/London"
+            },
+            "endTimeUnspecified": false,
+            "transparency": "opaque",
+            "visibility": "public",
+            "iCalUID": "UID:19960401T080045Z-4000F192713-0053@example.com",
+            "sequence": 1,
+            "attendees": [
+              {
+                "id": "user-id",
+                "email": "someone@google.local",
+                "displayName": "Organizer",
+                "organizer": true,
+                "self": true,
+                "resource": false,
+                "optional": false,
+                "responseStatus": "accepted"
+              }
+            ],
+            "extendedProperties": {
+              "private": {},
+              "shared": {}
+            },
+            "hangoutLink": "https://meet.google.com/hangout-id",
+            "anyoneCanAddSelf": false,
+            "locked": false,
+            "reminders": {
+              "useDefault": true,
+              "overrides": []
+            },
+            "source": {
+              "url": "https://calendar.google.com",
+              "title": "Calendar"
+            },
+            "attachments": [],
+            "eventType": "outOfOffice"
+          }
+        ]
+      }
+    },
+    {
+      "comment": "https://developers.google.com/workspace/calendar/api/v3/reference/events/list",
+      "uri": "https://www.googleapis.com/calendar/v3/calendars/google-calendar-id/events?singleEvents=true&timeMax=2023-12-26T00%3A00%3A00Z&timeMin=2023-12-25T00%3A00%3A00Z&timeZone=Europe%2FLondon&fields=items%28start%2Cend%2Csummary%2Ctransparency%2CeventType%29",
       "method": "GET",
       "contentFormat": "json",
       "contentJson": {

--- a/tests/Costellobot.Tests/Bundles/google.json
+++ b/tests/Costellobot.Tests/Bundles/google.json
@@ -292,6 +292,170 @@
     },
     {
       "comment": "https://developers.google.com/workspace/calendar/api/v3/reference/events/list",
+      "uri": "https://www.googleapis.com/calendar/v3/calendars/partial-day-event/events?singleEvents=true&timeMax=2023-09-01T23%3A00%3A00Z&timeMin=2023-08-31T23%3A00%3A00Z&timeZone=Europe%2FLondon&fields=items%28start%2Cend%2Csummary%2Ctransparency%2CeventType%29",
+      "method": "GET",
+      "contentFormat": "json",
+      "contentJson": {
+        "kind": "calendar#events",
+        "etag": "partial-day-event",
+        "summary": "A calendar",
+        "description": "The calendar for a user with a normal meeting",
+        "updated": "2023-09-01T09:00:00Z",
+        "timeZone": "Europe/London",
+        "accessRole": "reader",
+        "defaultReminders": [],
+        "nextSyncToken": "next-sync-token",
+        "items": [
+          {
+            "kind": "calendar#event",
+            "etag": "etag",
+            "id": "string",
+            "status": "confirmed",
+            "htmlLink": "https://calendar.google.com/calendar/event/event-id",
+            "created": "2023-09-01T09:30:00Z",
+            "updated": "2023-09-01T09:00:00Z",
+            "summary": "Team meeting",
+            "description": "Not an all-day event",
+            "location": "Somewhere fun",
+            "creator": {
+              "id": "user-id",
+              "email": "someone@google.local",
+              "displayName": "Organizer",
+              "self": true
+            },
+            "organizer": {
+              "id": "user-id",
+              "email": "someone@google.local",
+              "displayName": "Organizer",
+              "self": true
+            },
+            "start": {
+              "dateTime": "2023-09-01T10:00:00+01:00",
+              "timeZone": "Europe/London"
+            },
+            "end": {
+              "dateTime": "2023-09-01T11:00:00+01:00",
+              "timeZone": "Europe/London"
+            },
+            "endTimeUnspecified": false,
+            "transparency": "opaque",
+            "visibility": "public",
+            "iCalUID": "UID:19960401T080045Z-4000F192713-0054@example.com",
+            "sequence": 1,
+            "attendees": [
+              {
+                "id": "user-id",
+                "email": "someone@google.local",
+                "displayName": "Organizer",
+                "organizer": true,
+                "self": true,
+                "resource": false,
+                "optional": false,
+                "responseStatus": "accepted"
+              }
+            ],
+            "extendedProperties": {
+              "private": {},
+              "shared": {}
+            },
+            "hangoutLink": "https://meet.google.com/hangout-id",
+            "anyoneCanAddSelf": false,
+            "locked": false,
+            "reminders": {
+              "useDefault": true,
+              "overrides": []
+            },
+            "source": {
+              "url": "https://calendar.google.com",
+              "title": "Calendar"
+            },
+            "attachments": [],
+            "eventType": "default"
+          }
+        ]
+      }
+    },
+    {
+      "comment": "https://developers.google.com/workspace/calendar/api/v3/reference/events/list",
+      "uri": "https://www.googleapis.com/calendar/v3/calendars/malformed-event/events?singleEvents=true&timeMax=2023-09-01T23%3A00%3A00Z&timeMin=2023-08-31T23%3A00%3A00Z&timeZone=Europe%2FLondon&fields=items%28start%2Cend%2Csummary%2Ctransparency%2CeventType%29",
+      "method": "GET",
+      "contentFormat": "json",
+      "contentJson": {
+        "kind": "calendar#events",
+        "etag": "malformed-event",
+        "summary": "A calendar",
+        "description": "The calendar for a user with an event missing both start and end date/time information",
+        "updated": "2023-09-01T09:00:00Z",
+        "timeZone": "Europe/London",
+        "accessRole": "reader",
+        "defaultReminders": [],
+        "nextSyncToken": "next-sync-token",
+        "items": [
+          {
+            "kind": "calendar#event",
+            "etag": "etag",
+            "id": "string",
+            "status": "confirmed",
+            "htmlLink": "https://calendar.google.com/calendar/event/event-id",
+            "created": "2023-09-01T09:30:00Z",
+            "updated": "2023-09-01T09:00:00Z",
+            "summary": "Malformed",
+            "description": "Neither a date nor a dateTime is set",
+            "location": "Somewhere fun",
+            "creator": {
+              "id": "user-id",
+              "email": "someone@google.local",
+              "displayName": "Organizer",
+              "self": true
+            },
+            "organizer": {
+              "id": "user-id",
+              "email": "someone@google.local",
+              "displayName": "Organizer",
+              "self": true
+            },
+            "start": {},
+            "end": {},
+            "endTimeUnspecified": false,
+            "transparency": "opaque",
+            "visibility": "public",
+            "iCalUID": "UID:19960401T080045Z-4000F192713-0055@example.com",
+            "sequence": 1,
+            "attendees": [
+              {
+                "id": "user-id",
+                "email": "someone@google.local",
+                "displayName": "Organizer",
+                "organizer": true,
+                "self": true,
+                "resource": false,
+                "optional": false,
+                "responseStatus": "accepted"
+              }
+            ],
+            "extendedProperties": {
+              "private": {},
+              "shared": {}
+            },
+            "hangoutLink": "https://meet.google.com/hangout-id",
+            "anyoneCanAddSelf": false,
+            "locked": false,
+            "reminders": {
+              "useDefault": true,
+              "overrides": []
+            },
+            "source": {
+              "url": "https://calendar.google.com",
+              "title": "Calendar"
+            },
+            "attachments": [],
+            "eventType": "outOfOffice"
+          }
+        ]
+      }
+    },
+    {
+      "comment": "https://developers.google.com/workspace/calendar/api/v3/reference/events/list",
       "uri": "https://www.googleapis.com/calendar/v3/calendars/google-calendar-id/events?singleEvents=true&timeMax=2023-12-26T00%3A00%3A00Z&timeMin=2023-12-25T00%3A00%3A00Z&timeZone=Europe%2FLondon&fields=items%28start%2Cend%2Csummary%2Ctransparency%2CeventType%29",
       "method": "GET",
       "contentFormat": "json",

--- a/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
@@ -763,6 +763,7 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
         await Fixture.ClearCacheAsync();
         Fixture.ChangeClock(new(2023, 10, 29, 12, 00, 00, TimeSpan.Zero));
         Fixture.OverrideConfiguration("Google:CalendarIds:0", "dst-transition-event");
+        Fixture.OverrideConfiguration("Google:CalendarTimeZoneId", "Europe/London");
 
         try
         {
@@ -792,6 +793,51 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
             response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
             await AssertTaskNotRun(deploymentApproved);
+        }
+        finally
+        {
+            await Fixture.ClearCacheAsync();
+        }
+    }
+
+    [Theory]
+    [InlineData("partial-day-event")]
+    [InlineData("malformed-event")]
+    public async Task Deployment_Is_Approved_If_Calendar_Event_Is_Not_An_All_Day_Event(string calendarId)
+    {
+        // Arrange
+        await Fixture.ClearCacheAsync();
+        Fixture.OverrideConfiguration("Google:CalendarIds:0", calendarId);
+
+        try
+        {
+            Fixture.ApproveDeployments();
+
+            var driver = new DeploymentStatusDriver(
+                (repo) => repo.CreateCommit(),
+                CreateTrustedCommit);
+
+            driver.WithPendingDeployment(CreateDeployment);
+
+            driver.WithActiveDeployment();
+            driver.WithInactiveDeployment();
+
+            RegisterGetAccessToken();
+
+            RegisterAllDeployments(driver);
+            RegisterCommitComparison(driver);
+            RegisterDependabotConfiguration(driver);
+            RegisterPullRequestForCommit(driver.HeadCommit);
+
+            var deploymentApproved = RegisterApprovePendingDeployment(driver);
+
+            // Act
+            using var response = await PostWebhookAsync(driver);
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+            await deploymentApproved.Task.WaitAsync(ResultTimeout, CancellationToken);
         }
         finally
         {

--- a/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
+++ b/tests/Costellobot.Tests/Handlers/DeploymentStatusHandlerTests.cs
@@ -757,6 +757,49 @@ public sealed class DeploymentStatusHandlerTests : IntegrationTests<AppFixture>
     }
 
     [Fact]
+    public async Task Deployment_Is_Not_Approved_If_Calendar_Is_Busy_On_Day_Clocks_Go_Back()
+    {
+        // Arrange
+        await Fixture.ClearCacheAsync();
+        Fixture.ChangeClock(new(2023, 10, 29, 12, 00, 00, TimeSpan.Zero));
+        Fixture.OverrideConfiguration("Google:CalendarIds:0", "dst-transition-event");
+
+        try
+        {
+            Fixture.ApproveDeployments();
+
+            var driver = new DeploymentStatusDriver(
+                (repo) => repo.CreateCommit(),
+                CreateTrustedCommit);
+
+            driver.WithPendingDeployment(CreateDeployment);
+
+            driver.WithActiveDeployment();
+            driver.WithInactiveDeployment();
+
+            RegisterGetAccessToken();
+
+            RegisterAllDeployments(driver);
+            RegisterCommitComparison(driver);
+            RegisterPullRequestForCommit(driver.HeadCommit);
+
+            var deploymentApproved = RegisterApprovePendingDeployment(driver);
+
+            // Act
+            using var response = await PostWebhookAsync(driver);
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+            await AssertTaskNotRun(deploymentApproved);
+        }
+        finally
+        {
+            await Fixture.ClearCacheAsync();
+        }
+    }
+
+    [Fact]
     public async Task Handler_Ignores_Events_That_Are_Not_Deployment_Statuses()
     {
         // Arrange


### PR DESCRIPTION
- Fix deployments not being approved in BST when a calendar event the next day started at 2300 UTC by making the evaluation time zone configurable.
- Fix handling of 23/25 hour long days around DST transitions.
